### PR TITLE
feat: check for github scopes

### DIFF
--- a/src/components/fields/Checkbox.tsx
+++ b/src/components/fields/Checkbox.tsx
@@ -27,7 +27,9 @@ export const FieldCheckbox = (props: IFieldCheckbox) => {
         <label
           htmlFor={props.name}
           className="font-medium text-gray-700 dark:text-gray-200"
-          style={{ textDecoration: props.disabled && 'line-through' }}
+          style={
+            props.disabled ? { textDecoration: 'line-through' } : undefined
+          }
         >
           {props.label}
         </label>

--- a/src/components/fields/Checkbox.tsx
+++ b/src/components/fields/Checkbox.tsx
@@ -6,6 +6,7 @@ interface IFieldCheckbox {
   checked: boolean;
   onChange: any;
   placeholder?: string;
+  disabled?: boolean;
 }
 
 export const FieldCheckbox = (props: IFieldCheckbox) => {
@@ -18,6 +19,7 @@ export const FieldCheckbox = (props: IFieldCheckbox) => {
           className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
           checked={props.checked}
           onChange={props.onChange}
+          disabled={props.disabled}
         />
       </div>
 
@@ -25,6 +27,7 @@ export const FieldCheckbox = (props: IFieldCheckbox) => {
         <label
           htmlFor={props.name}
           className="font-medium text-gray-700 dark:text-gray-200"
+          style={{ textDecoration: props.disabled && 'line-through' }}
         >
           {props.label}
         </label>

--- a/src/context/App.test.tsx
+++ b/src/context/App.test.tsx
@@ -264,7 +264,7 @@ describe('context/App.tsx', () => {
         participating: true,
         playSound: true,
         showNotifications: true,
-        colors: true,
+        colors: false,
       },
     );
   });
@@ -302,7 +302,7 @@ describe('context/App.tsx', () => {
         participating: false,
         playSound: true,
         showNotifications: true,
-        colors: true,
+        colors: false,
       },
     );
   });

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -37,7 +37,7 @@ export const defaultSettings: SettingsState = {
   markOnClick: false,
   openAtStartup: false,
   appearance: Appearance.SYSTEM,
-  colors: true,
+  colors: false,
 };
 
 interface AppContextState {

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -1,11 +1,13 @@
 import React, {
-  useState,
   createContext,
   useCallback,
   useEffect,
   useMemo,
+  useState,
 } from 'react';
 
+import { useInterval } from '../hooks/useInterval';
+import { useNotifications } from '../hooks/useNotifications';
 import {
   AccountNotifications,
   Appearance,
@@ -15,14 +17,12 @@ import {
   SettingsState,
 } from '../types';
 import { apiRequestAuth } from '../utils/api-requests';
-import { addAccount, authGitHub, getToken, getUserData } from '../utils/auth';
-import { clearState, loadState, saveState } from '../utils/storage';
 import { setAppearance } from '../utils/appearance';
+import { addAccount, authGitHub, getToken, getUserData } from '../utils/auth';
 import { setAutoLaunch } from '../utils/comms';
-import { useInterval } from '../hooks/useInterval';
-import { useNotifications } from '../hooks/useNotifications';
 import Constants from '../utils/constants';
 import { generateGitHubAPIUrl } from '../utils/helpers';
+import { clearState, loadState, saveState } from '../utils/storage';
 
 const defaultAccounts: AuthState = {
   token: null,

--- a/src/routes/Settings.test.tsx
+++ b/src/routes/Settings.test.tsx
@@ -343,7 +343,7 @@ describe('routes/Settings.tsx', () => {
     expect(updateSetting).toHaveBeenCalledWith('colors', true);
   });
 
-  it('should not be able to enable colors', async () => {
+  it('should not be able to enable colors due to missing scope', async () => {
     jest.spyOn(apiRequests, 'apiRequestAuth').mockResolvedValue({
       headers: {
         'x-oauth-scopes': 'read:user, notifications',

--- a/src/routes/Settings.test.tsx
+++ b/src/routes/Settings.test.tsx
@@ -9,7 +9,7 @@ const { ipcRenderer } = require('electron');
 
 import { SettingsRoute } from './Settings';
 import { AppContext } from '../context/App';
-import { mockSettings } from '../__mocks__/mock-state';
+import { mockAccounts, mockSettings } from '../__mocks__/mock-state';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -31,7 +31,9 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       tree = TestRenderer.create(
-        <AppContext.Provider value={{ settings: mockSettings }}>
+        <AppContext.Provider
+          value={{ settings: mockSettings, accounts: mockAccounts }}
+        >
           <MemoryRouter>
             <SettingsRoute />
           </MemoryRouter>
@@ -48,7 +50,11 @@ describe('routes/Settings.tsx', () => {
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
         <AppContext.Provider
-          value={{ settings: mockSettings, logout: logoutMock }}
+          value={{
+            settings: mockSettings,
+            accounts: mockAccounts,
+            logout: logoutMock,
+          }}
         >
           <Router location={history.location} navigator={history}>
             <SettingsRoute />
@@ -73,7 +79,9 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
-        <AppContext.Provider value={{ settings: mockSettings }}>
+        <AppContext.Provider
+          value={{ settings: mockSettings, accounts: mockAccounts }}
+        >
           <Router location={history.location} navigator={history}>
             <SettingsRoute />
           </Router>
@@ -91,7 +99,13 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
-        <AppContext.Provider value={{ settings: mockSettings, updateSetting }}>
+        <AppContext.Provider
+          value={{
+            settings: mockSettings,
+            accounts: mockAccounts,
+            updateSetting,
+          }}
+        >
           <MemoryRouter>
             <SettingsRoute />
           </MemoryRouter>
@@ -113,7 +127,13 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
-        <AppContext.Provider value={{ settings: mockSettings, updateSetting }}>
+        <AppContext.Provider
+          value={{
+            settings: mockSettings,
+            accounts: mockAccounts,
+            updateSetting,
+          }}
+        >
           <MemoryRouter>
             <SettingsRoute />
           </MemoryRouter>
@@ -135,7 +155,13 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
-        <AppContext.Provider value={{ settings: mockSettings, updateSetting }}>
+        <AppContext.Provider
+          value={{
+            settings: mockSettings,
+            accounts: mockAccounts,
+            updateSetting,
+          }}
+        >
           <MemoryRouter>
             <SettingsRoute />
           </MemoryRouter>
@@ -157,7 +183,13 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
-        <AppContext.Provider value={{ settings: mockSettings, updateSetting }}>
+        <AppContext.Provider
+          value={{
+            settings: mockSettings,
+            accounts: mockAccounts,
+            updateSetting,
+          }}
+        >
           <MemoryRouter>
             <SettingsRoute />
           </MemoryRouter>
@@ -179,7 +211,13 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
-        <AppContext.Provider value={{ settings: mockSettings, updateSetting }}>
+        <AppContext.Provider
+          value={{
+            settings: mockSettings,
+            accounts: mockAccounts,
+            updateSetting,
+          }}
+        >
           <MemoryRouter>
             <SettingsRoute />
           </MemoryRouter>
@@ -201,7 +239,13 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
-        <AppContext.Provider value={{ settings: mockSettings, updateSetting }}>
+        <AppContext.Provider
+          value={{
+            settings: mockSettings,
+            accounts: mockAccounts,
+            updateSetting,
+          }}
+        >
           <MemoryRouter>
             <SettingsRoute />
           </MemoryRouter>
@@ -221,7 +265,9 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
-        <AppContext.Provider value={{ settings: mockSettings }}>
+        <AppContext.Provider
+          value={{ settings: mockSettings, accounts: mockAccounts }}
+        >
           <Router location={history.location} navigator={history}>
             <SettingsRoute />
           </Router>
@@ -241,7 +287,9 @@ describe('routes/Settings.tsx', () => {
 
     await act(async () => {
       const { getByLabelText: getByLabelTextLocal } = render(
-        <AppContext.Provider value={{ settings: mockSettings }}>
+        <AppContext.Provider
+          value={{ settings: mockSettings, accounts: mockAccounts }}
+        >
           <MemoryRouter>
             <SettingsRoute />
           </MemoryRouter>
@@ -252,5 +300,41 @@ describe('routes/Settings.tsx', () => {
 
     fireEvent.click(getByLabelText('Quit Gitify'));
     expect(ipcRenderer.send).toHaveBeenCalledWith('app-quit');
+  });
+
+  it('should not be able to disable colors', async () => {
+    let queryByLabelText;
+    jest.mock('../utils/helpers', () => ({
+      ...jest.requireActual('../utils/helpers'),
+      apiRequestAuth: jest.fn().mockResolvedValue({
+        headers: {
+          'x-oauth-scopes': 'repo, notifications',
+        },
+      }),
+    }));
+
+    await act(async () => {
+      const { queryByLabelText: queryByLabelLocal } = render(
+        <AppContext.Provider
+          value={{
+            settings: mockSettings,
+            accounts: mockAccounts,
+          }}
+        >
+          <MemoryRouter>
+            <SettingsRoute />
+          </MemoryRouter>
+        </AppContext.Provider>,
+      );
+      queryByLabelText = queryByLabelLocal;
+    });
+
+    console.log(
+      queryByLabelText('Use GitHub-like state colors (requires re-auth)'),
+    );
+
+    expect(
+      queryByLabelText('Use GitHub-like state colors (requires re-auth)'),
+    ).toBeDefined();
   });
 });

--- a/src/routes/Settings.test.tsx
+++ b/src/routes/Settings.test.tsx
@@ -10,6 +10,7 @@ const { ipcRenderer } = require('electron');
 import { SettingsRoute } from './Settings';
 import { AppContext } from '../context/App';
 import { mockAccounts, mockSettings } from '../__mocks__/mock-state';
+import Constants from '../utils/constants';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -300,6 +301,60 @@ describe('routes/Settings.tsx', () => {
 
     fireEvent.click(getByLabelText('Quit Gitify'));
     expect(ipcRenderer.send).toHaveBeenCalledWith('app-quit');
+  });
+
+  it('should be able to enable colors', async () => {
+    let getByLabelText;
+    jest.mock('../utils/api-requests', () => ({
+      ...jest.requireActual('../utils/api-requests'),
+      apiRequestAuth: jest.fn().mockResolvedValue({
+        headers: {
+          'x-oauth-scopes': Constants.AUTH_SCOPE.join(', '),
+          'access-control-allow-headers': 'Authorization',
+          'access-control-allow-origin': '*',
+          'access-control-expose-headers': 'X-OAuth-Scopes',
+          'cache-control': 'private, max-age=60, s-maxage=60',
+          'content-encoding': 'gzip',
+          'content-security-policy': "default-src 'none'",
+          'content-type': 'application/json; charset=utf-8',
+          server: 'GitHub.com',
+          'strict-transport-security':
+            'max-age=31536000; includeSubdomains; preload',
+          vary: 'Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With',
+        },
+      }),
+    }));
+    await act(async () => {
+      const { getByLabelText: getByLabelTextLocal } = render(
+        <AppContext.Provider
+          value={{
+            settings: mockSettings,
+            accounts: mockAccounts,
+            updateSetting,
+          }}
+        >
+          <MemoryRouter>
+            <SettingsRoute />
+          </MemoryRouter>
+        </AppContext.Provider>,
+      );
+      getByLabelText = getByLabelTextLocal;
+    });
+
+    // await act(async () => {
+    //   expect(getByLabelText('Use GitHub-like state colors')).toBeDefined();
+    // });
+
+    // await act(async () => {
+    await act(
+      () =>
+        // waitFor(() =>
+        fireEvent.click(getByLabelText('Use GitHub-like state colors')),
+      // ),
+    );
+
+    expect(updateSetting).toHaveBeenCalledTimes(1);
+    expect(updateSetting).toHaveBeenCalledWith('colors', true);
   });
 
   it('should not be able to disable colors', async () => {

--- a/src/routes/Settings.test.tsx
+++ b/src/routes/Settings.test.tsx
@@ -380,6 +380,7 @@ describe('routes/Settings.tsx', () => {
     );
 
     // check if the checkbox is still unchecked
+    expect(updateSetting).not.toHaveBeenCalled();
     expect(
       screen.getByLabelText(
         'Use GitHub-like state colors (requires repo scope)',

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -113,7 +113,9 @@ export const SettingsRoute: React.FC = () => {
             !colorScope ? ' (requires repo scope)' : ''
           }`}
           checked={colorScope && settings.colors}
-          onChange={(evt) => updateSetting('colors', evt.target.checked)}
+          onChange={(evt) =>
+            colorScope && updateSetting('colors', evt.target.checked)
+          }
           disabled={!colorScope}
         />
         <FieldCheckbox

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -48,8 +48,6 @@ export const SettingsRoute: React.FC = () => {
         accounts.token,
       );
 
-      console.info("Token's scopes:", response.headers['x-oauth-scopes']);
-
       if (response.headers['x-oauth-scopes'].includes('repo'))
         setColorScope(true);
     })();

--- a/src/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/routes/__snapshots__/Settings.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`routes/Settings.tsx should not be able to enable colors 1`] = `
+exports[`routes/Settings.tsx should not be able to enable colors due to missing scope 1`] = `
 <div
   class="flex items-start mt-1 mb-3"
 >

--- a/src/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/routes/__snapshots__/Settings.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <input
           checked={false}
           className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
-          disabled={true}
+          disabled={false}
           id="colors"
           onChange={[Function]}
           type="checkbox"
@@ -142,11 +142,11 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
           htmlFor="colors"
           style={
             {
-              "textDecoration": "line-through",
+              "textDecoration": false,
             }
           }
         >
-          Use GitHub-like state colors (requires re-auth)
+          Use GitHub-like state colors
         </label>
       </div>
     </div>

--- a/src/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/routes/__snapshots__/Settings.test.tsx.snap
@@ -128,6 +128,7 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <input
           checked={false}
           className="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
+          disabled={true}
           id="colors"
           onChange={[Function]}
           type="checkbox"
@@ -139,8 +140,13 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="colors"
+          style={
+            {
+              "textDecoration": "line-through",
+            }
+          }
         >
-          Use colors to indicate state
+          Use GitHub-like state colors (requires re-auth)
         </label>
       </div>
     </div>
@@ -164,6 +170,11 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="showOnlyParticipating"
+          style={
+            {
+              "textDecoration": undefined,
+            }
+          }
         >
           Show only participating
         </label>
@@ -189,6 +200,11 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="playSound"
+          style={
+            {
+              "textDecoration": undefined,
+            }
+          }
         >
           Play sound
         </label>
@@ -214,6 +230,11 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="showNotifications"
+          style={
+            {
+              "textDecoration": undefined,
+            }
+          }
         >
           Show notifications
         </label>
@@ -239,6 +260,11 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="onClickMarkAsRead"
+          style={
+            {
+              "textDecoration": undefined,
+            }
+          }
         >
           Mark as read on click
         </label>
@@ -264,6 +290,11 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="openAtStartUp"
+          style={
+            {
+              "textDecoration": undefined,
+            }
+          }
         >
           Open at startup
         </label>

--- a/src/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/routes/__snapshots__/Settings.test.tsx.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`routes/Settings.tsx should not be able to enable colors 1`] = `
+<div
+  class="flex items-start mt-1 mb-3"
+>
+  <div
+    class="flex items-center h-5"
+  >
+    <input
+      class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
+      disabled=""
+      id="colors"
+      type="checkbox"
+    />
+  </div>
+  <div
+    class="ml-3 text-sm"
+  >
+    <label
+      class="font-medium text-gray-700 dark:text-gray-200"
+      for="colors"
+      style="text-decoration: line-through;"
+    >
+      Use GitHub-like state colors (requires repo scope)
+    </label>
+  </div>
+</div>
+`;
+
 exports[`routes/Settings.tsx should render itself & its children 1`] = `
 <div
   className="flex flex-1 flex-col dark:bg-gray-dark dark:text-white"
@@ -140,11 +168,6 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="colors"
-          style={
-            {
-              "textDecoration": false,
-            }
-          }
         >
           Use GitHub-like state colors
         </label>
@@ -170,11 +193,6 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="showOnlyParticipating"
-          style={
-            {
-              "textDecoration": undefined,
-            }
-          }
         >
           Show only participating
         </label>
@@ -200,11 +218,6 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="playSound"
-          style={
-            {
-              "textDecoration": undefined,
-            }
-          }
         >
           Play sound
         </label>
@@ -230,11 +243,6 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="showNotifications"
-          style={
-            {
-              "textDecoration": undefined,
-            }
-          }
         >
           Show notifications
         </label>
@@ -260,11 +268,6 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="onClickMarkAsRead"
-          style={
-            {
-              "textDecoration": undefined,
-            }
-          }
         >
           Mark as read on click
         </label>
@@ -290,11 +293,6 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         <label
           className="font-medium text-gray-700 dark:text-gray-200"
           htmlFor="openAtStartUp"
-          style={
-            {
-              "textDecoration": undefined,
-            }
-          }
         >
           Open at startup
         </label>


### PR DESCRIPTION
Alternative to #660, also attempting to fix https://github.com/gitify-app/gitify/issues/624, since enabling colors for existing users is breaking notifications for those without the repo scope.

This PR notifies the user every time that he doesn't have the required scopes and disables colors in case he doesn't. Opted by not logging out to not be too annoying.

Warning: Implementation might not be the best.