### PR TITLE
Change casing and phrasing of `onClickMarkAsRead` field

### DIFF
--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -93,7 +93,7 @@ export const SettingsRoute: React.FC = () => {
         />
         <FieldCheckbox
           name="onClickMarkAsRead"
-          label="On Click, Mark as Read"
+          label="Mark as read on click"
           checked={settings.markOnClick}
           onChange={(evt) => updateSetting('markOnClick', evt.target.checked)}
         />


### PR DESCRIPTION
Changes the casing and phrasing of the "On Click, Mark as Read" label to "Mark as read on click".