### PR TITLE
build(semantic-pr): allow special chars in scope

### DIFF
--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            const regex = /^(?<type>build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|deps)(?<scope>\(\w+\)?((?=:\s)|(?=!:\s)))?(?<breaking>!)?(?<subject>:\s.*)?/gm;
+            const regex = /^(?<type>build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|deps)(?<scope>\([\w\-\/]+\)?((?=:\s)|(?=!:\s)))?(?<breaking>!)?(?<subject>:\s.*)?/gm;
             const match = regex.exec(title);
 
             if (!match) {


### PR DESCRIPTION
Updating our regex to support `-` or `/` within the semantic pr scope match group.

This will address the issues reported in #808 