### PR TITLE
fix: remove `outputFileSync` usage

### DIFF
--- a/first-run.js
+++ b/first-run.js
@@ -42,7 +42,7 @@ function isFirstRun() {
       return false;
     }
 
-    fs.outputFileSync(configPath, '');
+    fs.writeFileSync(configPath, '');
   } catch (error) {
     console.warn(`First run: Unable to write firstRun file`, error);
   }


### PR DESCRIPTION
I'm not sure where this came from since `outputFileSync` comes from `fs-extra`... I guess it always failed?