### PR TITLE
fix: github enterprise login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ temp/
 
 dist/
 build/
+
+# Jetbrains IDEs
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,3 @@ temp/
 
 dist/
 build/
-
-# Jetbrains IDEs
-.idea/

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -22,6 +22,7 @@ import { setAutoLaunch } from '../utils/comms';
 import { useInterval } from '../hooks/useInterval';
 import { useNotifications } from '../hooks/useNotifications';
 import Constants from '../utils/constants';
+import { generateGitHubAPIUrl } from '../utils/helpers';
 
 const defaultAccounts: AuthState = {
   token: null,
@@ -134,7 +135,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   const validateToken = useCallback(
     async ({ token, hostname }: AuthTokenOptions) => {
       await apiRequestAuth(
-        `https://api.${hostname}/notifications`,
+        `${generateGitHubAPIUrl(hostname)}notifications`,
         'HEAD',
         token
       );

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -57,16 +57,14 @@ export const useNotifications = (): NotificationsState => {
         if (!isGitHubLoggedIn) {
           return;
         }
-        const url = `https://api.${Constants.DEFAULT_AUTH_OPTIONS.hostname}/${endpointSuffix}`;
+        const url = `${generateGitHubAPIUrl(Constants.DEFAULT_AUTH_OPTIONS.hostname)}${endpointSuffix}`;
         return apiRequestAuth(url, 'GET', accounts.token);
       }
 
       function getEnterpriseNotifications() {
         return accounts.enterpriseAccounts.map((account) => {
-          const hostname = account.hostname;
-          const token = account.token;
-          const url = `https://${hostname}/api/v3/${endpointSuffix}`;
-          return apiRequestAuth(url, 'GET', token);
+          const url = `${generateGitHubAPIUrl(account.hostname)}${endpointSuffix}`;
+          return apiRequestAuth(url, 'GET', account.token);
         });
       }
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,3 +1,5 @@
+import { generateGitHubAPIUrl } from "./helpers";
+
 const { remote } = require('electron');
 const BrowserWindow = remote.BrowserWindow;
 
@@ -78,7 +80,7 @@ export const getUserData = async (
   hostname: string
 ): Promise<User> => {
   const response = await apiRequestAuth(
-    `https://api.${hostname}/user`,
+    `${generateGitHubAPIUrl(hostname)}user`,
     'GET',
     token
   );


### PR DESCRIPTION
Hello,

I saw #524, Also I tested with latest commits.
But Login to Github Enterprise Server with PAT not works. (See #527)
Because Github Etnerprise Server's API url pattern is `https://${hostname}/api/v3`.

## Changes
This PR deduplicates api-url generate codes.

## Github Enterprise API url reference
https://docs.github.com/en/enterprise-server@3.3/rest/reference/users
![image](https://user-images.githubusercontent.com/35264628/147275160-f40929e3-3ff1-4e6c-a1ad-0fd0b2fb3bac.png)
