### PR TITLE
fix: website version bump workflow

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -3,8 +3,6 @@ name: On Tag
 on:
   push:
     tags: 'v*'
-    branches:
-      - fix/*
 
 jobs:
   update-website:
@@ -15,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gitify-app/website
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -26,8 +24,7 @@ jobs:
           node-version-file: '.nvmrc'
       
       - name: Bump version to latest tag
-        # run: echo "GITIFY_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
-        run: echo "GITIFY_VERSION=5.4.1" >> $GITHUB_OUTPUT
+        run: echo "GITIFY_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
 
       - name: Setup git config
         run: |
@@ -40,7 +37,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           branch: "bump/${{ env.GITIFY_VERSION }}"
           delete-branch: true
           title: |

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -31,17 +31,28 @@ jobs:
         with:
           repository: gitify-app/website
           token: ${{ secrets.GH_TOKEN }}
-      
+
+      - name: setup git config
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Create branch
+        run: git checkout -b "bump/${{ env.GITIFY_VERSION }}"
+            
       - name: Bump version
         run: pnpm version ${{ env.GITIFY_VERSION }}
       
+      - name: Push changes
+        run: git push origin "bump/${{ env.GITIFY_VERSION }}"
+
       - uses: peter-evans/create-pull-request@v6
         name: Create pull request
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: |
             docs: update latest release to ${{ env.GITIFY_VERSION }}
-          branch: 'bump/gitify-version'
+          branch: "bump/${{ env.GITIFY_VERSION }}"
           delete-branch: true
           title: |
             docs: update latest release to ${{ env.GITIFY_VERSION }}

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -3,6 +3,8 @@ name: On Tag
 on:
   push:
     tags: 'v*'
+    branches:
+      - fix/*
 
 jobs:
   update-website:

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -11,12 +11,17 @@ jobs:
     name: Update Website Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout website repository
+        uses: actions/checkout@v4
         with:
           repository: gitify-app/website
           token: ${{ secrets.GH_TOKEN }}
-      - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v4
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       
@@ -24,16 +29,16 @@ jobs:
         # run: echo "GITIFY_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT  # uncomment before merging
         run: echo "GITIFY_VERSION=5.4.1" >> $GITHUB_ENV # remove before merging
 
-     # - name: setup git config
-     #   run: |
-     #     git config user.name github-actions[bot]
-     #     git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      # - run: git checkout -b "bump/${{ env.GITIFY_VERSION }}"
-      - run: pnpm version ${{ env.GITIFY_VERSION }}
-      # - run: git push origin "bump/${{ env.GITIFY_VERSION }}"
+      - name: Setup git config
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
-      - uses: peter-evans/create-pull-request@v6
-        name: Create pull request
+      - name: Bump version to latest
+        run: pnpm version ${{ env.GITIFY_VERSION }}
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: |

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -40,6 +40,7 @@ jobs:
             docs: update latest release to ${{ env.GITIFY_VERSION }}
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          base: main
           branch: "bump/${{ env.GITIFY_VERSION }}"
           delete-branch: true
           title: |

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags: 'v*'
     branches:
-      - fix/*
+      - fix/* # remove before merging
 
 jobs:
   update-website:
@@ -21,7 +21,8 @@ jobs:
           node-version-file: '.nvmrc'
       - id: version
         name: Bump version to latest tag
-        run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
+        #run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT # uncomment before merging
+        run: echo "version=5.4.1" >> $GITHUB_ENV # remove before merging
       - run: pnpm version ${{ steps.version.outputs.version }}
       - uses: actions/checkout@v4
         name: Checkout gitify-app/website

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -12,40 +12,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        name: Checkout gitify-app/gitify
-      
-      - uses: pnpm/action-setup@v3
-        name: Setup pnpm
-      
-      - uses: actions/setup-node@v4
-        name: Setup Node.js
-        with:
-          node-version-file: '.nvmrc'
-      
-      - name: Find latest version tag
-        #run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT # uncomment before merging
-        run: echo "GITIFY_VERSION=5.4.1" >> $GITHUB_ENV # remove before merging
-     
-      - uses: actions/checkout@v4
-        name: Checkout gitify-app/website
         with:
           repository: gitify-app/website
           token: ${{ secrets.GH_TOKEN }}
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      
+      - name: Bump version to latest tag
+        # run: echo "GITIFY_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT  # uncomment before merging
+        run: echo "GITIFY_VERSION=5.4.1" >> $GITHUB_ENV # remove before merging
 
-      - name: Setup git
+      - name: setup git config
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          
-      - name: Create version branch
-        run: |
-          git checkout -b "bump/${{ env.GITIFY_VERSION }}"
+      - run: git checkout -b "bump/${{ env.GITIFY_VERSION }}"
+      - run: pnpm version ${{ env.GITIFY_VERSION }}
+      - run: git push origin "bump/${{ env.GITIFY_VERSION }}"
 
-      - name: Bump version
-        run: |
-          pnpm version ${{ env.GITIFY_VERSION }}
-          git commit -am "chore: update release to ${{ env.GITIFY_VERSION }}"
-      
       - uses: peter-evans/create-pull-request@v6
         name: Create pull request
         with:

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -39,7 +39,7 @@ jobs:
           commit-message: |
             docs: update latest release to ${{ env.GITIFY_VERSION }}
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           base: main
           branch: "bump/${{ env.GITIFY_VERSION }}"
           delete-branch: true

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -28,9 +28,9 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - run: git checkout -b "bump/${{ env.GITIFY_VERSION }}"
+      # - run: git checkout -b "bump/${{ env.GITIFY_VERSION }}"
       - run: pnpm version ${{ env.GITIFY_VERSION }}
-      - run: git push origin "bump/${{ env.GITIFY_VERSION }}"
+      # - run: git push origin "bump/${{ env.GITIFY_VERSION }}"
 
       - uses: peter-evans/create-pull-request@v6
         name: Create pull request

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -32,13 +32,15 @@ jobs:
           repository: gitify-app/website
           token: ${{ secrets.GH_TOKEN }}
 
-      - name: setup git config
+      - name: Setup git
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          
       - name: Bump version
-        run: pnpm version ${{ env.GITIFY_VERSION }}
+        run: |
+          pnpm version ${{ env.GITIFY_VERSION }}
+          git commit -am "chore: update release to ${{ env.GITIFY_VERSION }}"
       
       - uses: peter-evans/create-pull-request@v6
         name: Create pull request
@@ -46,6 +48,8 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: |
             docs: update latest release to ${{ env.GITIFY_VERSION }}
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           branch: "bump/${{ env.GITIFY_VERSION }}"
           delete-branch: true
           title: |

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -3,6 +3,8 @@ name: On Tag
 on:
   push:
     tags: 'v*'
+    branches:
+      - fix/*
 
 jobs:
   update-website:
@@ -13,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: gitify-app/website
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -24,7 +26,8 @@ jobs:
           node-version-file: '.nvmrc'
       
       - name: Bump version to latest tag
-        run: echo "GITIFY_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
+        # run: echo "GITIFY_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
+        run: echo "GITIFY_VERSION=5.4.1" >> $GITHUB_OUTPUT
 
       - name: Setup git config
         run: |
@@ -37,7 +40,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: "bump/${{ env.GITIFY_VERSION }}"
           delete-branch: true
           title: |

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -3,8 +3,6 @@ name: On Tag
 on:
   push:
     tags: 'v*'
-    branches:
-      - fix/* # remove before merging
 
 jobs:
   update-website:
@@ -26,8 +24,7 @@ jobs:
           node-version-file: '.nvmrc'
       
       - name: Bump version to latest tag
-        # run: echo "GITIFY_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT  # uncomment before merging
-        run: echo "GITIFY_VERSION=5.4.1" >> $GITHUB_ENV # remove before merging
+        run: echo "GITIFY_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
 
       - name: Setup git config
         run: |

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -41,10 +41,6 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_TOKEN }}
-          commit-message: "docs: update to latest release version ${{ env.GITIFY_VERSION }}"
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          base: main
           branch: "bump/${{ env.GITIFY_VERSION }}"
           delete-branch: true
           title: |

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -41,8 +41,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GH_TOKEN }}
-          commit-message: |
-            docs: update to latest release version ${{ env.GITIFY_VERSION }}
+          commit-message: "docs: update to latest release version ${{ env.GITIFY_VERSION }}"
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           base: main

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -24,7 +24,7 @@ jobs:
       
       - name: Find latest version tag
         #run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT # uncomment before merging
-        run: echo "gitify_version=5.4.1" >> $GITHUB_ENV # remove before merging
+        run: echo "GITIFY_VERSION=5.4.1" >> $GITHUB_ENV # remove before merging
      
       - uses: actions/checkout@v4
         name: Checkout gitify-app/website

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -22,10 +22,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       
-      - id: version
-        name: Find latest version tag
+      - name: Find latest version tag
         #run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT # uncomment before merging
-        run: echo "version=5.4.1" >> $GITHUB_ENV # remove before merging
+        run: echo "gitify_version=5.4.1" >> $GITHUB_ENV # remove before merging
      
       - uses: actions/checkout@v4
         name: Checkout gitify-app/website
@@ -34,19 +33,19 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       
       - name: Bump version
-        run: pnpm version ${{ steps.version.outputs.version }}
+        run: pnpm version ${{ env.GITIFY_VERSION }}
       
       - uses: peter-evans/create-pull-request@v6
         name: Create pull request
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: |
-            docs: update latest release to ${{ steps.version.outputs.version }}
-          branch: 'bump/${{ steps.version.outputs.version }}'
+            docs: update latest release to ${{ env.GITIFY_VERSION }}
+          branch: 'bump/${{ env.GITIFY_VERSION }}'
           delete-branch: true
           title: |
-            docs: update latest release to ${{ steps.version.outputs.version }}
+            docs: update latest release to ${{ env.GITIFY_VERSION }}
           body: |
-            Update latest release to ${{ steps.version.outputs.version }}
+            Update latest release to ${{ env.GITIFY_VERSION }}
           labels: |
             documentation

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -37,6 +37,10 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           
+      - name: Create version branch
+        run: |
+          git checkout -b "bump/${{ env.GITIFY_VERSION }}"
+
       - name: Bump version
         run: |
           pnpm version ${{ env.GITIFY_VERSION }}

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: |
             docs: update latest release to ${{ env.GITIFY_VERSION }}
-          branch: 'bump/${{ env.GITIFY_VERSION }}'
+          branch: 'bump/gitify-version'
           delete-branch: true
           title: |
             docs: update latest release to ${{ env.GITIFY_VERSION }}

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -8,9 +8,11 @@ on:
 
 jobs:
   update-website:
-    name: Website
+    name: Update Website Version
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        name: Checkout gitify-app/gitify
       - uses: pnpm/action-setup@v3
         name: Setup pnpm
       - uses: actions/setup-node@v4
@@ -22,7 +24,7 @@ jobs:
         run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
       - run: pnpm version ${{ steps.version.outputs.version }}
       - uses: actions/checkout@v4
-        name: Checkout website
+        name: Checkout gitify-app/website
         with:
           repository: gitify-app/website
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -10,26 +10,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        name: Checkout website
         with:
           repository: gitify-app/website
           token: ${{ secrets.GH_TOKEN }}
       - uses: pnpm/action-setup@v3
+        name: Setup pnpm
       - uses: actions/setup-node@v4
+        name: Setup Node.js
         with:
           node-version-file: '.nvmrc'
       - id: version
+        name: Bump version to latest tag
         run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
       - run: pnpm version ${{ steps.version.outputs.version }}
       - uses: peter-evans/create-pull-request@v6
+        name: Create pull request
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'docs: update latest release to ${{ steps.version.outputs.version }}'
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          signoff: false
+          token: ${{ secrets.GH_TOKEN }}
+          commit-message: |
+            docs: update latest release to ${{ steps.version.outputs.version }}
           branch: 'bump/${{ steps.version.outputs.version }}'
           delete-branch: true
-          title: 'docs: update latest release to ${{ steps.version.outputs.version }}'
+          title: |
+            docs: update latest release to ${{ steps.version.outputs.version }}
           body: |
             Update latest release to ${{ steps.version.outputs.version }}
           labels: |

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -13,22 +13,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         name: Checkout gitify-app/gitify
+      
       - uses: pnpm/action-setup@v3
         name: Setup pnpm
+      
       - uses: actions/setup-node@v4
         name: Setup Node.js
         with:
           node-version-file: '.nvmrc'
+      
       - id: version
-        name: Bump version to latest tag
+        name: Find latest version tag
         #run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT # uncomment before merging
         run: echo "version=5.4.1" >> $GITHUB_ENV # remove before merging
-      - run: pnpm version ${{ steps.version.outputs.version }}
+     
       - uses: actions/checkout@v4
         name: Checkout gitify-app/website
         with:
           repository: gitify-app/website
           token: ${{ secrets.GH_TOKEN }}
+      
+      - name: Bump version
+        run: pnpm version ${{ steps.version.outputs.version }}
+      
       - uses: peter-evans/create-pull-request@v6
         name: Create pull request
         with:

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -37,15 +37,9 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-      - name: Create branch
-        run: git checkout -b "bump/${{ env.GITIFY_VERSION }}"
-            
       - name: Bump version
         run: pnpm version ${{ env.GITIFY_VERSION }}
       
-      - name: Push changes
-        run: git push origin "bump/${{ env.GITIFY_VERSION }}"
-
       - uses: peter-evans/create-pull-request@v6
         name: Create pull request
         with:

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -24,10 +24,10 @@ jobs:
         # run: echo "GITIFY_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT  # uncomment before merging
         run: echo "GITIFY_VERSION=5.4.1" >> $GITHUB_ENV # remove before merging
 
-      - name: setup git config
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+     # - name: setup git config
+     #   run: |
+     #     git config user.name github-actions[bot]
+     #     git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       # - run: git checkout -b "bump/${{ env.GITIFY_VERSION }}"
       - run: pnpm version ${{ env.GITIFY_VERSION }}
       # - run: git push origin "bump/${{ env.GITIFY_VERSION }}"
@@ -37,15 +37,15 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: |
-            docs: update latest release to ${{ env.GITIFY_VERSION }}
+            docs: update to latest release version ${{ env.GITIFY_VERSION }}
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           base: main
           branch: "bump/${{ env.GITIFY_VERSION }}"
           delete-branch: true
           title: |
-            docs: update latest release to ${{ env.GITIFY_VERSION }}
+            docs: update to latest release version ${{ env.GITIFY_VERSION }}
           body: |
-            Update latest release to ${{ env.GITIFY_VERSION }}
+            Automated update to latest release version ${{ env.GITIFY_VERSION }}
           labels: |
             documentation

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -11,11 +11,6 @@ jobs:
     name: Website
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        name: Checkout website
-        with:
-          repository: gitify-app/website
-          token: ${{ secrets.GH_TOKEN }}
       - uses: pnpm/action-setup@v3
         name: Setup pnpm
       - uses: actions/setup-node@v4
@@ -26,6 +21,11 @@ jobs:
         name: Bump version to latest tag
         run: echo "version=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_OUTPUT
       - run: pnpm version ${{ steps.version.outputs.version }}
+      - uses: actions/checkout@v4
+        name: Checkout website
+        with:
+          repository: gitify-app/website
+          token: ${{ secrets.GH_TOKEN }}
       - uses: peter-evans/create-pull-request@v6
         name: Create pull request
         with:


### PR DESCRIPTION
Closes #1028 

Successfully tested here
* workflow: https://github.com/gitify-app/gitify/actions/runs/8754907654/job/24027797143
* pr: https://github.com/gitify-app/website/pull/108

Note: PR author/ownership cannot be changed as per https://github.com/peter-evans/create-pull-request/issues/2779