### PR TITLE
build: husky run all tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 pnpx lint-staged
-pnpm test -- --onlyChanged
+pnpm test


### PR DESCRIPTION
Since enabling `collectCoverage` by default, husky will routinely fail since the changes files do not cover the test cases to get a correct coverage gating measure.

Changing to run all tests as part of the husky pre-commit hook. I think this OK.

Alternatively, if we want to continue running on changes files only, we could disable the coverage check
`pnpm test -- --onlyChanged --collectCoverage=false`