### PR TITLE
build: allow release workflow to be run manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'release/v**'
+  workflow_dispatch:
 
 jobs:
   release-macos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'release/v**'
-  workflow_dispatch:
+  workflow_dispatch: #For manually running release process to verify codesigning of artifacts
 
 jobs:
   release-macos:


### PR DESCRIPTION
Allow us to manually run the release workflow to confirm things like code-signing in future