### PR TITLE
build: remove `pr-to-homebrew` job

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -5,22 +5,6 @@ on:
     tags: 'v*'
 
 jobs:
-  pr-to-homebrew:
-    name: Homebrew
-    runs-on: macos-14
-    steps:
-      # Ensure our Homebrew/homebrew-cask fork repository is in-sync with the upstream to avoid conflicts
-      # during automated commit and PR creation in the brew bump-cask-pr step below.
-      - run: gh repo sync setchy/homebrew-cask -b master 
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - uses: Homebrew/actions/setup-homebrew@master
-      - id: version
-        run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
-      - run: brew bump-cask-pr gitify --version=${{ steps.version.outputs.version }} --message="Bump gitify to ${{ steps.version.outputs.version }}"
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GH_TOKEN }}
-
   update-website:
     name: Website
     runs-on: ubuntu-latest


### PR DESCRIPTION
It seems we're on the autobump list now 😎 It's like the VIP club for Homebrew Casks

<img width="750" alt="image" src="https://github.com/gitify-app/gitify/assets/19473034/615ef7fe-6ed4-48d0-b3bd-e1eead4c0f82">

Either way, let's wait until the schedule hits so we are truly sure that it is working.

<img width="436" alt="image" src="https://github.com/gitify-app/gitify/assets/19473034/6257d9b0-e796-41d8-ae6a-113535cc8646">
