### PR TITLE
feat: keyboard shortcut to open app (with setting to disable) 

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { ipcMain, app, nativeTheme } = require('electron');
+const { ipcMain, app, nativeTheme, globalShortcut } = require('electron');
 const { menubar } = require('menubar');
 const { autoUpdater } = require('electron-updater');
 const { onFirstRunMaybe } = require('./first-run');
@@ -79,6 +79,20 @@ menubarApp.on('ready', () => {
     if (!menubarApp.tray.isDestroyed()) {
       menubarApp.tray.setTitle(title);
     }
+  });
+  ipcMain.on('update-kbd-shortcut', (_, { enabled, kbdShortcut }) => {
+    if (!enabled) {
+      globalShortcut.unregister(kbdShortcut);
+      return;
+    }
+
+    globalShortcut.register(kbdShortcut, () => {
+      if (menubarApp.window.isVisible()) {
+        menubarApp.hideWindow();
+      } else {
+        menubarApp.showWindow();
+      }
+    });
   });
   ipcMain.on('set-login-item-settings', (event, settings) => {
     app.setLoginItemSettings(settings);

--- a/src/__mocks__/mock-state.ts
+++ b/src/__mocks__/mock-state.ts
@@ -1,4 +1,5 @@
 import { type AuthState, type SettingsState, Theme } from '../types';
+import Constants from '../utils/constants';
 import { mockedEnterpriseAccounts, mockedUser } from './mockedData';
 
 export const mockAccounts: AuthState = {
@@ -18,6 +19,6 @@ export const mockSettings: SettingsState = {
   detailedNotifications: false,
   markAsDoneOnOpen: false,
   showAccountHostname: false,
-  kbdShortcut: 'CmdOrCtrl+Alt+G',
+  kbdShortcut: Constants.KBD_SHORTCUT_DEFAULT,
   kbdShortcutEnabled: false,
 };

--- a/src/__mocks__/mock-state.ts
+++ b/src/__mocks__/mock-state.ts
@@ -18,4 +18,6 @@ export const mockSettings: SettingsState = {
   detailedNotifications: false,
   markAsDoneOnOpen: false,
   showAccountHostname: false,
+  kbdShortcut: 'CmdOrCtrl+Alt+G',
+  kbdShortcutEnabled: false,
 };

--- a/src/context/App.test.tsx
+++ b/src/context/App.test.tsx
@@ -6,6 +6,7 @@ import { useNotifications } from '../hooks/useNotifications';
 import type { AuthState, SettingsState } from '../types';
 import * as apiRequests from '../utils/api-requests';
 import * as comms from '../utils/comms';
+import Constants from '../utils/constants';
 import * as notifications from '../utils/notifications';
 import * as storage from '../utils/storage';
 import { AppContext, AppProvider } from './App';
@@ -291,7 +292,7 @@ describe('context/App.tsx', () => {
         detailedNotifications: false,
         markAsDoneOnOpen: false,
         showAccountHostname: false,
-        kbdShortcut: 'CmdOrCtrl+Alt+G',
+        kbdShortcut: Constants.KBD_SHORTCUT_DEFAULT,
         kbdShortcutEnabled: false,
       },
     );
@@ -337,7 +338,7 @@ describe('context/App.tsx', () => {
         detailedNotifications: false,
         markAsDoneOnOpen: false,
         showAccountHostname: false,
-        kbdShortcut: 'CmdOrCtrl+Alt+G',
+        kbdShortcut: Constants.KBD_SHORTCUT_DEFAULT,
         kbdShortcutEnabled: false,
       },
     );

--- a/src/context/App.test.tsx
+++ b/src/context/App.test.tsx
@@ -291,6 +291,8 @@ describe('context/App.tsx', () => {
         detailedNotifications: false,
         markAsDoneOnOpen: false,
         showAccountHostname: false,
+        kbdShortcut: 'CmdOrCtrl+Alt+G',
+        kbdShortcutEnabled: false,
       },
     );
   });
@@ -335,6 +337,8 @@ describe('context/App.tsx', () => {
         detailedNotifications: false,
         markAsDoneOnOpen: false,
         showAccountHostname: false,
+        kbdShortcut: 'CmdOrCtrl+Alt+G',
+        kbdShortcutEnabled: false,
       },
     );
   });

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -43,7 +43,7 @@ export const defaultSettings: SettingsState = {
   detailedNotifications: false,
   markAsDoneOnOpen: false,
   showAccountHostname: false,
-  kbdShortcut: 'CmdOrCtrl+Alt+G',
+  kbdShortcut: Constants.KBD_SHORTCUT_DEFAULT,
   kbdShortcutEnabled: false,
 };
 

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -19,7 +19,7 @@ import {
 } from '../types';
 import { apiRequestAuth } from '../utils/api-requests';
 import { addAccount, authGitHub, getToken, getUserData } from '../utils/auth';
-import { setAutoLaunch, updateTrayTitle } from '../utils/comms';
+import { setAutoLaunch, setKbdShortcut, updateTrayTitle } from '../utils/comms';
 import Constants from '../utils/constants';
 import { generateGitHubAPIUrl } from '../utils/helpers';
 import { getNotificationCount } from '../utils/notifications';
@@ -43,6 +43,8 @@ export const defaultSettings: SettingsState = {
   detailedNotifications: false,
   markAsDoneOnOpen: false,
   showAccountHostname: false,
+  kbdShortcut: 'CmdOrCtrl+Alt+G',
+  kbdShortcutEnabled: false,
 };
 
 interface AppContextState {
@@ -121,6 +123,10 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [settings.showNotificationsCountInTray, notifications]);
 
+  useEffect(() => {
+    setKbdShortcut(settings.kbdShortcutEnabled, settings.kbdShortcut);
+  }, [settings.kbdShortcutEnabled]);
+
   const updateSetting = useCallback(
     (name: keyof SettingsState, value: boolean | Theme) => {
       if (name === 'openAtStartup') {
@@ -184,6 +190,13 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
     if (existing.accounts) {
       setAccounts({ ...defaultAccounts, ...existing.accounts });
+    }
+
+    if (existing.settings?.kbdShortcutEnabled) {
+      setKbdShortcut(
+        existing.settings.kbdShortcutEnabled,
+        existing.settings.kbdShortcut,
+      );
     }
 
     if (existing.settings) {

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -241,6 +241,14 @@ export const SettingsRoute: FC = () => {
             System
           </legend>
           <Checkbox
+            name="kbdShortcutEnabled"
+            label="Enable keyboard shortcut to open app"
+            checked={settings.kbdShortcutEnabled}
+            onChange={(evt) =>
+              updateSetting('kbdShortcutEnabled', evt.target.checked)
+            }
+          />
+          <Checkbox
             name="showNotificationsCountInTray"
             label="Show notifications count in tray"
             checked={settings.showNotificationsCountInTray}

--- a/src/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/routes/__snapshots__/Settings.test.tsx.snap
@@ -401,6 +401,33 @@ exports[`routes/Settings.tsx General should render itself & its children 1`] = `
           >
             <input
               class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
+              id="kbdShortcutEnabled"
+              type="checkbox"
+            />
+          </div>
+          <div
+            class="ml-3 "
+          >
+            <label
+              class="font-medium text-gray-700 dark:text-gray-200"
+              for="kbdShortcutEnabled"
+            >
+              Enable keyboard shortcut to open app
+            </label>
+          </div>
+        </div>
+      </div>
+      <div
+        class="mt-1 mb-3 text-sm"
+      >
+        <div
+          class="flex items-start"
+        >
+          <div
+            class="flex items-center h-5"
+          >
+            <input
+              class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
               id="showNotificationsCountInTray"
               type="checkbox"
             />

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ interface SystemSettingsState {
   playSound: boolean;
   openAtStartup: boolean;
   showNotificationsCountInTray: boolean;
+  kbdShortcut: string;
+  kbdShortcutEnabled: boolean;
 }
 
 export enum Theme {

--- a/src/utils/comms.ts
+++ b/src/utils/comms.ts
@@ -13,6 +13,10 @@ export function setAutoLaunch(value: boolean): void {
   });
 }
 
+export function setKbdShortcut(enabled: boolean, kbdShortcut: string): void {
+  ipcRenderer.send('update-kbd-shortcut', { enabled, kbdShortcut });
+}
+
 export function updateTrayIcon(notificationsLength = 0): void {
   if (notificationsLength > 0) {
     ipcRenderer.send('update-icon', 'TrayActive');

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -18,6 +18,8 @@ export const Constants = {
   ALLREAD_EMOJIS: ['😉', '🎉', '🐯', '🙈', '🎈', '🎊', '👏', '🎪', '🍝'],
 
   FETCH_INTERVAL: 60000,
+
+  KBD_SHORTCUT_DEFAULT: 'CmdOrCtrl+Alt+G',
 };
 
 export const Errors: Record<ErrorType, GitifyError> = {


### PR DESCRIPTION
## Related issues

#995 

## Context

- Add a keyboard shortcut to show/hide the app window without having to use the mouse/trackpad- 
- Also add a setting to enable/disable this shortcut

## Discussion

- I put the shortcut string in the settings even though this PR doesn't allow the shortcut to be customized (we can add that as another new feature later)
- What do you think about the shortcut I've added by default ? (`CmdOrCtrl+Alt+G`)
- Right now the shortcut is disabled by default, do you think we could/should enable it by default?
