### PR TITLE
feat: add support for `approval_requested` reason

### DIFF
--- a/src/typesGithub.ts
+++ b/src/typesGithub.ts
@@ -1,4 +1,5 @@
 export type Reason =
+  | 'approval_requested'
   | 'assign'
   | 'author'
   | 'ci_activity'

--- a/src/utils/__snapshots__/github-api.test.ts.snap
+++ b/src/utils/__snapshots__/github-api.test.ts.snap
@@ -2,103 +2,110 @@
 
 exports[`formatReason should format the notification reason 1`] = `
 {
+  "description": "You were requested to review and approve a deployment.",
+  "type": "Approval Requested",
+}
+`;
+
+exports[`formatReason should format the notification reason 2`] = `
+{
   "description": "You were assigned to the issue.",
   "type": "Assign",
 }
 `;
 
-exports[`formatReason should format the notification reason 2`] = `
+exports[`formatReason should format the notification reason 3`] = `
 {
   "description": "You created the thread.",
   "type": "Author",
 }
 `;
 
-exports[`formatReason should format the notification reason 3`] = `
+exports[`formatReason should format the notification reason 4`] = `
 {
   "description": "A GitHub Actions workflow run was triggered for your repository",
   "type": "Workflow Run",
 }
 `;
 
-exports[`formatReason should format the notification reason 4`] = `
+exports[`formatReason should format the notification reason 5`] = `
 {
   "description": "You commented on the thread.",
   "type": "Comment",
 }
 `;
 
-exports[`formatReason should format the notification reason 5`] = `
+exports[`formatReason should format the notification reason 6`] = `
 {
   "description": "You accepted an invitation to contribute to the repository.",
   "type": "Invitation",
 }
 `;
 
-exports[`formatReason should format the notification reason 6`] = `
+exports[`formatReason should format the notification reason 7`] = `
 {
   "description": "You subscribed to the thread (via an issue or pull request).",
   "type": "Manual",
 }
 `;
 
-exports[`formatReason should format the notification reason 7`] = `
+exports[`formatReason should format the notification reason 8`] = `
 {
   "description": "Organization members have requested to enable a feature such as Draft Pull Requests or CoPilot.",
   "type": "Member Feature Requested",
 }
 `;
 
-exports[`formatReason should format the notification reason 8`] = `
+exports[`formatReason should format the notification reason 9`] = `
 {
   "description": "You were specifically @mentioned in the content.",
   "type": "Mention",
 }
 `;
 
-exports[`formatReason should format the notification reason 9`] = `
+exports[`formatReason should format the notification reason 10`] = `
 {
   "description": "You, or a team you're a member of, were requested to review a pull request.",
   "type": "Review Requested",
 }
 `;
 
-exports[`formatReason should format the notification reason 10`] = `
+exports[`formatReason should format the notification reason 11`] = `
 {
   "description": "You were credited for contributing to a security advisory.",
   "type": "Security Advisory Credit",
 }
 `;
 
-exports[`formatReason should format the notification reason 11`] = `
+exports[`formatReason should format the notification reason 12`] = `
 {
   "description": "GitHub discovered a security vulnerability in your repository.",
   "type": "Security Alert",
 }
 `;
 
-exports[`formatReason should format the notification reason 12`] = `
+exports[`formatReason should format the notification reason 13`] = `
 {
   "description": "You changed the thread state (for example, closing an issue or merging a pull request).",
   "type": "State Change",
 }
 `;
 
-exports[`formatReason should format the notification reason 13`] = `
+exports[`formatReason should format the notification reason 14`] = `
 {
   "description": "You're watching the repository.",
   "type": "Subscribed",
 }
 `;
 
-exports[`formatReason should format the notification reason 14`] = `
+exports[`formatReason should format the notification reason 15`] = `
 {
   "description": "You were on a team that was mentioned.",
   "type": "Team Mention",
 }
 `;
 
-exports[`formatReason should format the notification reason 15`] = `
+exports[`formatReason should format the notification reason 16`] = `
 {
   "description": "The reason for this notification is not supported by the app.",
   "type": "Unknown",

--- a/src/utils/github-api.test.ts
+++ b/src/utils/github-api.test.ts
@@ -7,6 +7,7 @@ import { Reason, StateType, Subject, SubjectType } from '../typesGithub';
 
 describe('formatReason', () => {
   it('should format the notification reason', () => {
+    expect(formatReason('approval_requested')).toMatchSnapshot();
     expect(formatReason('assign')).toMatchSnapshot();
     expect(formatReason('author')).toMatchSnapshot();
     expect(formatReason('ci_activity')).toMatchSnapshot();

--- a/src/utils/github-api.ts
+++ b/src/utils/github-api.ts
@@ -24,21 +24,22 @@ import { CheckSuiteStatus, Reason, Subject } from '../typesGithub';
 
 // prettier-ignore
 const DESCRIPTIONS = {
-    ASSIGN: 'You were assigned to the issue.',
-    AUTHOR: 'You created the thread.',
-    COMMENT: 'You commented on the thread.',
-    INVITATION: 'You accepted an invitation to contribute to the repository.',
-    MANUAL: 'You subscribed to the thread (via an issue or pull request).',
-    MEMBER_FEATURE_REQUESTED: 'Organization members have requested to enable a feature such as Draft Pull Requests or CoPilot.',
-    MENTION: 'You were specifically @mentioned in the content.',
-    REVIEW_REQUESTED: "You, or a team you're a member of, were requested to review a pull request.",
-    SECURITY_ADVISORY_CREDIT: "You were credited for contributing to a security advisory.",
-    SECURITY_ALERT: 'GitHub discovered a security vulnerability in your repository.',
-    STATE_CHANGE: 'You changed the thread state (for example, closing an issue or merging a pull request).',
-    SUBSCRIBED: "You're watching the repository.",
-    TEAM_MENTION: 'You were on a team that was mentioned.',
-    CI_ACTIVITY: 'A GitHub Actions workflow run was triggered for your repository',
-    UNKNOWN: 'The reason for this notification is not supported by the app.',
+  APPROVAL_REQUESTED: 'You were requested to review and approve a deployment.',
+  ASSIGN: 'You were assigned to the issue.',
+  AUTHOR: 'You created the thread.',
+  COMMENT: 'You commented on the thread.',
+  INVITATION: 'You accepted an invitation to contribute to the repository.',
+  MANUAL: 'You subscribed to the thread (via an issue or pull request).',
+  MEMBER_FEATURE_REQUESTED: 'Organization members have requested to enable a feature such as Draft Pull Requests or CoPilot.',
+  MENTION: 'You were specifically @mentioned in the content.',
+  REVIEW_REQUESTED: "You, or a team you're a member of, were requested to review a pull request.",
+  SECURITY_ADVISORY_CREDIT: 'You were credited for contributing to a security advisory.',
+  SECURITY_ALERT: 'GitHub discovered a security vulnerability in your repository.',
+  STATE_CHANGE: 'You changed the thread state (for example, closing an issue or merging a pull request).',
+  SUBSCRIBED: "You're watching the repository.",
+  TEAM_MENTION: 'You were on a team that was mentioned.',
+  CI_ACTIVITY: 'A GitHub Actions workflow run was triggered for your repository',
+  UNKNOWN: 'The reason for this notification is not supported by the app.',
 };
 
 export function formatReason(reason: Reason): {
@@ -47,6 +48,8 @@ export function formatReason(reason: Reason): {
 } {
   // prettier-ignore
   switch (reason) {
+    case 'approval_requested':
+      return { type: 'Approval Requested', description: DESCRIPTIONS['APPROVAL_REQUESTED'] };
     case 'assign':
       return { type: 'Assign', description: DESCRIPTIONS['ASSIGN'] };
     case 'author':

--- a/src/utils/github-api.ts
+++ b/src/utils/github-api.ts
@@ -24,22 +24,22 @@ import { CheckSuiteStatus, Reason, Subject } from '../typesGithub';
 
 // prettier-ignore
 const DESCRIPTIONS = {
-  APPROVAL_REQUESTED: 'You were requested to review and approve a deployment.',
-  ASSIGN: 'You were assigned to the issue.',
-  AUTHOR: 'You created the thread.',
-  COMMENT: 'You commented on the thread.',
-  INVITATION: 'You accepted an invitation to contribute to the repository.',
-  MANUAL: 'You subscribed to the thread (via an issue or pull request).',
-  MEMBER_FEATURE_REQUESTED: 'Organization members have requested to enable a feature such as Draft Pull Requests or CoPilot.',
-  MENTION: 'You were specifically @mentioned in the content.',
-  REVIEW_REQUESTED: "You, or a team you're a member of, were requested to review a pull request.",
-  SECURITY_ADVISORY_CREDIT: 'You were credited for contributing to a security advisory.',
-  SECURITY_ALERT: 'GitHub discovered a security vulnerability in your repository.',
-  STATE_CHANGE: 'You changed the thread state (for example, closing an issue or merging a pull request).',
-  SUBSCRIBED: "You're watching the repository.",
-  TEAM_MENTION: 'You were on a team that was mentioned.',
-  CI_ACTIVITY: 'A GitHub Actions workflow run was triggered for your repository',
-  UNKNOWN: 'The reason for this notification is not supported by the app.',
+    APPROVAL_REQUESTED: 'You were requested to review and approve a deployment.',
+    ASSIGN: 'You were assigned to the issue.',
+    AUTHOR: 'You created the thread.',
+    COMMENT: 'You commented on the thread.',
+    INVITATION: 'You accepted an invitation to contribute to the repository.',
+    MANUAL: 'You subscribed to the thread (via an issue or pull request).',
+    MEMBER_FEATURE_REQUESTED: 'Organization members have requested to enable a feature such as Draft Pull Requests or CoPilot.',
+    MENTION: 'You were specifically @mentioned in the content.',
+    REVIEW_REQUESTED: "You, or a team you're a member of, were requested to review a pull request.",
+    SECURITY_ADVISORY_CREDIT: 'You were credited for contributing to a security advisory.',
+    SECURITY_ALERT: 'GitHub discovered a security vulnerability in your repository.',
+    STATE_CHANGE: 'You changed the thread state (for example, closing an issue or merging a pull request).',
+    SUBSCRIBED: "You're watching the repository.",
+    TEAM_MENTION: 'You were on a team that was mentioned.',
+    CI_ACTIVITY: 'A GitHub Actions workflow run was triggered for your repository',
+    UNKNOWN: 'The reason for this notification is not supported by the app.',
 };
 
 export function formatReason(reason: Reason): {


### PR DESCRIPTION
As per https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#about-notification-reasons