### PR TITLE
fix: relocate set request status succeeded 

### DIFF
--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -96,12 +96,12 @@ export const useNotifications = (): NotificationsState => {
       }
 
       setIsFetching(true);
-      setRequestFailed(false);
 
       return axios
         .all([getGitHubNotifications(), ...getEnterpriseNotifications()])
         .then(
           axios.spread((gitHubNotifications, ...entAccNotifications) => {
+            setRequestFailed(false);
             const enterpriseNotifications = entAccNotifications.map(
               (accountNotifications) => {
                 const { hostname } = new URL(accountNotifications.config.url);


### PR DESCRIPTION
Moves the setRequestFailed(false) into the earliest location we have a successful response.

Fixes UI "flickering" when the app gets in an error state, such as rate-limiting (clicking refresh would flicker between notifications and the error page)