### PR TITLE
chore: rename to `on-tag` and trigger web build

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -23,13 +23,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: gitify-app/website
+          token: ${{ secrets.GH_TOKEN }}
       - uses: pnpm/action-setup@v2
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - id: version
-        run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo "4.5.2")" >> $GITHUB_OUTPUT
+        # run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
       - name: setup git config
         run: |
           git config user.name "Gitify Version Bot"
@@ -40,20 +42,12 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            github.repos.createPullRequest({
+            github.rest.pulls.create({
               owner: 'gitify-app',
               repo: 'website',
               title: `deps: bump gitify version to ${{ steps.version.outputs.version }}`,
               head: `bump/${{ steps.version.outputs.version }}`,
               base: 'main',
               body: `Bump gitify version to ${{ steps.version.outputs.version }}`,
-              draft: false,
               maintainer_can_modify: true,
-            })
-
-            github.issues.addAssignees({
-              owner: 'gitify-app',
-              repo: 'website',
-              issue_number: context.payload.pull_request.number,
-              assignees: ['afonsojramos'],
             })

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -2,16 +2,53 @@ name: On Tag
 
 on:
   push:
-    tags: 'v*'
+    # tags: 'v*'
 
 jobs:
-  pr-to-homebrew:
-    name: Homebrew
-    runs-on: macos-latest
+  # pr-to-homebrew:
+  #   name: Homebrew
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: Homebrew/actions/setup-homebrew@master
+  #     - id: version
+  #       run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
+  #     - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}"
+  #       env:
+  #         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  update-website:
+    name: Website
+    runs-on: ubuntu-latest
     steps:
-      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: actions/checkout@v4
+        with:
+          repository: gitify-app/website
       - id: version
         run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
-      - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}"
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: setup git config
+        run: |
+          git config user.name "Gitify Version Bot"
+          git config user.email "<>"
+      - run: git checkout -b "bump/${{ steps.version.outputs.version }}"
+      - run: pnpm version ${{ steps.version.outputs.version }}
+      - run: git push origin "bump/${{ steps.version.outputs.version }}"
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.repos.createPullRequest({
+              owner: 'gitify-app',
+              repo: 'website',
+              title: `deps: bump gitify version to ${{ steps.version.outputs.version }}`,
+              head: `bump/${{ steps.version.outputs.version }}`,
+              base: 'main',
+              body: `Bump gitify version to ${{ steps.version.outputs.version }}`,
+              draft: false,
+              maintainer_can_modify: true,
+            })
+
+            github.issues.addAssignees({
+              owner: 'gitify-app',
+              repo: 'website',
+              issue_number: context.payload.pull_request.number,
+              assignees: ['afonsojramos'],
+            })

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -23,6 +23,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: gitify-app/website
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
       - id: version
         run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
       - name: setup git config

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -2,19 +2,19 @@ name: On Tag
 
 on:
   push:
-    # tags: 'v*'
+    tags: 'v*'
 
 jobs:
-  # pr-to-homebrew:
-  #   name: Homebrew
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: Homebrew/actions/setup-homebrew@master
-  #     - id: version
-  #       run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
-  #     - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}"
-  #       env:
-  #         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
+  pr-to-homebrew:
+    name: Homebrew
+    runs-on: macos-latest
+    steps:
+      - uses: Homebrew/actions/setup-homebrew@master
+      - id: version
+        run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
+      - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}"
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
 
   update-website:
     name: Website
@@ -30,8 +30,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
       - id: version
-        run: echo "version=$(echo "4.5.2")" >> $GITHUB_OUTPUT
-        # run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
+        run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
       - name: setup git config
         run: |
           git config user.name "Gitify Version Bot"
@@ -42,12 +41,4 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            github.rest.pulls.create({
-              owner: 'gitify-app',
-              repo: 'website',
-              title: `deps: bump gitify version to ${{ steps.version.outputs.version }}`,
-              head: `bump/${{ steps.version.outputs.version }}`,
-              base: 'main',
-              body: `Bump gitify version to ${{ steps.version.outputs.version }}`,
-              maintainer_can_modify: true,
-            })
+            core.notice('Create PR by going to: https://github.com/gitify-app/website/compare/bump/${{ steps.version.outputs.version }}')

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -1,4 +1,4 @@
-name: Homebrew
+name: On Tag
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   pr-to-homebrew:
+    name: Homebrew
     runs-on: macos-latest
     steps:
       - uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
Create notice over pr so that there is no need for a PAT. In the future if we can get a fine grained token that would be better.

This is supposed to trigger a build so that Astro can fetch the new version, as this is still more performance than shipping Astro with something else to fetch the latest version on the client side as was tested in https://github.com/gitify-app/website/pull/33