### PR TITLE
refactor: use nodes shorthand in graphql queries

### DIFF
--- a/src/__mocks__/mockedData.ts
+++ b/src/__mocks__/mockedData.ts
@@ -4,7 +4,7 @@ import {
   Repository,
   User,
   GraphQLSearch,
-  DiscussionSearchResultEdge,
+  DiscussionSearchResultNode,
 } from '../typesGithub';
 
 export const mockedEnterpriseAccounts: EnterpriseAccount[] = [
@@ -282,214 +282,166 @@ export const mockedSingleAccountNotifications: AccountNotifications[] = [
   },
 ];
 
-export const mockedGraphQLResponse: GraphQLSearch<DiscussionSearchResultEdge> =
+export const mockedGraphQLResponse: GraphQLSearch<DiscussionSearchResultNode> =
   {
     data: {
       data: {
         search: {
-          edges: [
+          nodes: [
             {
-              node: {
-                viewerSubscription: 'SUBSCRIBED',
-                title: '1.16.0',
-                url: 'https://github.com/manosim/notifications-test/discussions/612',
-                comments: {
-                  edges: [
-                    {
-                      node: {
-                        databaseId: 2215656,
-                        createdAt: '2022-02-20T18:33:39Z',
-                        replies: {
-                          edges: [],
-                        },
-                      },
+              viewerSubscription: 'SUBSCRIBED',
+              title: '1.16.0',
+              url: 'https://github.com/manosim/notifications-test/discussions/612',
+              comments: {
+                nodes: [
+                  {
+                    databaseId: 2215656,
+                    createdAt: '2022-02-20T18:33:39Z',
+                    replies: {
+                      nodes: [],
                     },
-                    {
-                      node: {
-                        databaseId: 2217789,
-                        createdAt: '2022-02-21T03:30:42Z',
-                        replies: {
-                          edges: [],
-                        },
-                      },
+                  },
+                  {
+                    databaseId: 2217789,
+                    createdAt: '2022-02-21T03:30:42Z',
+                    replies: {
+                      nodes: [],
                     },
-                    {
-                      node: {
-                        databaseId: 2223243,
-                        createdAt: '2022-02-21T18:26:27Z',
-                        replies: {
-                          edges: [
-                            {
-                              node: {
-                                databaseId: 2232922,
-                                createdAt: '2022-02-23T00:57:58Z',
-                              },
-                            },
-                          ],
+                  },
+                  {
+                    databaseId: 2223243,
+                    createdAt: '2022-02-21T18:26:27Z',
+                    replies: {
+                      nodes: [
+                        {
+                          databaseId: 2232922,
+                          createdAt: '2022-02-23T00:57:58Z',
                         },
-                      },
+                      ],
                     },
-                    {
-                      node: {
-                        databaseId: 2232921,
-                        createdAt: '2022-02-23T00:57:49Z',
-                        replies: {
-                          edges: [],
+                  },
+                  {
+                    databaseId: 2232921,
+                    createdAt: '2022-02-23T00:57:49Z',
+                    replies: {
+                      nodes: [],
+                    },
+                  },
+                  {
+                    databaseId: 2258799,
+                    createdAt: '2022-02-27T01:22:20Z',
+                    replies: {
+                      nodes: [
+                        {
+                          databaseId: 2300902,
+                          createdAt: '2022-03-05T17:43:52Z',
                         },
-                      },
+                      ],
                     },
-                    {
-                      node: {
-                        databaseId: 2258799,
-                        createdAt: '2022-02-27T01:22:20Z',
-                        replies: {
-                          edges: [
-                            {
-                              node: {
-                                databaseId: 2300902,
-                                createdAt: '2022-03-05T17:43:52Z',
-                              },
-                            },
-                          ],
+                  },
+                  {
+                    databaseId: 2297637,
+                    createdAt: '2022-03-04T20:39:44Z',
+                    replies: {
+                      nodes: [
+                        {
+                          databaseId: 2300893,
+                          createdAt: '2022-03-05T17:41:04Z',
                         },
-                      },
+                      ],
                     },
-                    {
-                      node: {
-                        databaseId: 2297637,
-                        createdAt: '2022-03-04T20:39:44Z',
-                        replies: {
-                          edges: [
-                            {
-                              node: {
-                                databaseId: 2300893,
-                                createdAt: '2022-03-05T17:41:04Z',
-                              },
-                            },
-                          ],
+                  },
+                  {
+                    databaseId: 2299763,
+                    createdAt: '2022-03-05T11:05:42Z',
+                    replies: {
+                      nodes: [
+                        {
+                          databaseId: 2300895,
+                          createdAt: '2022-03-05T17:41:44Z',
                         },
-                      },
+                      ],
                     },
-                    {
-                      node: {
-                        databaseId: 2299763,
-                        createdAt: '2022-03-05T11:05:42Z',
-                        replies: {
-                          edges: [
-                            {
-                              node: {
-                                databaseId: 2300895,
-                                createdAt: '2022-03-05T17:41:44Z',
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    },
-                  ],
-                },
+                  },
+                ],
               },
             },
             {
-              node: {
-                viewerSubscription: 'IGNORED',
-                title: '1.16.0',
-                url: 'https://github.com/manosim/notifications-test/discussions/612',
-                comments: {
-                  edges: [
-                    {
-                      node: {
-                        databaseId: 2215656,
-                        createdAt: '2022-02-20T18:33:39Z',
-                        replies: {
-                          edges: [],
-                        },
-                      },
+              viewerSubscription: 'IGNORED',
+              title: '1.16.0',
+              url: 'https://github.com/manosim/notifications-test/discussions/612',
+              comments: {
+                nodes: [
+                  {
+                    databaseId: 2215656,
+                    createdAt: '2022-02-20T18:33:39Z',
+                    replies: {
+                      nodes: [],
                     },
-                    {
-                      node: {
-                        databaseId: 2217789,
-                        createdAt: '2022-02-21T03:30:42Z',
-                        replies: {
-                          edges: [],
-                        },
-                      },
+                  },
+                  {
+                    databaseId: 2217789,
+                    createdAt: '2022-02-21T03:30:42Z',
+                    replies: {
+                      nodes: [],
                     },
-                    {
-                      node: {
-                        databaseId: 2223243,
-                        createdAt: '2022-02-21T18:26:27Z',
-                        replies: {
-                          edges: [
-                            {
-                              node: {
-                                databaseId: 2232922,
-                                createdAt: '2022-02-23T00:57:58Z',
-                              },
-                            },
-                          ],
+                  },
+                  {
+                    databaseId: 2223243,
+                    createdAt: '2022-02-21T18:26:27Z',
+                    replies: {
+                      nodes: [
+                        {
+                          databaseId: 2232922,
+                          createdAt: '2022-02-23T00:57:58Z',
                         },
-                      },
+                      ],
                     },
-                    {
-                      node: {
-                        databaseId: 2232921,
-                        createdAt: '2022-02-23T00:57:49Z',
-                        replies: {
-                          edges: [],
+                  },
+                  {
+                    databaseId: 2232921,
+                    createdAt: '2022-02-23T00:57:49Z',
+                    replies: {
+                      nodes: [],
+                    },
+                  },
+                  {
+                    databaseId: 2258799,
+                    createdAt: '2022-02-27T01:22:20Z',
+                    replies: {
+                      nodes: [
+                        {
+                          databaseId: 2300902,
+                          createdAt: '2022-03-05T17:43:52Z',
                         },
-                      },
+                      ],
                     },
-                    {
-                      node: {
-                        databaseId: 2258799,
-                        createdAt: '2022-02-27T01:22:20Z',
-                        replies: {
-                          edges: [
-                            {
-                              node: {
-                                databaseId: 2300902,
-                                createdAt: '2022-03-05T17:43:52Z',
-                              },
-                            },
-                          ],
+                  },
+                  {
+                    databaseId: 2297637,
+                    createdAt: '2022-03-04T20:39:44Z',
+                    replies: {
+                      nodes: [
+                        {
+                          databaseId: 2300893,
+                          createdAt: '2022-03-05T17:41:04Z',
                         },
-                      },
+                      ],
                     },
-                    {
-                      node: {
-                        databaseId: 2297637,
-                        createdAt: '2022-03-04T20:39:44Z',
-                        replies: {
-                          edges: [
-                            {
-                              node: {
-                                databaseId: 2300893,
-                                createdAt: '2022-03-05T17:41:04Z',
-                              },
-                            },
-                          ],
+                  },
+                  {
+                    databaseId: 2299763,
+                    createdAt: '2022-03-05T11:05:42Z',
+                    replies: {
+                      nodes: [
+                        {
+                          databaseId: 2300895,
+                          createdAt: '2022-03-05T17:41:44Z',
                         },
-                      },
+                      ],
                     },
-                    {
-                      node: {
-                        databaseId: 2299763,
-                        createdAt: '2022-03-05T11:05:42Z',
-                        replies: {
-                          edges: [
-                            {
-                              node: {
-                                databaseId: 2300895,
-                                createdAt: '2022-03-05T17:41:44Z',
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    },
-                  ],
-                },
+                  },
+                ],
               },
             },
           ],

--- a/src/typesGithub.ts
+++ b/src/typesGithub.ts
@@ -169,47 +169,39 @@ export interface GraphQLSearch<T> {
   data: {
     data: {
       search: {
-        edges: T[];
+        nodes: T[];
       };
     };
   };
 }
 
-export interface DiscussionStateSearchResultEdge {
-  node: {
-    viewerSubscription: ViewerSubscription;
-    title: string;
-    stateReason: DiscussionStateType;
-    isAnswered: boolean;
+export interface DiscussionStateSearchResultNode {
+  viewerSubscription: ViewerSubscription;
+  title: string;
+  stateReason: DiscussionStateType;
+  isAnswered: boolean;
+}
+
+export interface DiscussionSearchResultNode {
+  viewerSubscription: ViewerSubscription;
+  title: string;
+  url: string;
+  comments: {
+    nodes: DiscussionCommentNode[];
   };
 }
 
-export interface DiscussionSearchResultEdge {
-  node: {
-    viewerSubscription: ViewerSubscription;
-    title: string;
-    url: string;
-    comments: {
-      edges: DiscussionCommentEdge[];
-    };
+export interface DiscussionCommentNode {
+  databaseId: string | number;
+  createdAt: string;
+  replies: {
+    nodes: DiscussionSubcommentNode[];
   };
 }
 
-export interface DiscussionCommentEdge {
-  node: {
-    databaseId: string | number;
-    createdAt: string;
-    replies: {
-      edges: DiscussionSubcommentEdge[];
-    };
-  };
-}
-
-export interface DiscussionSubcommentEdge {
-  node: {
-    databaseId: string | number;
-    createdAt: string;
-  };
+export interface DiscussionSubcommentNode {
+  databaseId: string | number;
+  createdAt: string;
 }
 
 export interface CheckSuiteAttributes {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,8 +2,8 @@ import { EnterpriseAccount, AuthState } from '../types';
 import {
   Notification,
   GraphQLSearch,
-  DiscussionCommentEdge,
-  DiscussionSearchResultEdge,
+  DiscussionCommentNode,
+  DiscussionSearchResultNode,
 } from '../typesGithub';
 import { apiRequestAuth } from '../utils/api-requests';
 import { openExternalLink } from '../utils/comms';
@@ -76,55 +76,52 @@ async function getDiscussionUrl(
 ): Promise<string> {
   let url = `${notification.repository.html_url}/discussions`;
 
-  const response: GraphQLSearch<DiscussionSearchResultEdge> =
+  const response: GraphQLSearch<DiscussionSearchResultNode> =
     await apiRequestAuth(`https://api.github.com/graphql`, 'POST', token, {
       query: `{
-      search(query:"${formatSearchQueryString(
-        notification.repository.full_name,
-        notification.subject.title,
-        notification.updated_at,
-      )}", type: DISCUSSION, first: 10) {
-          edges {
-              node {
-                  ... on Discussion {
-                      viewerSubscription
-                      title
-                      url
-                      comments(last: 100) {
-                        edges {
-                          node {
-                            databaseId
-                            createdAt
-                            replies(last: 1) {
-                              edges {
-                                node {
-                                  databaseId
-                                  createdAt
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
+        search(query:"${formatSearchQueryString(
+          notification.repository.full_name,
+          notification.subject.title,
+          notification.updated_at,
+        )}", type: DISCUSSION, first: 10) {
+          nodes {
+            ... on Discussion {
+              viewerSubscription
+              title
+              url
+              comments(last: 100) {
+                nodes {
+                  databaseId
+                  createdAt
+                  replies(last: 1) {
+                    nodes {
+                      databaseId
+                      createdAt
+                    }
                   }
+                }
               }
+            }
           }
-      }
-    }`,
+        }
+      }`,
     });
-  let edges =
-    response?.data?.data?.search?.edges?.filter(
-      (edge) => edge.node.title === notification.subject.title,
+
+  let discussions =
+    response?.data?.data?.search?.nodes?.filter(
+      (discussion) => discussion.title === notification.subject.title,
     ) || [];
-  if (edges.length > 1)
-    edges = edges.filter(
-      (edge) => edge.node.viewerSubscription === 'SUBSCRIBED',
+
+  if (discussions.length > 1)
+    discussions = discussions.filter(
+      (discussion) => discussion.viewerSubscription === 'SUBSCRIBED',
     );
 
-  if (edges[0]) {
-    url = edges[0].node.url;
+  if (discussions[0]) {
+    const discussion = discussions[0];
+    url = discussion.url;
 
-    let comments = edges[0]?.node.comments.edges;
+    let comments = discussion.comments.nodes;
 
     let latestCommentId: string | number;
     if (comments?.length) {
@@ -137,13 +134,12 @@ async function getDiscussionUrl(
 }
 
 export const getLatestDiscussionCommentId = (
-  comments: DiscussionCommentEdge[],
+  comments: DiscussionCommentNode[],
 ) =>
   comments
-    .flatMap((comment) => comment.node.replies.edges)
+    .flatMap((comment) => comment.replies.nodes)
     .concat([comments.at(-1)])
-    .reduce((a, b) => (a.node.createdAt > b.node.createdAt ? a : b))?.node
-    .databaseId;
+    .reduce((a, b) => (a.createdAt > b.createdAt ? a : b))?.databaseId;
 
 export async function generateGitHubWebUrl(
   notification: Notification,

--- a/src/utils/state.test.ts
+++ b/src/utils/state.test.ts
@@ -150,14 +150,12 @@ describe('utils/state.ts', () => {
         .reply(200, {
           data: {
             search: {
-              edges: [
+              nodes: [
                 {
-                  node: {
-                    title: 'This is an answered discussion',
-                    viewerSubscription: 'SUBSCRIBED',
-                    stateReason: null,
-                    isAnswered: true,
-                  },
+                  title: 'This is an answered discussion',
+                  viewerSubscription: 'SUBSCRIBED',
+                  stateReason: null,
+                  isAnswered: true,
                 },
               ],
             },
@@ -186,14 +184,12 @@ describe('utils/state.ts', () => {
         .reply(200, {
           data: {
             search: {
-              edges: [
+              nodes: [
                 {
-                  node: {
-                    title: 'This is a duplicate discussion',
-                    viewerSubscription: 'SUBSCRIBED',
-                    stateReason: 'DUPLICATE',
-                    isAnswered: false,
-                  },
+                  title: 'This is a duplicate discussion',
+                  viewerSubscription: 'SUBSCRIBED',
+                  stateReason: 'DUPLICATE',
+                  isAnswered: false,
                 },
               ],
             },
@@ -222,14 +218,12 @@ describe('utils/state.ts', () => {
         .reply(200, {
           data: {
             search: {
-              edges: [
+              nodes: [
                 {
-                  node: {
-                    title: 'This is an open discussion',
-                    viewerSubscription: 'SUBSCRIBED',
-                    stateReason: null,
-                    isAnswered: false,
-                  },
+                  title: 'This is an open discussion',
+                  viewerSubscription: 'SUBSCRIBED',
+                  stateReason: null,
+                  isAnswered: false,
                 },
               ],
             },
@@ -258,14 +252,12 @@ describe('utils/state.ts', () => {
         .reply(200, {
           data: {
             search: {
-              edges: [
+              nodes: [
                 {
-                  node: {
-                    title: 'This is an outdated discussion',
-                    viewerSubscription: 'SUBSCRIBED',
-                    stateReason: 'OUTDATED',
-                    isAnswered: false,
-                  },
+                  title: 'This is an outdated discussion',
+                  viewerSubscription: 'SUBSCRIBED',
+                  stateReason: 'OUTDATED',
+                  isAnswered: false,
                 },
               ],
             },
@@ -294,14 +286,12 @@ describe('utils/state.ts', () => {
         .reply(200, {
           data: {
             search: {
-              edges: [
+              nodes: [
                 {
-                  node: {
-                    title: 'This is a reopened discussion',
-                    viewerSubscription: 'SUBSCRIBED',
-                    stateReason: 'REOPENED',
-                    isAnswered: false,
-                  },
+                  title: 'This is a reopened discussion',
+                  viewerSubscription: 'SUBSCRIBED',
+                  stateReason: 'REOPENED',
+                  isAnswered: false,
                 },
               ],
             },
@@ -330,14 +320,12 @@ describe('utils/state.ts', () => {
         .reply(200, {
           data: {
             search: {
-              edges: [
+              nodes: [
                 {
-                  node: {
-                    title: 'This is a resolved discussion',
-                    viewerSubscription: 'SUBSCRIBED',
-                    stateReason: 'RESOLVED',
-                    isAnswered: false,
-                  },
+                  title: 'This is a resolved discussion',
+                  viewerSubscription: 'SUBSCRIBED',
+                  stateReason: 'RESOLVED',
+                  isAnswered: false,
                 },
               ],
             },
@@ -366,22 +354,18 @@ describe('utils/state.ts', () => {
         .reply(200, {
           data: {
             search: {
-              edges: [
+              nodes: [
                 {
-                  node: {
-                    title: 'This is a discussion',
-                    viewerSubscription: 'SUBSCRIBED',
-                    stateReason: null,
-                    isAnswered: false,
-                  },
+                  title: 'This is a discussion',
+                  viewerSubscription: 'SUBSCRIBED',
+                  stateReason: null,
+                  isAnswered: false,
                 },
                 {
-                  node: {
-                    title: 'This is a discussion',
-                    viewerSubscription: 'IGNORED',
-                    stateReason: null,
-                    isAnswered: true,
-                  },
+                  title: 'This is a discussion',
+                  viewerSubscription: 'IGNORED',
+                  stateReason: null,
+                  isAnswered: true,
                 },
               ],
             },


### PR DESCRIPTION
Closes #831

Since we aren't using any of the relay paginated information in the GraphQL search responses, we can simplify and use the `nodes` shorthand