### PR TITLE
feat: show "read" notifications

### DIFF
--- a/src/__mocks__/mock-state.ts
+++ b/src/__mocks__/mock-state.ts
@@ -18,4 +18,5 @@ export const mockSettings: SettingsState = {
   detailedNotifications: false,
   markAsDoneOnOpen: false,
   showAccountHostname: false,
+  showReadNotifications: false,
 };

--- a/src/__mocks__/mock-state.ts
+++ b/src/__mocks__/mock-state.ts
@@ -18,5 +18,5 @@ export const mockSettings: SettingsState = {
   detailedNotifications: false,
   markAsDoneOnOpen: false,
   showAccountHostname: false,
-  showReadNotifications: false,
+  showAllNotifications: false,
 };

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -40,26 +40,13 @@ export const NotificationRow: FC<IProps> = ({ notification, hostname }) => {
     notifications,
   } = useContext(AppContext);
 
-  const setNotificationAsOpaque = () => {
-    if (notification.unread) {
-      const notificationRow = document.getElementById(notification.id);
-      notificationRow.className += Constants.READ_CLASS_NAME;
-    }
-    notification.unread = false;
-  };
-
   const openNotification = useCallback(() => {
     openInBrowser(notification, accounts);
 
     if (settings.markAsDoneOnOpen) {
       markNotificationDone(notification.id, hostname);
     }
-
-    if (!settings.showReadNotifications) {
-      removeNotificationFromState(notification.id, hostname);
-    } else {
-      setNotificationAsOpaque();
-    }
+    handleNotificationState();
   }, [notifications, notification, accounts, settings]); // notifications required here to prevent weird state issues
 
   const unsubscribe = (event: MouseEvent<HTMLElement>) => {
@@ -68,32 +55,17 @@ export const NotificationRow: FC<IProps> = ({ notification, hostname }) => {
 
     unsubscribeNotification(notification.id, hostname);
     markNotificationRead(notification.id, hostname);
-
-    if (!settings.showReadNotifications) {
-      removeNotificationFromState(notification.id, hostname);
-    } else {
-      setNotificationAsOpaque();
-    }
+    handleNotificationState();
   };
 
   const markAsRead = () => {
     markNotificationRead(notification.id, hostname);
-
-    if (!settings.showReadNotifications) {
-      removeNotificationFromState(notification.id, hostname);
-    } else {
-      setNotificationAsOpaque();
-    }
+    handleNotificationState();
   };
 
   const markAsDone = () => {
     markNotificationDone(notification.id, hostname);
-
-    if (!settings.showReadNotifications) {
-      removeNotificationFromState(notification.id, hostname);
-    } else {
-      setNotificationAsOpaque();
-    }
+    handleNotificationState();
   };
 
   const openUserProfile = (
@@ -104,6 +76,20 @@ export const NotificationRow: FC<IProps> = ({ notification, hostname }) => {
 
     openExternalLink(notification.subject.user.html_url);
   };
+
+  const handleNotificationState = useCallback(() => {
+    if (!settings.showAllNotifications) {
+      removeNotificationFromState(notification.id, hostname);
+    }
+
+    if (notification.unread) {
+      const notificationRow = document.getElementById(notification.id);
+      notificationRow.className += Constants.READ_CLASS_NAME;
+    }
+
+    // TODO FIXME - this is not updating the notification count
+    notification.unread = false;
+  }, [notification, notifications]);
 
   const reason = formatReason(notification.reason);
   const NotificationIcon = getNotificationTypeIcon(notification.subject);

--- a/src/components/Repository.test.tsx
+++ b/src/components/Repository.test.tsx
@@ -10,7 +10,7 @@ jest.mock('./NotificationRow', () => ({
 }));
 
 describe('components/Repository.tsx', () => {
-  const markRepoNotifications = jest.fn();
+  const markRepoNotificationsRead = jest.fn();
   const markRepoNotificationsDone = jest.fn();
 
   const props = {
@@ -20,7 +20,7 @@ describe('components/Repository.tsx', () => {
   };
 
   beforeEach(() => {
-    markRepoNotifications.mockReset();
+    markRepoNotificationsRead.mockReset();
 
     jest.spyOn(shell, 'openExternal');
   });
@@ -51,14 +51,14 @@ describe('components/Repository.tsx', () => {
 
   it('should mark a repo as read', () => {
     render(
-      <AppContext.Provider value={{ markRepoNotifications }}>
+      <AppContext.Provider value={{ markRepoNotificationsRead }}>
         <RepositoryNotifications {...props} />
       </AppContext.Provider>,
     );
 
     fireEvent.click(screen.getByTitle('Mark Repository as Read'));
 
-    expect(markRepoNotifications).toHaveBeenCalledWith(
+    expect(markRepoNotificationsRead).toHaveBeenCalledWith(
       'manosim/notifications-test',
       'github.com',
     );

--- a/src/components/Repository.tsx
+++ b/src/components/Repository.tsx
@@ -28,16 +28,6 @@ export const RepositoryNotifications: FC<IProps> = ({
     removeNotificationsFromState,
   } = useContext(AppContext);
 
-  const setNotificationsAsOpaque = (repoNotifications: Notification[]) => {
-    for (const notification of repoNotifications) {
-      if (notification.unread) {
-        const notificationRow = document.getElementById(notification.id);
-        notificationRow.className += Constants.READ_CLASS_NAME;
-      }
-      notification.unread = false;
-    }
-  };
-
   const openBrowser = useCallback(() => {
     const url = repoNotifications[0].repository.html_url;
     openExternalLink(url);
@@ -46,22 +36,33 @@ export const RepositoryNotifications: FC<IProps> = ({
   const markRepoAsRead = useCallback(() => {
     const repoSlug = repoNotifications[0].repository.full_name;
     markRepoNotificationsRead(repoSlug, hostname);
-    if (!settings.showReadNotifications) {
-      removeNotificationsFromState(repoSlug, notifications, hostname);
-    } else {
-      setNotificationsAsOpaque(repoNotifications);
-    }
+    handleNotificationState(repoSlug);
   }, [repoNotifications, hostname]);
 
   const markRepoAsDone = useCallback(() => {
     const repoSlug = repoNotifications[0].repository.full_name;
     markRepoNotificationsDone(repoSlug, hostname);
-    if (!settings.showReadNotifications) {
-      removeNotificationsFromState(repoSlug, notifications, hostname);
-    } else {
-      setNotificationsAsOpaque(repoNotifications);
-    }
+    handleNotificationState(repoSlug);
   }, [repoNotifications, hostname]);
+
+  const handleNotificationState = useCallback(
+    (repoSlug: string) => {
+      if (!settings.showAllNotifications) {
+        removeNotificationsFromState(repoSlug, notifications, hostname);
+      }
+
+      for (const notification of repoNotifications) {
+        if (notification.unread) {
+          const notificationRow = document.getElementById(notification.id);
+          notificationRow.className += Constants.READ_CLASS_NAME;
+        }
+
+        // TODO FIXME - this is not updating the notification count
+        notification.unread = false;
+      }
+    },
+    [repoNotifications, hostname, notifications],
+  );
 
   const avatarUrl = repoNotifications[0].repository.owner.avatar_url;
   const repoSlug = repoNotifications[0].repository.full_name;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -13,7 +13,7 @@ import { Logo } from '../components/Logo';
 import { AppContext } from '../context/App';
 import { openExternalLink } from '../utils/comms';
 import { Constants } from '../utils/constants';
-import { getNotificationCount } from '../utils/notifications';
+import { getUnreadNotificationCount } from '../utils/notifications';
 
 export const Sidebar: FC = () => {
   const navigate = useNavigate();
@@ -35,7 +35,7 @@ export const Sidebar: FC = () => {
   }, []);
 
   const notificationsCount = useMemo(() => {
-    return getNotificationCount(notifications);
+    return getUnreadNotificationCount(notifications);
   }, [notifications]);
 
   const sidebarButtonClasses =

--- a/src/context/App.test.tsx
+++ b/src/context/App.test.tsx
@@ -193,15 +193,15 @@ describe('context/App.tsx', () => {
       );
     });
 
-    it('should call markRepoNotifications', async () => {
+    it('should call markRepoNotificationsRead', async () => {
       const TestComponent = () => {
-        const { markRepoNotifications } = useContext(AppContext);
+        const { markRepoNotificationsRead } = useContext(AppContext);
 
         return (
           <button
             type="button"
             onClick={() =>
-              markRepoNotifications('manosim/gitify', 'github.com')
+              markRepoNotificationsRead('manosim/gitify', 'github.com')
             }
           >
             Test Case

--- a/src/context/App.test.tsx
+++ b/src/context/App.test.tsx
@@ -37,11 +37,11 @@ describe('context/App.tsx', () => {
 
   describe('api methods', () => {
     const apiRequestAuthMock = jest.spyOn(apiRequests, 'apiRequestAuth');
-    const getNotificationCountMock = jest.spyOn(
+    const getUnreadNotificationCountMock = jest.spyOn(
       notifications,
-      'getNotificationCount',
+      'getUnreadNotificationCount',
     );
-    getNotificationCountMock.mockReturnValue(1);
+    getUnreadNotificationCountMock.mockReturnValue(1);
 
     const fetchNotificationsMock = jest.fn();
     const markNotificationReadMock = jest.fn();

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -23,7 +23,7 @@ import { addAccount, authGitHub, getToken, getUserData } from '../utils/auth';
 import { setAutoLaunch, updateTrayTitle } from '../utils/comms';
 import Constants from '../utils/constants';
 import { generateGitHubAPIUrl } from '../utils/helpers';
-import { getNotificationCount } from '../utils/notifications';
+import { getUnreadNotificationCount } from '../utils/notifications';
 import { clearState, loadState, saveState } from '../utils/storage';
 import { setTheme } from '../utils/theme';
 
@@ -44,7 +44,7 @@ export const defaultSettings: SettingsState = {
   detailedNotifications: false,
   markAsDoneOnOpen: false,
   showAccountHostname: false,
-  showReadNotifications: false,
+  showAllNotifications: false,
 };
 
 interface AppContextState {
@@ -114,7 +114,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     settings.participating,
     settings.showBots,
     settings.detailedNotifications,
-    settings.showReadNotifications,
+    settings.showAllNotifications,
     accounts.token,
     accounts.enterpriseAccounts.length,
   ]);
@@ -125,7 +125,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: We need to update tray title when settings or notifications changes.
   useEffect(() => {
-    const count = getNotificationCount(notifications);
+    const count = getUnreadNotificationCount(notifications);
 
     if (settings.showNotificationsCountInTray && count > 0) {
       updateTrayTitle(count.toString());

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -44,6 +44,7 @@ export const defaultSettings: SettingsState = {
   detailedNotifications: false,
   markAsDoneOnOpen: false,
   showAccountHostname: false,
+  showReadNotifications: false,
 };
 
 interface AppContextState {
@@ -59,11 +60,16 @@ interface AppContextState {
   requestFailed: boolean;
   errorDetails: GitifyError;
   removeNotificationFromState: (id: string, hostname: string) => void;
+  removeNotificationsFromState: (
+    repoSlug: string,
+    notifications: AccountNotifications[],
+    hostname: string,
+  ) => void;
   fetchNotifications: () => Promise<void>;
   markNotificationRead: (id: string, hostname: string) => Promise<void>;
   markNotificationDone: (id: string, hostname: string) => Promise<void>;
   unsubscribeNotification: (id: string, hostname: string) => Promise<void>;
-  markRepoNotifications: (id: string, hostname: string) => Promise<void>;
+  markRepoNotificationsRead: (id: string, hostname: string) => Promise<void>;
   markRepoNotificationsDone: (id: string, hostname: string) => Promise<void>;
 
   settings: SettingsState;
@@ -85,10 +91,11 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     errorDetails,
     isFetching,
     removeNotificationFromState,
+    removeNotificationsFromState,
     markNotificationRead,
     markNotificationDone,
     unsubscribeNotification,
-    markRepoNotifications,
+    markRepoNotificationsRead,
     markRepoNotificationsDone,
   } = useNotifications();
 
@@ -107,6 +114,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     settings.participating,
     settings.showBots,
     settings.detailedNotifications,
+    settings.showReadNotifications,
     accounts.token,
     accounts.enterpriseAccounts.length,
   ]);
@@ -222,7 +230,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const markRepoNotificationsWithAccounts = useCallback(
     async (repoSlug: string, hostname: string) =>
-      await markRepoNotifications(accounts, repoSlug, hostname),
+      await markRepoNotificationsRead(accounts, repoSlug, hostname),
     [accounts, notifications],
   );
 
@@ -247,11 +255,12 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         requestFailed,
         errorDetails,
         removeNotificationFromState,
+        removeNotificationsFromState,
         fetchNotifications: fetchNotificationsWithAccounts,
         markNotificationRead: markNotificationReadWithAccounts,
         markNotificationDone: markNotificationDoneWithAccounts,
         unsubscribeNotification: unsubscribeNotificationWithAccounts,
-        markRepoNotifications: markRepoNotificationsWithAccounts,
+        markRepoNotificationsRead: markRepoNotificationsWithAccounts,
         markRepoNotificationsDone: markRepoNotificationsDoneWithAccounts,
 
         settings,

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -796,7 +796,11 @@ describe('hooks/useNotifications.ts', () => {
         const { result } = renderHook(() => useNotifications());
 
         act(() => {
-          result.current.markRepoNotifications(accounts, repoSlug, hostname);
+          result.current.markRepoNotificationsRead(
+            accounts,
+            repoSlug,
+            hostname,
+          );
         });
 
         await waitFor(() => {
@@ -814,7 +818,11 @@ describe('hooks/useNotifications.ts', () => {
         const { result } = renderHook(() => useNotifications());
 
         act(() => {
-          result.current.markRepoNotifications(accounts, repoSlug, hostname);
+          result.current.markRepoNotificationsRead(
+            accounts,
+            repoSlug,
+            hostname,
+          );
         });
 
         await waitFor(() => {
@@ -837,7 +845,11 @@ describe('hooks/useNotifications.ts', () => {
         const { result } = renderHook(() => useNotifications());
 
         act(() => {
-          result.current.markRepoNotifications(accounts, repoSlug, hostname);
+          result.current.markRepoNotificationsRead(
+            accounts,
+            repoSlug,
+            hostname,
+          );
         });
 
         await waitFor(() => {
@@ -855,7 +867,11 @@ describe('hooks/useNotifications.ts', () => {
         const { result } = renderHook(() => useNotifications());
 
         act(() => {
-          result.current.markRepoNotifications(accounts, repoSlug, hostname);
+          result.current.markRepoNotificationsRead(
+            accounts,
+            repoSlug,
+            hostname,
+          );
         });
 
         await waitFor(() => {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -80,7 +80,7 @@ export const useNotifications = (): NotificationsState => {
   const fetchNotifications = useCallback(
     async (accounts: AuthState, settings: SettingsState) => {
       function getNotifications(hostname: string, token: string): AxiosPromise {
-        const endpointSuffix = `notifications?all=${settings.showReadNotifications}&participating=${settings.participating}`;
+        const endpointSuffix = `notifications?all=${settings.showAllNotifications}&participating=${settings.participating}`;
         const url = `${generateGitHubAPIUrl(hostname)}${endpointSuffix}`;
         return apiRequestAuth(url, 'GET', token);
       }

--- a/src/routes/Notifications.tsx
+++ b/src/routes/Notifications.tsx
@@ -5,7 +5,7 @@ import { AllRead } from '../components/AllRead';
 import { Oops } from '../components/Oops';
 import { AppContext } from '../context/App';
 import { Errors } from '../utils/constants';
-import { getNotificationCount } from '../utils/notifications';
+import { getUnreadNotificationCount } from '../utils/notifications';
 
 export const NotificationsRoute: FC = () => {
   const { notifications, requestFailed, errorDetails, settings } =
@@ -16,7 +16,7 @@ export const NotificationsRoute: FC = () => {
     [notifications],
   );
   const notificationsCount = useMemo(() => {
-    return getNotificationCount(notifications);
+    return getUnreadNotificationCount(notifications);
   }, [notifications]);
 
   const hasNotifications = useMemo(
@@ -28,7 +28,7 @@ export const NotificationsRoute: FC = () => {
     return <Oops error={errorDetails ?? Errors.UNKNOWN} />;
   }
 
-  if (!hasNotifications) {
+  if (!hasNotifications && !settings.showAllNotifications) {
     return <AllRead />;
   }
 

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -183,11 +183,23 @@ export const SettingsRoute: FC = () => {
             Notifications
           </legend>
           <Checkbox
-            name="showReadNotifications"
-            label="Show read notifications"
-            checked={settings.showReadNotifications}
+            name="showAllNotifications"
+            label="Show all notifications"
+            checked={settings.showAllNotifications}
             onChange={(evt) =>
-              updateSetting('showReadNotifications', evt.target.checked)
+              updateSetting('showAllNotifications', evt.target.checked)
+            }
+            tooltip={
+              <div>
+                <div className="pb-3">
+                  Will show up to 50 latest notifications regardless of status
+                  (read, unread, done).
+                </div>
+                <div className="text-orange-600">
+                  ⚠️ Users <i>may</i> experience rate limiting under certain
+                  circumstances. Disable this setting if you experience this.
+                </div>
+              </div>
             }
           />
           <Checkbox

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -183,6 +183,14 @@ export const SettingsRoute: FC = () => {
             Notifications
           </legend>
           <Checkbox
+            name="showReadNotifications"
+            label="Show read notifications"
+            checked={settings.showReadNotifications}
+            onChange={(evt) =>
+              updateSetting('showReadNotifications', evt.target.checked)
+            }
+          />
+          <Checkbox
             name="showOnlyParticipating"
             label="Show only participating"
             checked={settings.participating}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ interface NotificationSettingsState {
   showNotifications: boolean;
   showBots: boolean;
   markAsDoneOnOpen: boolean;
+  showReadNotifications: boolean;
 }
 
 interface SystemSettingsState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ interface NotificationSettingsState {
   showNotifications: boolean;
   showBots: boolean;
   markAsDoneOnOpen: boolean;
-  showReadNotifications: boolean;
+  showAllNotifications: boolean;
 }
 
 interface SystemSettingsState {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -18,6 +18,8 @@ export const Constants = {
   ALLREAD_EMOJIS: ['😉', '🎉', '🐯', '🙈', '🎈', '🎊', '👏', '🎪', '🍝'],
 
   FETCH_INTERVAL: 60000,
+
+  READ_CLASS_NAME: 'opacity-50 dark:opacity-50',
 };
 
 export const Errors: Record<ErrorType, GitifyError> = {

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -6,14 +6,18 @@ import { updateTrayIcon } from './comms';
 import type { AccountNotifications, AuthState, SettingsState } from '../types';
 
 export const setTrayIconColor = (notifications: AccountNotifications[]) => {
-  const allNotificationsCount = getNotificationCount(notifications);
+  const notificationCount = getUnreadNotificationCount(notifications);
 
-  updateTrayIcon(allNotificationsCount);
+  updateTrayIcon(notificationCount);
 };
 
-export function getNotificationCount(notifications: AccountNotifications[]) {
+export function getUnreadNotificationCount(
+  notifications: AccountNotifications[],
+) {
   return notifications.reduce(
-    (memo, acc) => memo + acc.notifications.length,
+    (memo, acc) =>
+      memo +
+      acc.notifications.filter((notification) => notification.unread).length,
     0,
   );
 }


### PR DESCRIPTION
Closes #708 

Add new `Notification Settings` to show all notifications (defaulted to off).

When set, notification rows will be opaque when read.

The `mark as read` button both at the Repository and Notification level are conditional based on whether the notification(s) are unread or not.

Some things to note

1. we don't support fetching more than the first page of REST API results, so the notifications will be maxed at 50
2. the API returns all notifications (unread, read, done)

![Screenshot 2024-04-20 at 7 10 57 AM](https://github.com/gitify-app/gitify/assets/386277/fa9edaef-c8f8-406b-a2ee-8f8b23b6e4cc)
![Screenshot 2024-04-20 at 7 11 06 AM](https://github.com/gitify-app/gitify/assets/386277/4e982d6c-222b-4055-ac16-f044ee653543)
![Screenshot 2024-04-20 at 7 11 19 AM](https://github.com/gitify-app/gitify/assets/386277/28102691-0bc3-47a1-9b74-87408df62e37)




