### PR TITLE
fix: hide default orange outline around gitify logo on first start

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -46,7 +46,7 @@ export const Sidebar: React.FC = () => {
     <div className="flex flex-col fixed left-14 w-14 -ml-14 h-full bg-gray-sidebar overflow-y-auto	">
       <div className="flex flex-col flex-1 items-center py-4">
         <button
-          className="w-5 my-3 mx-auto cursor-pointer"
+          className="w-5 my-3 mx-auto cursor-pointer outline-none"
           title="Open Gitify on GitHub"
           onClick={onOpenBrowser}
           data-testid="gitify-logo"

--- a/src/components/__snapshots__/Sidebar.test.tsx.snap
+++ b/src/components/__snapshots__/Sidebar.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
     className="flex flex-col flex-1 items-center py-4"
   >
     <button
-      className="w-5 my-3 mx-auto cursor-pointer"
+      className="w-5 my-3 mx-auto cursor-pointer outline-none"
       data-testid="gitify-logo"
       onClick={[Function]}
       title="Open Gitify on GitHub"
@@ -133,7 +133,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
     className="flex flex-col flex-1 items-center py-4"
   >
     <button
-      className="w-5 my-3 mx-auto cursor-pointer"
+      className="w-5 my-3 mx-auto cursor-pointer outline-none"
       data-testid="gitify-logo"
       onClick={[Function]}
       title="Open Gitify on GitHub"


### PR DESCRIPTION
**Before**

<img width="56" alt="Screenshot 2024-03-21 at 12 12 14 AM" src="https://github.com/gitify-app/gitify/assets/386277/f84c0cb8-e959-44a6-a274-8efbd2eb4dc3">

**After**

<img width="58" alt="Screenshot 2024-03-21 at 12 12 29 AM" src="https://github.com/gitify-app/gitify/assets/386277/75e53e61-d70f-4f70-9400-f5ca294b1045">
