### PR TITLE
chore: auto-collapse snaphsots in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Snapshots are taken by our test suite and used to determine regressions.
+# We don't need to review their code in PRs, so treat them as auto-generated.
+# https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+*.snap linguist-generated=true


### PR DESCRIPTION
Snapshots make it a bit more annoying to review PRs. This improves that using a Github feature. See the comment for more info.

Files marked as linguist-generated:
* Are collapsed by default in pull request diffs, making code reviews more focused and manageable.
* Do not contribute to the repository's language statistics, keeping the language breakdown more relevant to the human-generated codebase.