### PR TITLE
refactor(discussions): optimize graphql queries

### DIFF
--- a/src/__mocks__/mockedData.ts
+++ b/src/__mocks__/mockedData.ts
@@ -291,6 +291,8 @@ export const mockedGraphQLResponse: GraphQLSearch<DiscussionSearchResultNode> =
             {
               viewerSubscription: 'SUBSCRIBED',
               title: '1.16.0',
+              isAnswered: false,
+              stateReason: null,
               url: 'https://github.com/manosim/notifications-test/discussions/612',
               comments: {
                 nodes: [
@@ -369,6 +371,8 @@ export const mockedGraphQLResponse: GraphQLSearch<DiscussionSearchResultNode> =
             {
               viewerSubscription: 'IGNORED',
               title: '1.16.0',
+              isAnswered: false,
+              stateReason: null,
               url: 'https://github.com/manosim/notifications-test/discussions/612',
               comments: {
                 nodes: [

--- a/src/typesGithub.ts
+++ b/src/typesGithub.ts
@@ -175,16 +175,11 @@ export interface GraphQLSearch<T> {
   };
 }
 
-export interface DiscussionStateSearchResultNode {
+export interface DiscussionSearchResultNode {
   viewerSubscription: ViewerSubscription;
   title: string;
   stateReason: DiscussionStateType;
   isAnswered: boolean;
-}
-
-export interface DiscussionSearchResultNode {
-  viewerSubscription: ViewerSubscription;
-  title: string;
   url: string;
   comments: {
     nodes: DiscussionCommentNode[];

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -121,27 +121,53 @@ async function getDiscussionUrl(
 ): Promise<string> {
   let url = `${notification.repository.html_url}/discussions`;
 
+  const discussion = await fetchDiscussion(notification, token, true);
+
+  if (discussion) {
+    url = discussion.url;
+
+    let comments = discussion.comments.nodes;
+
+    let latestCommentId: string | number;
+    if (comments?.length) {
+      latestCommentId = getLatestDiscussionCommentId(comments);
+      url += `#discussioncomment-${latestCommentId}`;
+    }
+  }
+
+  return url;
+}
+
+export async function fetchDiscussion(
+  notification: Notification,
+  token: string,
+  includeComments: boolean,
+): Promise<DiscussionSearchResultNode> {
   const response: GraphQLSearch<DiscussionSearchResultNode> =
     await apiRequestAuth(`https://api.github.com/graphql`, 'POST', token, {
-      query: `{
-        search(query:"${formatSearchQueryString(
-          notification.repository.full_name,
-          notification.subject.title,
-          notification.updated_at,
-        )}", type: DISCUSSION, first: 10) {
-          nodes {
-            ... on Discussion {
-              viewerSubscription
-              title
-              url
-              comments(last: 100) {
-                nodes {
-                  databaseId
-                  createdAt
-                  replies(last: 1) {
-                    nodes {
-                      databaseId
-                      createdAt
+      query: `query fetchDiscussions(
+          $queryStatement: String!,
+          $type: SearchType!,
+          $firstDiscussions: Int,
+          $lastComments: Int,
+          $includeComments: Boolean,
+          $lastReplies: Int
+        ) {
+          search(query:$queryStatement, type: $type, first: $firstDiscussions) {
+            nodes {
+              ... on Discussion {
+                viewerSubscription
+                title
+                url
+                comments(last: $lastComments) @include(if: $includeComments){
+                  nodes {
+                    databaseId
+                    createdAt
+                    replies(last: $firstReplies) {
+                      nodes {
+                        databaseId
+                        createdAt
+                      }
                     }
                   }
                 }
@@ -149,7 +175,19 @@ async function getDiscussionUrl(
             }
           }
         }
-      }`,
+      `,
+      variables: {
+        queryStatement: formatSearchQueryString(
+          notification.repository.full_name,
+          notification.subject.title,
+          notification.updated_at,
+        ),
+        type: 'DISCUSSION',
+        firstDiscussions: 10,
+        lastComments: 100,
+        firstReplies: 1,
+        includeComments: includeComments,
+      },
     });
 
   let discussions =
@@ -163,19 +201,10 @@ async function getDiscussionUrl(
     );
 
   if (discussions[0]) {
-    const discussion = discussions[0];
-    url = discussion.url;
-
-    let comments = discussion.comments.nodes;
-
-    let latestCommentId: string | number;
-    if (comments?.length) {
-      latestCommentId = getLatestDiscussionCommentId(comments);
-      url += `#discussioncomment-${latestCommentId}`;
-    }
+    return discussions[0];
   }
 
-  return url;
+  return null;
 }
 
 export const getLatestDiscussionCommentId = (


### PR DESCRIPTION
This PR covers a few optimization items
* combine graphql queries for discussion state and discussion url
* extract function to perform filtering of results to a specific discussion node (reduce code duplication)
* combine types
* use client-side include directive to skip over-fetching comments/replies when not required
* use graphql query variables instead of inline string building - closes #830 
