### PR TITLE
fix: use enterprise token if hostname of notification is enterprise server 

### DIFF
--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -124,12 +124,21 @@ export const useNotifications = (colors: boolean): NotificationsState => {
                           ) {
                             return notification;
                           }
+                          const isEnterprise =
+                            accountNotifications.hostname !==
+                            Constants.DEFAULT_AUTH_OPTIONS.hostname;
+                          const token = isEnterprise
+                            ? getEnterpriseAccountToken(
+                                accountNotifications.hostname,
+                                accounts.enterpriseAccounts,
+                              )
+                            : accounts.token;
 
                           const cardinalData = (
                             await apiRequestAuth(
                               notification.subject.url,
                               'GET',
-                              accounts.token,
+                              token,
                             )
                           ).data;
 


### PR DESCRIPTION
## Context

Thanks to many contributions released in https://github.com/gitify-app/gitify/releases/tag/v4.4.0, almost issues related to GitHub Enterprise Server have been fixed.
However, an issue about token usage still remains.

## Summrary

* Fix to use an enterprise token if the notification's hostname is enterprise server's name.
	* Current implementation used a github.com token for everything, so some API calls failed with a 401 error. 	