### PR TITLE
refactor: update Subject type

### DIFF
--- a/src/typesGithub.ts
+++ b/src/typesGithub.ts
@@ -125,9 +125,9 @@ export interface Owner {
 
 export interface Subject {
   title: string;
-  url?: string;
-  state: StateType;
-  latest_comment_url?: string;
+  url: string | null;
+  state?: StateType;
+  latest_comment_url: string | null;
   type: SubjectType;
 }
 


### PR DESCRIPTION
Update `Subject` type to match API response shape

* will always contain `url`, either string or null
* will always contain `latest_comment_url`, either string or null
* may contain a `state`