### PR TITLE
feat: add "Unsubscribe from repository" button

### DIFF
--- a/src/components/Repository.test.tsx
+++ b/src/components/Repository.test.tsx
@@ -13,6 +13,7 @@ jest.mock('./NotificationRow', () => ({
 }));
 
 describe('components/Repository.tsx', () => {
+  const unsubscribeRepository = jest.fn();
   const markRepoNotifications = jest.fn();
 
   const props = {
@@ -48,6 +49,21 @@ describe('components/Repository.tsx', () => {
     expect(shell.openExternal).toHaveBeenCalledTimes(1);
     expect(shell.openExternal).toHaveBeenCalledWith(
       'https://github.com/manosim/notifications-test',
+    );
+  });
+
+  it('should unsubscribe from the repository', () => {
+    const { getByTitle } = render(
+      <AppContext.Provider value={{ unsubscribeRepository }}>
+        <RepositoryNotifications {...props} />
+      </AppContext.Provider>,
+    );
+
+    fireEvent.click(getByTitle('Unsubscribe'));
+
+    expect(unsubscribeRepository).toHaveBeenCalledWith(
+      'manosim/notifications-test',
+      'github.com',
     );
   });
 

--- a/src/components/Repository.test.tsx
+++ b/src/components/Repository.test.tsx
@@ -52,13 +52,13 @@ describe('components/Repository.tsx', () => {
   });
 
   it('should mark a repo as read', function () {
-    const { getByRole } = render(
+    const { getByTitle } = render(
       <AppContext.Provider value={{ markRepoNotifications }}>
         <RepositoryNotifications {...props} />
       </AppContext.Provider>,
     );
 
-    fireEvent.click(getByRole('button'));
+    fireEvent.click(getByTitle('Mark Repository as Read'));
 
     expect(markRepoNotifications).toHaveBeenCalledWith(
       'manosim/notifications-test',

--- a/src/components/Repository.tsx
+++ b/src/components/Repository.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext } from 'react';
-import { ReadIcon } from '@primer/octicons-react';
+import { BellSlashIcon, ReadIcon } from '@primer/octicons-react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 import { AppContext } from '../context/App';
@@ -18,7 +18,8 @@ export const RepositoryNotifications: React.FC<IProps> = ({
   repoNotifications,
   hostname,
 }) => {
-  const { markRepoNotifications } = useContext(AppContext);
+  const { markRepoNotifications, unsubscribeRepository } =
+    useContext(AppContext);
 
   const openBrowser = useCallback(() => {
     const url = repoNotifications[0].repository.html_url;
@@ -28,6 +29,11 @@ export const RepositoryNotifications: React.FC<IProps> = ({
   const markRepoAsRead = useCallback(() => {
     const repoSlug = repoNotifications[0].repository.full_name;
     markRepoNotifications(repoSlug, hostname);
+  }, [repoNotifications, hostname]);
+
+  const unsubscribe = useCallback(() => {
+    const repoSlug = repoNotifications[0].repository.full_name;
+    unsubscribeRepository(repoSlug, hostname);
   }, [repoNotifications, hostname]);
 
   const avatarUrl = repoNotifications[0].repository.owner.avatar_url;
@@ -40,7 +46,15 @@ export const RepositoryNotifications: React.FC<IProps> = ({
           <span onClick={openBrowser}>{repoName}</span>
         </div>
 
-        <div className="flex justify-center items-center">
+        <div className="flex justify-center items-center gap-2">
+          <button
+            className="focus:outline-none h-full hover:text-red-500"
+            title="Unsubscribe"
+            onClick={unsubscribe}
+          >
+            <BellSlashIcon size={14} aria-label="Unsubscribe" />
+          </button>
+
           <button
             className="focus:outline-none h-full hover:text-green-500"
             title="Mark Repository as Read"

--- a/src/components/__snapshots__/Repository.test.tsx.snap
+++ b/src/components/__snapshots__/Repository.test.tsx.snap
@@ -19,8 +19,37 @@ exports[`components/Repository.tsx should render itself & its children 1`] = `
       </span>
     </div>
     <div
-      className="flex justify-center items-center"
+      className="flex justify-center items-center gap-2"
     >
+      <button
+        className="focus:outline-none h-full hover:text-red-500"
+        onClick={[Function]}
+        title="Unsubscribe"
+      >
+        <svg
+          aria-hidden="false"
+          aria-label="Unsubscribe"
+          className="octicon octicon-bell-slash"
+          fill="currentColor"
+          focusable="false"
+          height={14}
+          role="img"
+          style={
+            {
+              "display": "inline-block",
+              "overflow": "visible",
+              "userSelect": "none",
+              "verticalAlign": "text-bottom",
+            }
+          }
+          viewBox="0 0 16 16"
+          width={14}
+        >
+          <path
+            d="m4.182 4.31.016.011 10.104 7.316.013.01 1.375.996a.75.75 0 1 1-.88 1.214L13.626 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947V5.305L.31 3.357a.75.75 0 1 1 .88-1.214Zm7.373 7.19L4.5 6.391v1.556c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01c0 .005.002.009.005.012l.006.004.007.001ZM8 1.5c-.997 0-1.895.416-2.534 1.086A.75.75 0 1 1 4.38 1.55 5 5 0 0 1 13 5v2.373a.75.75 0 0 1-1.5 0V5A3.5 3.5 0 0 0 8 1.5ZM8 16a2 2 0 0 1-1.985-1.75c-.017-.137.097-.25.235-.25h3.5c.138 0 .252.113.235.25A2 2 0 0 1 8 16Z"
+          />
+        </svg>
+      </button>
       <button
         className="focus:outline-none h-full hover:text-green-500"
         onClick={[Function]}

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -55,6 +55,7 @@ interface AppContextState {
   markNotification: (id: string, hostname: string) => Promise<void>;
   markNotificationDone: (id: string, hostname: string) => Promise<void>;
   unsubscribeNotification: (id: string, hostname: string) => Promise<void>;
+  unsubscribeRepository: (repoSlug: string, hostname: string) => Promise<void>;
   markRepoNotifications: (id: string, hostname: string) => Promise<void>;
 
   settings: SettingsState;
@@ -74,6 +75,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
     markNotification,
     markNotificationDone,
     unsubscribeNotification,
+    unsubscribeRepository,
     markRepoNotifications,
   } = useNotifications(settings.colors);
 
@@ -191,6 +193,12 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
     [accounts, notifications],
   );
 
+  const unsubscribeRepositoryWithAccounts = useCallback(
+    async (repoSlug: string, hostname: string) =>
+      await unsubscribeRepository(accounts, repoSlug, hostname),
+    [accounts, notifications],
+  );
+
   const markRepoNotificationsWithAccounts = useCallback(
     async (repoSlug: string, hostname: string) =>
       await markRepoNotifications(accounts, repoSlug, hostname),
@@ -214,6 +222,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         markNotification: markNotificationWithAccounts,
         markNotificationDone: markNotificationDoneWithAccounts,
         unsubscribeNotification: unsubscribeNotificationWithAccounts,
+        unsubscribeRepository: unsubscribeRepositoryWithAccounts,
         markRepoNotifications: markRepoNotificationsWithAccounts,
 
         settings,

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -551,6 +551,117 @@ describe('hooks/useNotifications.ts', () => {
     });
   });
 
+  describe('unsubscribeRepository', () => {
+    const repoSlug = 'manosim/notifications-test';
+    const id = 'notification-123';
+
+    describe('github.com', () => {
+      const accounts = { ...mockAccounts, enterpriseAccounts: [] };
+      const hostname = 'github.com';
+
+      it('should unsubscribe from a repository with success - github.com', async () => {
+        // The unsubscribe endpoint call.
+        nock('https://api.github.com/')
+          .put(`/repos/${repoSlug}/subscription`)
+          .reply(200);
+
+        // The mark read endpoint call.
+        nock('https://api.github.com/')
+          .patch(`/notifications/threads/${id}`)
+          .reply(200);
+
+        const { result } = renderHook(() => useNotifications(false));
+
+        act(() => {
+          result.current.unsubscribeRepository(accounts, id, hostname);
+        });
+
+        await waitFor(() => {
+          expect(result.current.isFetching).toBe(false);
+        });
+
+        expect(result.current.notifications.length).toBe(0);
+      });
+
+      it('should unsubscribe from a repository with failure - github.com', async () => {
+        // The unsubscribe endpoint call.
+        nock('https://api.github.com/')
+          .put(`/repos/${repoSlug}/subscription`)
+          .reply(400);
+
+        // The mark read endpoint call.
+        nock('https://api.github.com/')
+          .patch(`/notifications/threads/${id}`)
+          .reply(400);
+
+        const { result } = renderHook(() => useNotifications(false));
+
+        act(() => {
+          result.current.unsubscribeRepository(accounts, id, hostname);
+        });
+
+        await waitFor(() => {
+          expect(result.current.isFetching).toBe(false);
+        });
+
+        expect(result.current.notifications.length).toBe(0);
+      });
+    });
+
+    describe('enterprise', () => {
+      const accounts = { ...mockAccounts, token: null };
+      const hostname = 'github.gitify.io';
+
+      it('should unsubscribe from a notification with success - enterprise', async () => {
+        // The unsubscribe endpoint call.
+        nock('https://github.gitify.io/')
+          .put(`/repos/${repoSlug}/subscription`)
+          .reply(200);
+
+        // The mark read endpoint call.
+        nock('https://github.gitify.io/')
+          .patch(`/notifications/threads/${id}`)
+          .reply(200);
+
+        const { result } = renderHook(() => useNotifications(false));
+
+        act(() => {
+          result.current.unsubscribeRepository(accounts, repoSlug, hostname);
+        });
+
+        await waitFor(() => {
+          expect(result.current.isFetching).toBe(false);
+        });
+
+        expect(result.current.notifications.length).toBe(0);
+      });
+
+      it('should unsubscribe from a notification with failure - enterprise', async () => {
+        // The unsubscribe endpoint call.
+        nock('https://github.gitify.io/')
+          .put(`/repos/${repoSlug}/subscription`)
+          .reply(400);
+
+        // The mark read endpoint call.
+        nock('https://github.gitify.io/')
+          .patch(`/notifications/threads/${id}`)
+          .reply(400);
+
+        const { result } = renderHook(() => useNotifications(false));
+
+        act(() => {
+          result.current.unsubscribeRepository(accounts, repoSlug, hostname);
+        });
+
+        await waitFor(() => {
+          expect(result.current.isFetching).toBe(false);
+        });
+
+        expect(result.current.notifications.length).toBe(0);
+      });
+    });
+  });
+
   describe('markRepoNotifications', () => {
     const repoSlug = 'manosim/gitify';
 


### PR DESCRIPTION
## Context

Add a "Unsubscribe from repository" button.
<img width="500" alt="image" src="https://github.com/gitify-app/gitify/assets/26418696/06c6ce38-46f0-462c-985d-5a592e57e1e3">

It uses the  ["Set a repository subscription" REST API](https://docs.github.com/en/rest/activity/watching?apiVersion=2022-11-28#set-a-repository-subscription), 

## Discussion

Two things:

- At first I was going to start implementing the "Mark repository as done" button (as it had already been discussed in #706, PR coming soon 😉), but having miss-aligned icons made me look into adding this feature first...
But I feel like it's really "heavy" on the UI, it's not so beautiful and it makes it harder to distinguish if the row is a Notification or a Repository...
What do you think?

- Following the "Unsubscribe from notification" implementation, I made it so that clicking on  Repository unsubscribe marks all of the repository's notifications as read. But this behaviour looks a bit odd to me; why automatically discard all those notifications? And why mark them as read instead of done? Perhaps it is better not to discard those notifications at all? If so, we would have to find a way to tell the user that the unsubscribe action has been successful...


