### PR TITLE
fix(macos): switch from `altool` to `notarytool`

### DIFF
--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -23,6 +23,7 @@ const notarizeApp = async (context) => {
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLEID_USERNAME,
     appleIdPassword: process.env.APPLEID_PASSWORD,
+    tool: 'notarytool',
   });
 };
 


### PR DESCRIPTION
It should be straightforward for us, as per https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool