### PR TITLE
test(settings): organize by section

### DIFF
--- a/src/routes/Settings.test.tsx
+++ b/src/routes/Settings.test.tsx
@@ -30,500 +30,512 @@ describe('routes/Settings.tsx', () => {
     jest.clearAllMocks();
   });
 
-  it('should render itself & its children', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{ settings: mockSettings, accounts: mockAccounts }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
+  describe('General', () => {
+    it('should render itself & its children', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{ settings: mockSettings, accounts: mockAccounts }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      expect(screen.getByTestId('settings')).toMatchSnapshot();
     });
 
-    expect(screen.getByTestId('settings')).toMatchSnapshot();
+    it('should go back by pressing the icon', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      fireEvent.click(screen.getByLabelText('Go Back'));
+      expect(mockNavigate).toHaveBeenNthCalledWith(1, -1);
+    });
   });
+  describe('Appearance section', () => {
+    it('should change the theme radio group', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
 
-  it('should press the logout', async () => {
-    const logoutMock = jest.fn();
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            logout: logoutMock,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
+      fireEvent.click(screen.getByLabelText('Light'));
+
+      expect(updateSetting).toHaveBeenCalledTimes(1);
+      expect(updateSetting).toHaveBeenCalledWith('theme', 'LIGHT');
+    });
+
+    it('should be able to enable detailed notifications', async () => {
+      jest.spyOn(apiRequests, 'apiRequestAuth').mockResolvedValue({
+        headers: {
+          'x-oauth-scopes': Constants.AUTH_SCOPE.join(', '),
+        },
+      } as unknown as AxiosResponse);
+
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      await screen.findByLabelText('Detailed notifications');
+
+      fireEvent.click(screen.getByLabelText('Detailed notifications'));
+
+      expect(updateSetting).toHaveBeenCalledTimes(1);
+      expect(updateSetting).toHaveBeenCalledWith('detailedNotifications', true);
+    });
+
+    it('should not be able to enable detailed notifications due to missing scope', async () => {
+      jest.spyOn(apiRequests, 'apiRequestAuth').mockResolvedValue({
+        headers: {
+          'x-oauth-scopes': 'read:user, notifications',
+        },
+      } as unknown as AxiosResponse);
+
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      expect(
+        screen
+          .getByLabelText('Detailed notifications (requires repo scope)')
+          .closest('input'),
+      ).toHaveProperty('disabled', true);
+
+      // click the checkbox
+      fireEvent.click(
+        screen.getByLabelText('Detailed notifications (requires repo scope)'),
       );
-    });
 
-    fireEvent.click(screen.getByTitle('Logout from octocat'));
+      // check if the checkbox is still unchecked
+      expect(updateSetting).not.toHaveBeenCalled();
+      expect(
+        screen.getByLabelText('Detailed notifications (requires repo scope)'),
+      ).not.toBe('checked');
 
-    expect(logoutMock).toHaveBeenCalledTimes(1);
-
-    expect(ipcRenderer.send).toHaveBeenCalledTimes(2);
-    expect(ipcRenderer.send).toHaveBeenCalledWith('update-icon');
-    expect(ipcRenderer.send).toHaveBeenCalledWith('update-title', '');
-    expect(mockNavigate).toHaveBeenNthCalledWith(1, -1);
-  });
-
-  it('should go back by pressing the icon', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    fireEvent.click(screen.getByLabelText('Go Back'));
-    expect(mockNavigate).toHaveBeenNthCalledWith(1, -1);
-  });
-
-  it('should toggle the showOnlyParticipating checkbox', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    fireEvent.click(screen.getByLabelText('Show only participating'), {
-      target: { checked: true },
-    });
-
-    expect(updateSetting).toHaveBeenCalledTimes(1);
-    expect(updateSetting).toHaveBeenCalledWith('participating', false);
-  });
-
-  it('should open official docs for showOnlyParticipating tooltip', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    const tooltipElement = screen.getByLabelText(
-      'tooltip-showOnlyParticipating',
-    );
-
-    fireEvent.mouseEnter(tooltipElement);
-
-    fireEvent.click(
-      screen.getByTitle(
-        'Open GitHub documentation for participating and watching notifications',
-      ),
-    );
-
-    expect(shell.openExternal).toHaveBeenCalledTimes(1);
-    expect(shell.openExternal).toHaveBeenCalledWith(
-      'https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#about-participating-and-watching-notifications',
-    );
-  });
-
-  it('should not be able to toggle the showBots checkbox when detailedNotifications is disabled', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: {
-              ...mockSettings,
-              detailedNotifications: false,
-              showBots: true,
-            },
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    expect(
-      screen
-        .getByLabelText('Show notifications from Bot accounts')
-        .closest('input'),
-    ).toHaveProperty('disabled', true);
-
-    // click the checkbox
-    fireEvent.click(
-      screen.getByLabelText('Show notifications from Bot accounts'),
-    );
-
-    // check if the checkbox is still unchecked
-    expect(updateSetting).not.toHaveBeenCalled();
-
-    expect(
-      screen.getByLabelText('Show notifications from Bot accounts').parentNode
-        .parentNode,
-    ).toMatchSnapshot();
-  });
-
-  it('should be able to toggle the showBots checkbox when detailedNotifications is enabled', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: {
-              ...mockSettings,
-              detailedNotifications: true,
-              showBots: true,
-            },
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    expect(
-      screen
-        .getByLabelText('Show notifications from Bot accounts')
-        .closest('input'),
-    ).toHaveProperty('disabled', false);
-
-    // click the checkbox
-    fireEvent.click(
-      screen.getByLabelText('Show notifications from Bot accounts'),
-    );
-
-    // check if the checkbox is still unchecked
-    expect(updateSetting).toHaveBeenCalledWith('showBots', false);
-
-    expect(
-      screen.getByLabelText('Show notifications from Bot accounts').parentNode
-        .parentNode,
-    ).toMatchSnapshot();
-  });
-
-  it('should toggle the showNotificationsCountInTray checkbox', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    fireEvent.click(screen.getByLabelText('Show notifications count in tray'), {
-      target: { checked: true },
-    });
-
-    expect(updateSetting).toHaveBeenCalledTimes(1);
-    expect(updateSetting).toHaveBeenCalledWith(
-      'showNotificationsCountInTray',
-      false,
-    );
-  });
-
-  it('should toggle the playSound checkbox', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    fireEvent.click(screen.getByLabelText('Play sound'), {
-      target: { checked: true },
-    });
-
-    expect(updateSetting).toHaveBeenCalledTimes(1);
-    expect(updateSetting).toHaveBeenCalledWith('playSound', false);
-  });
-
-  it('should toggle the showNotifications checkbox', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    fireEvent.click(screen.getByLabelText('Show system notifications'), {
-      target: { checked: true },
-    });
-
-    expect(updateSetting).toHaveBeenCalledTimes(1);
-    expect(updateSetting).toHaveBeenCalledWith('showNotifications', false);
-  });
-
-  it('should toggle the markAsDoneOnOpen checkbox', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    fireEvent.click(screen.getByLabelText('Mark as done on open'), {
-      target: { checked: true },
-    });
-
-    expect(updateSetting).toHaveBeenCalledTimes(1);
-    expect(updateSetting).toHaveBeenCalledWith('markAsDoneOnOpen', false);
-  });
-
-  it('should toggle the openAtStartup checkbox', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    fireEvent.click(screen.getByLabelText('Open at startup'), {
-      target: { checked: true },
-    });
-
-    expect(updateSetting).toHaveBeenCalledTimes(1);
-    expect(updateSetting).toHaveBeenCalledWith('openAtStartup', false);
-  });
-
-  it('should change the theme radio group', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    fireEvent.click(screen.getByLabelText('Light'));
-
-    expect(updateSetting).toHaveBeenCalledTimes(1);
-    expect(updateSetting).toHaveBeenCalledWith('theme', 'LIGHT');
-  });
-
-  it('should go to the enterprise login route', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
-    });
-
-    fireEvent.click(screen.getByTitle('Login with GitHub Enterprise'));
-    expect(mockNavigate).toHaveBeenNthCalledWith(1, '/login-enterprise', {
-      replace: true,
+      expect(
+        screen.getByLabelText('Detailed notifications (requires repo scope)')
+          .parentNode.parentNode,
+      ).toMatchSnapshot();
     });
   });
 
-  it('should quit the app', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{ settings: mockSettings, accounts: mockAccounts }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
+  describe('Notifications section', () => {
+    it('should toggle the showOnlyParticipating checkbox', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      fireEvent.click(screen.getByLabelText('Show only participating'), {
+        target: { checked: true },
+      });
+
+      expect(updateSetting).toHaveBeenCalledTimes(1);
+      expect(updateSetting).toHaveBeenCalledWith('participating', false);
+    });
+
+    it('should open official docs for showOnlyParticipating tooltip', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      const tooltipElement = screen.getByLabelText(
+        'tooltip-showOnlyParticipating',
+      );
+
+      fireEvent.mouseEnter(tooltipElement);
+
+      fireEvent.click(
+        screen.getByTitle(
+          'Open GitHub documentation for participating and watching notifications',
+        ),
+      );
+
+      expect(shell.openExternal).toHaveBeenCalledTimes(1);
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        'https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#about-participating-and-watching-notifications',
       );
     });
 
-    fireEvent.click(screen.getByTitle('Quit Gitify'));
-    expect(ipcRenderer.send).toHaveBeenCalledWith('app-quit');
+    it('should not be able to toggle the showBots checkbox when detailedNotifications is disabled', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: {
+                ...mockSettings,
+                detailedNotifications: false,
+                showBots: true,
+              },
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      expect(
+        screen
+          .getByLabelText('Show notifications from Bot accounts')
+          .closest('input'),
+      ).toHaveProperty('disabled', true);
+
+      // click the checkbox
+      fireEvent.click(
+        screen.getByLabelText('Show notifications from Bot accounts'),
+      );
+
+      // check if the checkbox is still unchecked
+      expect(updateSetting).not.toHaveBeenCalled();
+
+      expect(
+        screen.getByLabelText('Show notifications from Bot accounts').parentNode
+          .parentNode,
+      ).toMatchSnapshot();
+    });
+
+    it('should be able to toggle the showBots checkbox when detailedNotifications is enabled', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: {
+                ...mockSettings,
+                detailedNotifications: true,
+                showBots: true,
+              },
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      expect(
+        screen
+          .getByLabelText('Show notifications from Bot accounts')
+          .closest('input'),
+      ).toHaveProperty('disabled', false);
+
+      // click the checkbox
+      fireEvent.click(
+        screen.getByLabelText('Show notifications from Bot accounts'),
+      );
+
+      // check if the checkbox is still unchecked
+      expect(updateSetting).toHaveBeenCalledWith('showBots', false);
+
+      expect(
+        screen.getByLabelText('Show notifications from Bot accounts').parentNode
+          .parentNode,
+      ).toMatchSnapshot();
+    });
+
+    it('should toggle the markAsDoneOnOpen checkbox', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      fireEvent.click(screen.getByLabelText('Mark as done on open'), {
+        target: { checked: true },
+      });
+
+      expect(updateSetting).toHaveBeenCalledTimes(1);
+      expect(updateSetting).toHaveBeenCalledWith('markAsDoneOnOpen', false);
+    });
   });
 
-  it('should be able to enable detailed notifications', async () => {
-    jest.spyOn(apiRequests, 'apiRequestAuth').mockResolvedValue({
-      headers: {
-        'x-oauth-scopes': Constants.AUTH_SCOPE.join(', '),
-      },
-    } as unknown as AxiosResponse);
+  describe('System section', () => {
+    it('should toggle the showNotificationsCountInTray checkbox', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
 
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
+      fireEvent.click(
+        screen.getByLabelText('Show notifications count in tray'),
+        {
+          target: { checked: true },
+        },
+      );
+
+      expect(updateSetting).toHaveBeenCalledTimes(1);
+      expect(updateSetting).toHaveBeenCalledWith(
+        'showNotificationsCountInTray',
+        false,
       );
     });
 
-    await screen.findByLabelText('Detailed notifications');
+    it('should toggle the showNotifications checkbox', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
 
-    fireEvent.click(screen.getByLabelText('Detailed notifications'));
+      fireEvent.click(screen.getByLabelText('Show system notifications'), {
+        target: { checked: true },
+      });
 
-    expect(updateSetting).toHaveBeenCalledTimes(1);
-    expect(updateSetting).toHaveBeenCalledWith('detailedNotifications', true);
+      expect(updateSetting).toHaveBeenCalledTimes(1);
+      expect(updateSetting).toHaveBeenCalledWith('showNotifications', false);
+    });
+
+    it('should toggle the playSound checkbox', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      fireEvent.click(screen.getByLabelText('Play sound'), {
+        target: { checked: true },
+      });
+
+      expect(updateSetting).toHaveBeenCalledTimes(1);
+      expect(updateSetting).toHaveBeenCalledWith('playSound', false);
+    });
+
+    it('should toggle the openAtStartup checkbox', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              updateSetting,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      fireEvent.click(screen.getByLabelText('Open at startup'), {
+        target: { checked: true },
+      });
+
+      expect(updateSetting).toHaveBeenCalledTimes(1);
+      expect(updateSetting).toHaveBeenCalledWith('openAtStartup', false);
+    });
   });
 
-  it('should not be able to enable detailed notifications due to missing scope', async () => {
-    jest.spyOn(apiRequests, 'apiRequestAuth').mockResolvedValue({
-      headers: {
-        'x-oauth-scopes': 'read:user, notifications',
-      },
-    } as unknown as AxiosResponse);
+  describe('Footer section', () => {
+    it('should open release notes', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
 
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-            updateSetting,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
+      fireEvent.click(screen.getByTitle('View release notes'));
+
+      expect(shell.openExternal).toHaveBeenCalledTimes(1);
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        'https://github.com/gitify-app/gitify/releases/tag/v0.0.1',
       );
     });
 
-    expect(
-      screen
-        .getByLabelText('Detailed notifications (requires repo scope)')
-        .closest('input'),
-    ).toHaveProperty('disabled', true);
+    it('should go to the enterprise login route', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
 
-    // click the checkbox
-    fireEvent.click(
-      screen.getByLabelText('Detailed notifications (requires repo scope)'),
-    );
-
-    // check if the checkbox is still unchecked
-    expect(updateSetting).not.toHaveBeenCalled();
-    expect(
-      screen.getByLabelText('Detailed notifications (requires repo scope)'),
-    ).not.toBe('checked');
-
-    expect(
-      screen.getByLabelText('Detailed notifications (requires repo scope)')
-        .parentNode.parentNode,
-    ).toMatchSnapshot();
-  });
-
-  it('should open release notes', async () => {
-    await act(async () => {
-      render(
-        <AppContext.Provider
-          value={{
-            settings: mockSettings,
-            accounts: mockAccounts,
-          }}
-        >
-          <MemoryRouter>
-            <SettingsRoute />
-          </MemoryRouter>
-        </AppContext.Provider>,
-      );
+      fireEvent.click(screen.getByTitle('Login with GitHub Enterprise'));
+      expect(mockNavigate).toHaveBeenNthCalledWith(1, '/login-enterprise', {
+        replace: true,
+      });
     });
 
-    fireEvent.click(screen.getByTitle('View release notes'));
+    it('should press the logout', async () => {
+      const logoutMock = jest.fn();
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{
+              settings: mockSettings,
+              accounts: mockAccounts,
+              logout: logoutMock,
+            }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
 
-    expect(shell.openExternal).toHaveBeenCalledTimes(1);
-    expect(shell.openExternal).toHaveBeenCalledWith(
-      'https://github.com/gitify-app/gitify/releases/tag/v0.0.1',
-    );
+      fireEvent.click(screen.getByTitle('Logout from octocat'));
+
+      expect(logoutMock).toHaveBeenCalledTimes(1);
+
+      expect(ipcRenderer.send).toHaveBeenCalledTimes(2);
+      expect(ipcRenderer.send).toHaveBeenCalledWith('update-icon');
+      expect(ipcRenderer.send).toHaveBeenCalledWith('update-title', '');
+      expect(mockNavigate).toHaveBeenNthCalledWith(1, -1);
+    });
+
+    it('should quit the app', async () => {
+      await act(async () => {
+        render(
+          <AppContext.Provider
+            value={{ settings: mockSettings, accounts: mockAccounts }}
+          >
+            <MemoryRouter>
+              <SettingsRoute />
+            </MemoryRouter>
+          </AppContext.Provider>,
+        );
+      });
+
+      fireEvent.click(screen.getByTitle('Quit Gitify'));
+      expect(ipcRenderer.send).toHaveBeenCalledWith('app-quit');
+    });
   });
 });

--- a/src/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/routes/__snapshots__/Settings.test.tsx.snap
@@ -1,53 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`routes/Settings.tsx should be able to toggle the showBots checkbox when detailedNotifications is enabled 1`] = `
-<div
-  class="flex items-start"
->
-  <div
-    class="flex items-center h-5"
-  >
-    <input
-      checked=""
-      class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
-      id="showBots"
-      type="checkbox"
-    />
-  </div>
-  <div
-    class="ml-3 "
-  >
-    <label
-      class="font-medium text-gray-700 dark:text-gray-200"
-      for="showBots"
-    >
-      Show notifications from Bot accounts
-      <span
-        aria-label="tooltip-showBots"
-        class="relative"
-        id="tooltip-showBots"
-      >
-        <svg
-          aria-hidden="true"
-          class="text-blue-500 ml-1"
-          fill="currentColor"
-          focusable="false"
-          height="16"
-          style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
-          viewBox="0 0 16 16"
-          width="16"
-        >
-          <path
-            d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.92 6.085h.001a.749.749 0 1 1-1.342-.67c.169-.339.436-.701.849-.977C6.845 4.16 7.369 4 8 4a2.756 2.756 0 0 1 1.637.525c.503.377.863.965.863 1.725 0 .448-.115.83-.329 1.15-.205.307-.47.513-.692.662-.109.072-.22.138-.313.195l-.006.004a6.24 6.24 0 0 0-.26.16.952.952 0 0 0-.276.245.75.75 0 0 1-1.248-.832c.184-.264.42-.489.692-.661.103-.067.207-.132.313-.195l.007-.004c.1-.061.182-.11.258-.161a.969.969 0 0 0 .277-.245C8.96 6.514 9 6.427 9 6.25a.612.612 0 0 0-.262-.525A1.27 1.27 0 0 0 8 5.5c-.369 0-.595.09-.74.187a1.01 1.01 0 0 0-.34.398ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
-          />
-        </svg>
-      </span>
-    </label>
-  </div>
-</div>
-`;
-
-exports[`routes/Settings.tsx should not be able to enable detailed notifications due to missing scope 1`] = `
+exports[`routes/Settings.tsx Appearance section should not be able to enable detailed notifications due to missing scope 1`] = `
 <div
   class="flex items-start"
 >
@@ -95,56 +48,7 @@ exports[`routes/Settings.tsx should not be able to enable detailed notifications
 </div>
 `;
 
-exports[`routes/Settings.tsx should not be able to toggle the showBots checkbox when detailedNotifications is disabled 1`] = `
-<div
-  class="flex items-start"
->
-  <div
-    class="flex items-center h-5"
-  >
-    <input
-      checked=""
-      class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
-      disabled=""
-      id="showBots"
-      type="checkbox"
-    />
-  </div>
-  <div
-    class="ml-3 "
-  >
-    <label
-      class="font-medium text-gray-700 dark:text-gray-200"
-      for="showBots"
-      style="text-decoration: line-through;"
-    >
-      Show notifications from Bot accounts
-      <span
-        aria-label="tooltip-showBots"
-        class="relative"
-        id="tooltip-showBots"
-      >
-        <svg
-          aria-hidden="true"
-          class="text-blue-500 ml-1"
-          fill="currentColor"
-          focusable="false"
-          height="16"
-          style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
-          viewBox="0 0 16 16"
-          width="16"
-        >
-          <path
-            d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.92 6.085h.001a.749.749 0 1 1-1.342-.67c.169-.339.436-.701.849-.977C6.845 4.16 7.369 4 8 4a2.756 2.756 0 0 1 1.637.525c.503.377.863.965.863 1.725 0 .448-.115.83-.329 1.15-.205.307-.47.513-.692.662-.109.072-.22.138-.313.195l-.006.004a6.24 6.24 0 0 0-.26.16.952.952 0 0 0-.276.245.75.75 0 0 1-1.248-.832c.184-.264.42-.489.692-.661.103-.067.207-.132.313-.195l.007-.004c.1-.061.182-.11.258-.161a.969.969 0 0 0 .277-.245C8.96 6.514 9 6.427 9 6.25a.612.612 0 0 0-.262-.525A1.27 1.27 0 0 0 8 5.5c-.369 0-.595.09-.74.187a1.01 1.01 0 0 0-.34.398ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
-          />
-        </svg>
-      </span>
-    </label>
-  </div>
-</div>
-`;
-
-exports[`routes/Settings.tsx should render itself & its children 1`] = `
+exports[`routes/Settings.tsx General should render itself & its children 1`] = `
 <div
   class="flex flex-1 flex-col h-screen dark:bg-gray-dark dark:text-white"
   data-testid="settings"
@@ -675,6 +579,102 @@ exports[`routes/Settings.tsx should render itself & its children 1`] = `
         </svg>
       </button>
     </div>
+  </div>
+</div>
+`;
+
+exports[`routes/Settings.tsx Notifications section should be able to toggle the showBots checkbox when detailedNotifications is enabled 1`] = `
+<div
+  class="flex items-start"
+>
+  <div
+    class="flex items-center h-5"
+  >
+    <input
+      checked=""
+      class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
+      id="showBots"
+      type="checkbox"
+    />
+  </div>
+  <div
+    class="ml-3 "
+  >
+    <label
+      class="font-medium text-gray-700 dark:text-gray-200"
+      for="showBots"
+    >
+      Show notifications from Bot accounts
+      <span
+        aria-label="tooltip-showBots"
+        class="relative"
+        id="tooltip-showBots"
+      >
+        <svg
+          aria-hidden="true"
+          class="text-blue-500 ml-1"
+          fill="currentColor"
+          focusable="false"
+          height="16"
+          style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <path
+            d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.92 6.085h.001a.749.749 0 1 1-1.342-.67c.169-.339.436-.701.849-.977C6.845 4.16 7.369 4 8 4a2.756 2.756 0 0 1 1.637.525c.503.377.863.965.863 1.725 0 .448-.115.83-.329 1.15-.205.307-.47.513-.692.662-.109.072-.22.138-.313.195l-.006.004a6.24 6.24 0 0 0-.26.16.952.952 0 0 0-.276.245.75.75 0 0 1-1.248-.832c.184-.264.42-.489.692-.661.103-.067.207-.132.313-.195l.007-.004c.1-.061.182-.11.258-.161a.969.969 0 0 0 .277-.245C8.96 6.514 9 6.427 9 6.25a.612.612 0 0 0-.262-.525A1.27 1.27 0 0 0 8 5.5c-.369 0-.595.09-.74.187a1.01 1.01 0 0 0-.34.398ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+          />
+        </svg>
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`routes/Settings.tsx Notifications section should not be able to toggle the showBots checkbox when detailedNotifications is disabled 1`] = `
+<div
+  class="flex items-start"
+>
+  <div
+    class="flex items-center h-5"
+  >
+    <input
+      checked=""
+      class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
+      disabled=""
+      id="showBots"
+      type="checkbox"
+    />
+  </div>
+  <div
+    class="ml-3 "
+  >
+    <label
+      class="font-medium text-gray-700 dark:text-gray-200"
+      for="showBots"
+      style="text-decoration: line-through;"
+    >
+      Show notifications from Bot accounts
+      <span
+        aria-label="tooltip-showBots"
+        class="relative"
+        id="tooltip-showBots"
+      >
+        <svg
+          aria-hidden="true"
+          class="text-blue-500 ml-1"
+          fill="currentColor"
+          focusable="false"
+          height="16"
+          style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <path
+            d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.92 6.085h.001a.749.749 0 1 1-1.342-.67c.169-.339.436-.701.849-.977C6.845 4.16 7.369 4 8 4a2.756 2.756 0 0 1 1.637.525c.503.377.863.965.863 1.725 0 .448-.115.83-.329 1.15-.205.307-.47.513-.692.662-.109.072-.22.138-.313.195l-.006.004a6.24 6.24 0 0 0-.26.16.952.952 0 0 0-.276.245.75.75 0 0 1-1.248-.832c.184-.264.42-.489.692-.661.103-.067.207-.132.313-.195l.007-.004c.1-.061.182-.11.258-.161a.969.969 0 0 0 .277-.245C8.96 6.514 9 6.427 9 6.25a.612.612 0 0 0-.262-.525A1.27 1.27 0 0 0 8 5.5c-.369 0-.595.09-.74.187a1.01 1.01 0 0 0-.34.398ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+          />
+        </svg>
+      </span>
+    </label>
   </div>
 </div>
 `;


### PR DESCRIPTION
Organize settings tests into test suites based upon the settings sections (general, appearance, notifications, system, footer)