### PR TITLE
chore: update runners to `macos-14`

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-macos:
     name: Build macOS (electron-builder)
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-to-homebrew:
     name: Homebrew
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: Homebrew/actions/setup-homebrew@master
       - id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-macos:
     name: Publish macOS (electron-builder)
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
According to https://twitter.com/yagiznizipli/status/1752740836461167041 and https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/ this should severely improve our macos runners performance.

Edit: Confirmed ✅  Went from ~4minutes to ~2m10s