### PR TITLE
fix: missing icon colors on first load

### DIFF
--- a/src/context/App.test.tsx
+++ b/src/context/App.test.tsx
@@ -290,7 +290,7 @@ describe('context/App.tsx', () => {
         participating: true,
         playSound: true,
         showNotifications: true,
-        colors: false,
+        colors: null,
         markAsDoneOnOpen: false,
       },
     );
@@ -328,7 +328,7 @@ describe('context/App.tsx', () => {
         participating: false,
         playSound: true,
         showNotifications: true,
-        colors: false,
+        colors: null,
         markAsDoneOnOpen: false,
       },
     );

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -36,7 +36,7 @@ export const defaultSettings: SettingsState = {
   showNotifications: true,
   openAtStartup: false,
   appearance: Appearance.SYSTEM,
-  colors: false,
+  colors: null,
   markAsDoneOnOpen: false,
 };
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -104,7 +104,7 @@ export const useNotifications = (colors: boolean): NotificationsState => {
                 ]
               : [...enterpriseNotifications];
 
-            if (!colors) {
+            if (colors === false) {
               setNotifications(data);
               triggerNativeNotifications(
                 notifications,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface SettingsState {
   showNotifications: boolean;
   openAtStartup: boolean;
   appearance: Appearance;
-  colors: boolean;
+  colors: boolean | null;
   markAsDoneOnOpen: boolean;
 }
 


### PR DESCRIPTION
## Related issues

- Fixes #786 

## Context

Show notification icons colors on app first load / app refresh.

## Discussion

I've identified 2 possible fixes:

- First one would be to simply drop this code so that we fetch the `state` of each notifications, even though `settings.colors` is falsy.
https://github.com/gitify-app/gitify/blob/1c3c248fd89299d519457ed1d7c3444ab6bf92c2/src/hooks/useNotifications.ts#L107-L117
Since `notification.state` is, for now, only required to load the icons colors, this would result on making a lot of unnecessary api calls if the setting is disabled.

- Second one is the one I've implemented: init `settings.colors` to null and explicitely check for `settings.colors === false`, thus fixing the bug AND avoiding making unnecessary api calls