### PR TITLE
fix: combine fetchNotifications effect

### DIFF
--- a/src/context/App.test.tsx
+++ b/src/context/App.test.tsx
@@ -64,7 +64,7 @@ describe('context/App.tsx', () => {
       // Wait for the useEffects, for settings.participating and accounts, to run.
       // Those aren't what we're testing
       await waitFor(() =>
-        expect(fetchNotificationsMock).toHaveBeenCalledTimes(2),
+        expect(fetchNotificationsMock).toHaveBeenCalledTimes(1),
       );
 
       fetchNotificationsMock.mockReset();
@@ -245,7 +245,7 @@ describe('context/App.tsx', () => {
       fireEvent.click(getByText('Test Case'));
 
       await waitFor(() =>
-        expect(fetchNotificationsMock).toHaveBeenCalledTimes(2),
+        expect(fetchNotificationsMock).toHaveBeenCalledTimes(1),
       );
 
       expect(apiRequestAuthMock).toHaveBeenCalledTimes(2);

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -100,19 +100,20 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     setTheme(settings.theme as Theme);
   }, [settings.theme]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: We only want fetchNotifications to be called for a subset of settings changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: We only want fetchNotifications to be called for certain account or setting changes.
   useEffect(() => {
     fetchNotifications(accounts, settings);
   }, [
     settings.participating,
     settings.showBots,
     settings.detailedNotifications,
+    accounts.token,
+    accounts.enterpriseAccounts.length,
   ]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: We only want fetchNotifications to be called for certain account changes.
-  useEffect(() => {
+  useInterval(() => {
     fetchNotifications(accounts, settings);
-  }, [accounts.token, accounts.enterpriseAccounts.length]);
+  }, 60000);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We need to update tray title when settings or notifications changes.
   useEffect(() => {
@@ -124,10 +125,6 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       updateTrayTitle();
     }
   }, [settings.showNotificationsCountInTray, notifications]);
-
-  useInterval(() => {
-    fetchNotifications(accounts, settings);
-  }, 60000);
 
   const updateSetting = useCallback(
     (name: keyof SettingsState, value: boolean | Theme) => {


### PR DESCRIPTION
Reduces the number of fetchNotification calls on startup by combining into a single useEffect hook