### PR TITLE
chore: bump to `v4.6.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitify",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "GitHub Notifications on your menu bar.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Let's push this version even if we can't get it properly signed for macOS yet. I'll manually delete the release files for MacOS in the meantime so it doesn't create confusion.