### PR TITLE
feat: add hover title text to icons

### DIFF
--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -62,7 +62,7 @@ export const NotificationRow: React.FC<IProps> = ({
     addSuffix: true,
   });
   const notificationTitle = formatForDisplay(
-    `${notification.subject.state ?? ''} ${notification.subject.type ?? ''}`,
+    `${notification.subject.state ?? ''} ${notification.subject.type}`,
   );
 
   return (

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -7,7 +7,7 @@ import {
   getNotificationTypeIcon,
   getNotificationTypeIconColor,
 } from '../utils/github-api';
-import { openInBrowser } from '../utils/helpers';
+import { formatForDisplay, openInBrowser } from '../utils/helpers';
 import { Notification } from '../typesGithub';
 import { AppContext } from '../context/App';
 
@@ -61,10 +61,16 @@ export const NotificationRow: React.FC<IProps> = ({
   const updatedAt = formatDistanceToNow(parseISO(notification.updated_at), {
     addSuffix: true,
   });
+  const notificationTitle = formatForDisplay(
+    `${notification.subject.state ?? ''} ${notification.subject.type ?? ''}`,
+  );
 
   return (
     <div className="flex space-x-3 py-2 px-3 bg-white dark:bg-gray-dark dark:text-white hover:bg-gray-100 dark:hover:bg-gray-darker border-b border-gray-100 dark:border-gray-darker">
-      <div className={`flex justify-center items-center w-5 ${realIconColor}`}>
+      <div
+        className={`flex justify-center items-center w-5 ${realIconColor}`}
+        title={notificationTitle}
+      >
         <NotificationIcon size={18} aria-label={notification.subject.type} />
       </div>
 

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -61,9 +61,10 @@ export const NotificationRow: React.FC<IProps> = ({
   const updatedAt = formatDistanceToNow(parseISO(notification.updated_at), {
     addSuffix: true,
   });
-  const notificationTitle = formatForDisplay(
-    `${notification.subject.state ?? ''} ${notification.subject.type}`,
-  );
+  const notificationTitle = formatForDisplay([
+    notification.subject.state,
+    notification.subject.type,
+  ]);
 
   return (
     <div className="flex space-x-3 py-2 px-3 bg-white dark:bg-gray-dark dark:text-white hover:bg-gray-100 dark:hover:bg-gray-darker border-b border-gray-100 dark:border-gray-darker">

--- a/src/components/__snapshots__/NotificationRow.test.tsx.snap
+++ b/src/components/__snapshots__/NotificationRow.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`components/Notification.js should render itself & its children 1`] = `
 >
   <div
     className="flex justify-center items-center w-5 text-green-500"
+    title="Open Issue"
   >
     <svg
       aria-hidden="false"

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -7,6 +7,7 @@ import {
   addNotificationReferrerIdToUrl,
   getHtmlUrl,
   generateGitHubWebUrl,
+  formatForDisplay,
 } from './helpers';
 import {
   mockedGraphQLResponse,
@@ -557,6 +558,15 @@ describe('utils/helpers.ts', () => {
       expect(result).toBe(
         `${mockedSingleNotification.repository.html_url}?${mockedNotificationReferrer}`,
       );
+    });
+
+    it('formatForDisplay', () => {
+      expect(formatForDisplay(null)).toBe('');
+      expect(formatForDisplay('open PullRequest')).toBe('Open Pull Request');
+      expect(formatForDisplay('OUTDATED Discussion')).toBe(
+        'Outdated Discussion',
+      );
+      expect(formatForDisplay('not_planned Issue')).toBe('Not Planned Issue');
     });
   });
 });

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -562,11 +562,16 @@ describe('utils/helpers.ts', () => {
 
     it('formatForDisplay', () => {
       expect(formatForDisplay(null)).toBe('');
-      expect(formatForDisplay('open PullRequest')).toBe('Open Pull Request');
-      expect(formatForDisplay('OUTDATED Discussion')).toBe(
+      expect(formatForDisplay([])).toBe('');
+      expect(formatForDisplay(['open', 'PullRequest'])).toBe(
+        'Open Pull Request',
+      );
+      expect(formatForDisplay(['OUTDATED', 'Discussion'])).toBe(
         'Outdated Discussion',
       );
-      expect(formatForDisplay('not_planned Issue')).toBe('Not Planned Issue');
+      expect(formatForDisplay(['not_planned', 'Issue'])).toBe(
+        'Not Planned Issue',
+      );
     });
   });
 });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -225,6 +225,20 @@ export async function generateGitHubWebUrl(
   return url;
 }
 
+export function formatForDisplay(text: string) {
+  if (!text) {
+    return '';
+  }
+
+  return text
+    .replace(/([a-z])([A-Z])/g, '$1 $2') // Add space between lowercase character followed by an uppercase character
+    .replace(/_/g, ' ') // Replace underscores with spaces
+    .replace(/\w+/g, (word) => {
+      // Convert to proper case (capitalize first letter of each word)
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+    });
+}
+
 export async function openInBrowser(
   notification: Notification,
   accounts: AuthState,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -225,12 +225,13 @@ export async function generateGitHubWebUrl(
   return url;
 }
 
-export function formatForDisplay(text: string) {
+export function formatForDisplay(text: string[]) {
   if (!text) {
     return '';
   }
 
   return text
+    .join(' ')
     .replace(/([a-z])([A-Z])/g, '$1 $2') // Add space between lowercase character followed by an uppercase character
     .replace(/_/g, ' ') // Replace underscores with spaces
     .replace(/\w+/g, (word) => {


### PR DESCRIPTION
This PR adds text which shows when mousing over the notification icons.

The text is formatted based on the notification subject type and reason (if applicable)

*Examples*
![Screenshot 2024-03-11 at 11 41 52 AM](https://github.com/gitify-app/gitify/assets/386277/7d6189d0-e2d0-4391-8958-b96d3f0a6f00)
![Screenshot 2024-03-11 at 11 42 08 AM](https://github.com/gitify-app/gitify/assets/386277/e62665e1-fe48-4d54-bc05-c5522e29f742)
![Screenshot 2024-03-11 at 11 42 16 AM](https://github.com/gitify-app/gitify/assets/386277/17e3e0f4-1e36-4d23-881c-29f8d678d87e)
