### PR TITLE
Hotfix missing discussion items url

### DIFF
--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -38,16 +38,12 @@ export const NotificationRow: React.FC<IProps> = ({
         accounts.user?.id
       );
       shell.openExternal(url);
-    }
-
-    // TODO remove this future-legacy code when Github have pushed a fix (see #424)
-    if (
-      notification.subject.url === null &&
-      notification.subject.type === 'Discussion' &&
-      notification.repository.url
-    ) {
+    // For discussions, we can at least send users to the main discussions page.
+    } else if (notification.subject.type === 'Discussion') {
       const url = generateGitHubWebUrl(
-        `${notification.repository.url}/discussions`
+        `${notification.repository.url}/discussions`,
+        notification.id,
+        accounts.user?.id
       );
       shell.openExternal(url);
     }

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -38,11 +38,13 @@ export const NotificationRow: React.FC<IProps> = ({
 
     // TODO remove this future-legacy code when Github have pushed a fix (see #424)
     if (
-      notification.subject.url === null
-      && notification.subject.type === 'Discussion'
-      && notification.repository.url
+      notification.subject.url === null &&
+      notification.subject.type === 'Discussion' &&
+      notification.repository.url
     ) {
-      const url = generateGitHubWebUrl(`${notification.repository.url}/discussions`);
+      const url = generateGitHubWebUrl(
+        `${notification.repository.url}/discussions`
+      );
       shell.openExternal(url);
     }
   }, [notification]);

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -35,6 +35,16 @@ export const NotificationRow: React.FC<IProps> = ({
       const url = generateGitHubWebUrl(notification.subject.url);
       shell.openExternal(url);
     }
+
+    // TODO remove this future-legacy code when Github have pushed a fix (see #424)
+    if (
+      notification.subject.url === null
+      && notification.subject.type === 'Discussion'
+      && notification.repository.url
+    ) {
+      const url = generateGitHubWebUrl(`${notification.repository.url}/discussions`);
+      shell.openExternal(url);
+    }
   }, [notification]);
 
   const unsubscribe = (event: React.MouseEvent<HTMLElement>) => {


### PR DESCRIPTION
I'm aware it's not super clean, but it does the trick until Github fix its REST API (see #424). If so, the first test will pass and this code will never reach out again and we will be able to remove it without second thought 😉

Again, it's just an idea for the mean time, feel free to say that it's a bad idea. I didn't update the test due to the very “temporary” aspect of this code, but I can do so if needed.