### PR TITLE
fix: preserve `zoomFactor` on restarts

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,6 +43,11 @@ const menubarApp = menubar({
 });
 
 menubarApp.on('ready', () => {
+  // Force the window to retrieve its previous zoom factor
+  menubarApp.window.webContents.setZoomFactor(
+    menubarApp.window.webContents.getZoomFactor(),
+  );
+
   menubarApp.tray.setIgnoreDoubleClickEvents(true);
 
   autoUpdater.checkForUpdatesAndNotify();


### PR DESCRIPTION
## Related issues

#1034 

## Context

Small tweak to retrieve the previous `zoomFactor` on app start