### PR TITLE
feat: add title to notification heading

### DIFF
--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -80,7 +80,10 @@ export const NotificationRow: React.FC<IProps> = ({
         onClick={() => pressTitle()}
         role="main"
       >
-        <div className="mb-1 text-sm whitespace-nowrap overflow-ellipsis overflow-hidden">
+        <div
+          className="mb-1 text-sm whitespace-nowrap overflow-ellipsis overflow-hidden"
+          title={notification.subject.title}
+        >
           {notification.subject.title}
         </div>
 

--- a/src/components/__snapshots__/NotificationRow.test.tsx.snap
+++ b/src/components/__snapshots__/NotificationRow.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`components/Notification.js should render itself & its children 1`] = `
   >
     <div
       className="mb-1 text-sm whitespace-nowrap overflow-ellipsis overflow-hidden"
+      title="I am a robot and this is a test!"
     >
       I am a robot and this is a test!
     </div>


### PR DESCRIPTION
For situations when the title is truncated, this enhancement allows you to see the full notification title on hover

![Screenshot 2024-03-18 at 2 00 56 PM](https://github.com/gitify-app/gitify/assets/386277/9dad01f4-8895-40d4-a90d-2aa2118a56fb)
