### PR TITLE
fix: move `update-native-theme` into ipcRenderer `useEffect`

### DIFF
--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -62,6 +62,12 @@ export const SettingsRoute: FC = () => {
     ipcRenderer.invoke('get-app-version').then((result: string) => {
       setAppVersion(result);
     });
+
+    ipcRenderer.on('update-native-theme', (_, updatedTheme: Theme) => {
+      if (settings.theme === Theme.SYSTEM) {
+        setTheme(updatedTheme);
+      }
+    });
   }, []);
 
   useMemo(() => {
@@ -76,12 +82,6 @@ export const SettingsRoute: FC = () => {
         setRepoScope(true);
     })();
   }, [accounts.token]);
-
-  ipcRenderer.on('update-native-theme', (_, updatedTheme: Theme) => {
-    if (settings.theme === Theme.SYSTEM) {
-      setTheme(updatedTheme);
-    }
-  });
 
   const logoutUser = useCallback(() => {
     logout();


### PR DESCRIPTION
I've been seeing the following warning/error in the console when running locally

```
(node:7668) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 update-native-theme listeners added to [IpcRenderer]. Use emitter.setMaxListeners() to increase limit
```

Moving this into the useEffect along with the other ipcRenderer calls seems to alleviate this.  Tested by toggling theme within the Gitify app, as well as via the macOS system settings and all seemed to behave as anticipated.