### PR TITLE
refactor: use brew CLI over custom action

### DIFF
--- a/.github/workflows/trigger-homebrew.yml
+++ b/.github/workflows/trigger-homebrew.yml
@@ -3,14 +3,10 @@ on:
     tags: 'v*'
 
 jobs:
-  homebrew:
-    name: Bump Homebrew Cask
+  pr-to-homebrew:
     runs-on: macos-latest
     steps:
-      - uses: macauley/action-homebrew-bump-cask@v1
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-          org: gitify-app
-          tap: homebrew/homebrew-cask
-          cask: gitify
-          force: false
+      - uses: Homebrew/actions/setup-homebrew@master
+      - run: brew bump-cask-pr gitify --version=${{ github.ref }} --message="Bump gitify to ${{ github.ref }}" --dry-run
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/trigger-homebrew.yml
+++ b/.github/workflows/trigger-homebrew.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: Homebrew/actions/setup-homebrew@master
       - id: version
-        run: echo ::set-output name=version::$(echo ${{ github.ref }} | cut -d'/' -f3)
+        run: echo ::set-output name=version::$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')
       - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}" --dry-run
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/trigger-homebrew.yml
+++ b/.github/workflows/trigger-homebrew.yml
@@ -2,7 +2,7 @@ name: Homebrew
 
 on:
   push:
-    tags: 'v*'
+    # tags: 'v*'
 
 jobs:
   pr-to-homebrew:
@@ -11,6 +11,7 @@ jobs:
       - uses: Homebrew/actions/setup-homebrew@master
       - id: version
         run: echo ::set-output name=version::$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')
-      - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}" --dry-run
+      # - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}" --dry-run
+      - run: brew bump-cask-pr gitify --version=4.5.1 --message="Bump gitify to 4.5.1" --dry-run
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/trigger-homebrew.yml
+++ b/.github/workflows/trigger-homebrew.yml
@@ -1,3 +1,5 @@
+name: Homebrew
+
 on:
   push:
     tags: 'v*'
@@ -7,6 +9,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: Homebrew/actions/setup-homebrew@master
-      - run: brew bump-cask-pr gitify --version=${{ github.ref }} --message="Bump gitify to ${{ github.ref }}" --dry-run
+      - id: version
+        run: echo ::set-output name=version::$(echo ${{ github.ref }} | cut -d'/' -f3)
+      - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}" --dry-run
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/trigger-homebrew.yml
+++ b/.github/workflows/trigger-homebrew.yml
@@ -2,7 +2,7 @@ name: Homebrew
 
 on:
   push:
-    # tags: 'v*'
+    tags: 'v*'
 
 jobs:
   pr-to-homebrew:
@@ -10,8 +10,7 @@ jobs:
     steps:
       - uses: Homebrew/actions/setup-homebrew@master
       - id: version
-        run: echo ::set-output name=version::$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')
-      # - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}" --dry-run
-      - run: brew bump-cask-pr gitify --version=4.5.1 --message="Bump gitify to 4.5.1" --dry-run
+        run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
+      - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}"
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Custom action was broken, so this PR replaces it with the official `bump-cask-pr` CLI, which can be seen working here: https://github.com/gitify-app/gitify/actions/runs/7108934623/job/19353060346