### PR TITLE
feat: resizable window

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const { autoUpdater } = require('electron-updater');
 const { onFirstRunMaybe } = require('./first-run');
 const path = require('path');
 
-require('@electron/remote/main').initialize()
+require('@electron/remote/main').initialize();
 
 app.setAppUserModelId('com.electron.gitify');
 
@@ -12,7 +12,7 @@ const iconIdle = path.join(
   __dirname,
   'assets',
   'images',
-  'tray-idleTemplate.png'
+  'tray-idleTemplate.png',
 );
 const iconActive = path.join(__dirname, 'assets', 'images', 'tray-active.png');
 
@@ -21,7 +21,7 @@ const browserWindowOpts = {
   height: 400,
   minWidth: 500,
   minHeight: 400,
-  resizable: false,
+  resizable: true,
   webPreferences: {
     enableRemoteModule: true,
     overlayScrollbars: true,
@@ -52,7 +52,30 @@ const menubarApp = menubar({
 });
 
 menubarApp.on('ready', () => {
+  // Utility function to reposition the window so it stays in the tray center
+  function moveToTrayCenter() {
+    const trayBounds = menubarApp.tray.getBounds();
+    menubarApp.positioner.move('trayCenter', trayBounds);
+  }
+
+  // If window has previously been resized, update its size
+  function restoreWindowSize() {
+    menubarApp.window.webContents
+      .executeJavaScript('localStorage.getItem("size");', true)
+      .then((result) => {
+        const size = result.split(',');
+        if (!result || size.length !== 2) return;
+
+        const width = Number(size[0]);
+        const height = Number(size[1]);
+        menubarApp.window.setSize(width, height);
+
+        moveToTrayCenter();
+      });
+  }
+
   delayedHideAppIcon();
+  restoreWindowSize();
 
   menubarApp.tray.setIgnoreDoubleClickEvents(true);
 
@@ -93,17 +116,11 @@ menubarApp.on('ready', () => {
   menubarApp.window.webContents.on('devtools-opened', () => {
     menubarApp.window.setSize(800, 600);
     menubarApp.window.center();
-    menubarApp.window.resizable = true;
   });
 
   menubarApp.window.webContents.on('devtools-closed', () => {
-    const trayBounds = menubarApp.tray.getBounds();
-    menubarApp.window.setSize(
-      browserWindowOpts.width,
-      browserWindowOpts.height
-    );
-    menubarApp.positioner.move('trayCenter', trayBounds);
-    menubarApp.window.resizable = false;
+    restoreWindowSize();
+    moveToTrayCenter();
   });
 
   menubarApp.window.webContents.on('before-input-event', (event, input) => {
@@ -111,5 +128,15 @@ menubarApp.on('ready', () => {
       menubarApp.window.hide();
       event.preventDefault();
     }
+  });
+
+  menubarApp.window.on('resized', () => {
+    moveToTrayCenter();
+
+    // Store the current size in localStorage to persist across restarts
+    menubarApp.window.webContents.executeJavaScript(
+      `localStorage.setItem("size", ${JSON.stringify(menubarApp.window.getSize())});`,
+      true,
+    );
   });
 });


### PR DESCRIPTION
## Related issues

- #433
- #434

## Context

Make the Gitify window resizable

## Discussion

I decided to make it so that it's resizable by default because IMO it's better to not have too many settings.

I used localStorage to persist the size of the window across restarts (note if you're testing it in dev, make sure you properly quit gitify using the close button instead of `cmd+c` the `pnpm start` process; otherwise the size sometimes doesn't get saved across restarts (idk why))

I had to make a small hack (`menubarApp.window.webContents.executeJavaScript`) to get access to the localStorage in the `main.js` file because it was undefined in `menubarApp.window`; if you have a cleaner way to do this please let me know!
