### PR TITLE
chore(CI): don't run tests twice per PR

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,10 @@
 name: Run Tests
 
-on: [pull_request]
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   run-unit-tests:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   run-unit-tests:


### PR DESCRIPTION
This change resolves #646 by modifying the .github/workflows/run-test file to just execute the test on the pull request not in the push. Before tests were executed twice. 
Signed-off-by: JoseAlberola