### PR TITLE
refactor: make explicit the different user types

### DIFF
--- a/src/__mocks__/mockedData.ts
+++ b/src/__mocks__/mockedData.ts
@@ -1,8 +1,7 @@
-import { AccountNotifications, EnterpriseAccount } from '../types';
+import { AccountNotifications, EnterpriseAccount, GitifyUser } from '../types';
 import {
   Notification,
   Repository,
-  User,
   GraphQLSearch,
   DiscussionSearchResultNode,
 } from '../typesGithub';
@@ -14,7 +13,7 @@ export const mockedEnterpriseAccounts: EnterpriseAccount[] = [
   },
 ];
 
-export const mockedUser: User = {
+export const mockedUser: GitifyUser = {
   login: 'octocat',
   name: 'Mona Lisa Octocat',
   id: 123456789,

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -62,7 +62,7 @@ export const NotificationRow: React.FC<IProps> = ({
     addSuffix: true,
   });
   const updatedBy = notification.subject.user
-    ? ` by ${notification.subject.user}`
+    ? ` by ${notification.subject.user.login}`
     : '';
   const updatedLabel = `Updated ${updatedAt}${updatedBy}`;
   const notificationTitle = formatForDisplay([

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
-import { Notification, User } from './typesGithub';
+import { Notification } from './typesGithub';
 
 export interface AuthState {
   token?: string;
   enterpriseAccounts: EnterpriseAccount[];
-  user: User | null;
+  user: GitifyUser | null;
 }
 
 export interface SettingsState {
@@ -55,4 +55,10 @@ export interface AuthResponse {
 export interface AuthTokenResponse {
   hostname: string;
   token: string;
+}
+
+export interface GitifyUser {
+  login: string;
+  name: string;
+  id: number;
 }

--- a/src/typesGithub.ts
+++ b/src/typesGithub.ts
@@ -81,10 +81,66 @@ export interface Notification {
   subscription_url: string;
 }
 
+export interface UserProfile {
+  name: string;
+  company: string;
+  blog: string;
+  location: string;
+  email: string;
+  hireable: string;
+  bio: string;
+  twitter_username: string;
+  public_repos: number;
+  public_gists: number;
+  followers: number;
+  following: number;
+  created_at: string;
+  updated_at: string;
+  private_gists: number;
+  total_private_repos: number;
+  owned_private_repos: number;
+  disk_usage: number;
+  collaborators: number;
+  two_factor_authentication: boolean;
+  plan: Plan;
+}
+export interface Plan {
+  name: string;
+  space: number;
+  private_repos: number;
+  collaborators: number;
+}
+
 export interface User {
   login: string;
   name: string;
   id: number;
+  node_id: string;
+  avatar_url: string;
+  gravatar_url: string;
+  url: string;
+  html_url: string;
+  followers_url: string;
+  following_url: string;
+  gists_url: string;
+  starred_url: string;
+  subscriptions_url: string;
+  organizations_url: string;
+  repos_url: string;
+  events_url: string;
+  received_events_url: string;
+  type: UserType;
+  site_admin: boolean;
+}
+
+export type UserType = 'User' | 'Bot';
+
+export interface SubjectUser {
+  login: string;
+}
+
+export interface DiscussionAuthor {
+  login: string;
 }
 
 export interface Repository {
@@ -169,7 +225,7 @@ interface GitHubSubject {
 // This is not in the GitHub API, but we add it to the type to make it easier to work with
 export interface GitifySubject {
   state?: StateType;
-  user?: string;
+  user?: SubjectUser;
 }
 
 export interface PullRequest {
@@ -285,7 +341,7 @@ export interface DiscussionSearchResultNode {
 export interface DiscussionCommentNode {
   databaseId: string | number;
   createdAt: string;
-  author: { login: string };
+  author: DiscussionAuthor;
   replies: {
     nodes: DiscussionSubcommentNode[];
   };
@@ -294,7 +350,7 @@ export interface DiscussionCommentNode {
 export interface DiscussionSubcommentNode {
   databaseId: string | number;
   createdAt: string;
-  author: { login: string };
+  author: DiscussionAuthor;
 }
 
 export interface CheckSuiteAttributes {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -2,9 +2,13 @@ import { BrowserWindow } from '@electron/remote';
 
 import { generateGitHubAPIUrl, isEnterpriseHost } from './helpers';
 import { apiRequest, apiRequestAuth } from '../utils/api-requests';
-import { AuthResponse, AuthState, AuthTokenResponse } from '../types';
+import {
+  AuthResponse,
+  AuthState,
+  AuthTokenResponse,
+  GitifyUser,
+} from '../types';
 import { Constants } from '../utils/constants';
-import { User } from '../typesGithub';
 
 export const authGitHub = (
   authOptions = Constants.DEFAULT_AUTH_OPTIONS,
@@ -76,7 +80,7 @@ export const authGitHub = (
 export const getUserData = async (
   token: string,
   hostname: string,
-): Promise<User> => {
+): Promise<GitifyUser> => {
   const response = await apiRequestAuth(
     `${generateGitHubAPIUrl(hostname)}user`,
     'GET',
@@ -112,7 +116,7 @@ export const addAccount = (
   accounts: AuthState,
   token,
   hostname,
-  user?: User,
+  user?: GitifyUser,
 ): AuthState => {
   if (!isEnterpriseHost(hostname)) {
     return {

--- a/src/utils/subject.test.ts
+++ b/src/utils/subject.test.ts
@@ -435,7 +435,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('open');
-        expect(result.user).toBe('some-commenter');
+        expect(result.user).toEqual({ login: 'some-commenter' });
       });
 
       it('closed issue state', async () => {
@@ -453,7 +453,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('closed');
-        expect(result.user).toBe('some-commenter');
+        expect(result.user).toEqual({ login: 'some-commenter' });
       });
 
       it('completed issue state', async () => {
@@ -475,7 +475,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('completed');
-        expect(result.user).toBe('some-commenter');
+        expect(result.user).toEqual({ login: 'some-commenter' });
       });
 
       it('not_planned issue state', async () => {
@@ -497,7 +497,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('not_planned');
-        expect(result.user).toBe('some-commenter');
+        expect(result.user).toEqual({ login: 'some-commenter' });
       });
 
       it('reopened issue state', async () => {
@@ -519,7 +519,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('reopened');
-        expect(result.user).toBe('some-commenter');
+        expect(result.user).toEqual({ login: 'some-commenter' });
       });
 
       it('handle issues without latest_comment_url', async () => {
@@ -544,7 +544,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('open');
-        expect(result.user).toBe('some-user');
+        expect(result.user).toEqual({ login: 'some-user' });
       });
     });
 
@@ -577,7 +577,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('closed');
-        expect(result.user).toBe('some-commenter');
+        expect(result.user).toEqual({ login: 'some-commenter' });
       });
 
       it('draft pull request state', async () => {
@@ -600,7 +600,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('draft');
-        expect(result.user).toBe('some-commenter');
+        expect(result.user).toEqual({ login: 'some-commenter' });
       });
 
       it('merged pull request state', async () => {
@@ -623,7 +623,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('merged');
-        expect(result.user).toBe('some-commenter');
+        expect(result.user).toEqual({ login: 'some-commenter' });
       });
 
       it('open pull request state', async () => {
@@ -646,7 +646,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('open');
-        expect(result.user).toBe('some-commenter');
+        expect(result.user).toEqual({ login: 'some-commenter' });
       });
 
       it('handle pull request without latest_comment_url', async () => {
@@ -671,7 +671,7 @@ describe('utils/subject.ts', () => {
         );
 
         expect(result.state).toBe('open');
-        expect(result.user).toBe('some-user');
+        expect(result.user).toEqual({ login: 'some-user' });
       });
     });
   });
@@ -698,7 +698,7 @@ describe('utils/subject.ts', () => {
         mockAccounts.token,
       );
 
-      expect(result.user).toBe('some-user');
+      expect(result.user).toEqual({ login: 'some-user' });
     });
   });
 

--- a/src/utils/subject.ts
+++ b/src/utils/subject.ts
@@ -107,8 +107,13 @@ async function getGitifySubjectForDiscussion(
     }
   }
 
-  const discussionUser = getLatestDiscussionComment(discussion.comments.nodes)
-    ?.author.login;
+  const latestDiscussionComment = getLatestDiscussionComment(
+    discussion.comments.nodes,
+  );
+  let discussionUser = null;
+  if (latestDiscussionComment) {
+    discussionUser = latestDiscussionComment.author;
+  }
 
   return {
     state: discussionState,
@@ -128,7 +133,9 @@ async function getGitifySubjectForIssue(
 
   return {
     state: issue.state_reason ?? issue.state,
-    user: issueCommentUser?.login ?? issue.user.login,
+    user: {
+      login: issueCommentUser?.login ?? issue.user.login,
+    },
   };
 }
 
@@ -151,7 +158,9 @@ async function getGitifySubjectForPullRequest(
 
   return {
     state: prState,
-    user: prCommentUser?.login ?? pr.user.login,
+    user: {
+      login: prCommentUser?.login ?? pr.user.login,
+    },
   };
 }
 
@@ -163,7 +172,9 @@ async function getGitifySubjectForRelease(
 
   return {
     state: null,
-    user: releaseCommentUser.login,
+    user: {
+      login: releaseCommentUser.login,
+    },
   };
 }
 


### PR DESCRIPTION
Previously, a shared User type was being used to represent
* Gitify Auth User - persisted once after authentication
* Response object for Issues/PRs
* Enhanced Subject details for Gitify

This update makes the types separate and explicit