### PR TITLE
refactor: split issue state types and document pullrequest state type

### DIFF
--- a/src/typesGithub.ts
+++ b/src/typesGithub.ts
@@ -26,16 +26,20 @@ export type SubjectType =
   | 'RepositoryVulnerabilityAlert'
   | 'WorkflowRun';
 
-export type IssueStateType =
-  | 'closed'
-  | 'completed'
-  | 'not_planned'
-  | 'open'
-  | 'reopened';
+export type IssueStateType = 'closed' | 'open';
 
+export type IssueStateReasonType = 'completed' | 'not_planned' | 'reopened';
+
+/**
+ * Note: draft and merged are not official states in the GitHub API.
+ * These are derived from the pull request's `merged` and `draft` properties.
+ */
 export type PullRequestStateType = 'closed' | 'draft' | 'merged' | 'open';
 
-export type StateType = IssueStateType | PullRequestStateType;
+export type StateType =
+  | IssueStateType
+  | IssueStateReasonType
+  | PullRequestStateType;
 
 export type ViewerSubscription = 'IGNORED' | 'SUBSCRIBED' | 'UNSUBSCRIBED';
 


### PR DESCRIPTION
Split Issue Types to match the schema documented at https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue

Add comment to PullRequestStateType as `merged` and `draft` are not officially part of https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request