### PR TITLE
build(renovate): configuration updates for major versions and osv

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "labels": ["dependency"],
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependency"
+  ],
   "prConcurrentLimit": 5,
   "rangeStrategy": "pin",
-  "schedule": ["monthly"]
+  "schedule": [
+    "monthly"
+  ],
+  "separateMultipleMajor": true
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,6 @@
   "schedule": [
     "monthly"
   ],
-  "separateMultipleMajor": true
+  "separateMultipleMajor": true,
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
Configure Renovate to split multiple major release jumps into individual PRs, so that we can incrementally close the gap (eg: electron 22 -> 28).

Also enabled osv alerts for security related PRs