### PR TITLE
fix(notifs): Default colors off

### DIFF
--- a/src/context/App.test.tsx
+++ b/src/context/App.test.tsx
@@ -264,7 +264,7 @@ describe('context/App.tsx', () => {
         participating: true,
         playSound: true,
         showNotifications: true,
-        colors: true,
+        colors: false,
       },
     );
   });
@@ -302,7 +302,7 @@ describe('context/App.tsx', () => {
         participating: false,
         playSound: true,
         showNotifications: true,
-        colors: true,
+        colors: false,
       },
     );
   });

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -37,7 +37,7 @@ export const defaultSettings: SettingsState = {
   markOnClick: false,
   openAtStartup: false,
   appearance: Appearance.SYSTEM,
-  colors: true,
+  colors: false,
 };
 
 interface AppContextState {

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -73,7 +73,7 @@ export const SettingsRoute: React.FC = () => {
 
         <FieldCheckbox
           name="colors"
-          label="Show PR state using color (requires re-auth)"
+          label="Use GitHub-like state colors (requires re-auth)"
           checked={settings.colors}
           onChange={(evt) => updateSetting('colors', evt.target.checked)}
         />

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -73,7 +73,7 @@ export const SettingsRoute: React.FC = () => {
 
         <FieldCheckbox
           name="colors"
-          label="Use colors to indicate state"
+          label="Show PR state using color (requires re-auth)"
           checked={settings.colors}
           onChange={(evt) => updateSetting('colors', evt.target.checked)}
         />

--- a/src/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/routes/__snapshots__/Settings.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="colors"
         >
-          Use colors to indicate state
+          Use GitHub-like state colors (requires re-auth)
         </label>
       </div>
     </div>


### PR DESCRIPTION
Per https://github.com/gitify-app/gitify/issues/624, enabling colors for existing users is breaking notifications for those without the repo scope.

As a quick stopgap, this PR defaults colors to off and flags that re-auth is required.

Following this, we can add an error check that shows a message to the user when their request fails because they don't have the necessary scope. Alternatively, as #624 suggests, we can just log the user out in this case. When we've done that, we can re-enable colors as a default. I don't have time for this better fix today, so pushing this.

I recommend we release this as 4.4.1 to fix the immediate problem. WDYT @afonsojramos ?