### PR TITLE
refactor: clarify unsubscribe behavior

### DIFF
--- a/src/components/NotificationRow.test.tsx
+++ b/src/components/NotificationRow.test.tsx
@@ -165,7 +165,7 @@ describe('components/NotificationRow.tsx', () => {
         </AppContext.Provider>
       </AppContext.Provider>,
     );
-    fireEvent.click(screen.getByTitle('Unsubscribe'));
+    fireEvent.click(screen.getByTitle('Unsubscribe from Thread'));
     expect(unsubscribeNotification).toHaveBeenCalledTimes(1);
   });
 

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -50,7 +50,7 @@ export const NotificationRow: FC<IProps> = ({ notification, hostname }) => {
     }
   }, [notifications, notification, accounts, settings]); // notifications required here to prevent weird state issues
 
-  const unsubscribe = (event: MouseEvent<HTMLElement>) => {
+  const unsubscribeFromThread = (event: MouseEvent<HTMLElement>) => {
     // Don't trigger onClick of parent element.
     event.stopPropagation();
 
@@ -149,10 +149,10 @@ export const NotificationRow: FC<IProps> = ({ notification, hostname }) => {
         <button
           type="button"
           className="focus:outline-none h-full hover:text-red-500"
-          title="Unsubscribe"
-          onClick={unsubscribe}
+          title="Unsubscribe from Thread"
+          onClick={unsubscribeFromThread}
         >
-          <BellSlashIcon size={14} aria-label="Unsubscribe" />
+          <BellSlashIcon size={14} aria-label="Unsubscribe from Thread" />
         </button>
 
         <button

--- a/src/components/__snapshots__/NotificationRow.test.tsx.snap
+++ b/src/components/__snapshots__/NotificationRow.test.tsx.snap
@@ -118,11 +118,11 @@ exports[`components/NotificationRow.tsx should render itself & its children 1`] 
     <button
       className="focus:outline-none h-full hover:text-red-500"
       onClick={[Function]}
-      title="Unsubscribe"
+      title="Unsubscribe from Thread"
       type="button"
     >
       <svg
-        aria-label="Unsubscribe"
+        aria-label="Unsubscribe from Thread"
         className="octicon octicon-bell-slash"
         fill="currentColor"
         focusable="false"
@@ -306,11 +306,11 @@ exports[`components/NotificationRow.tsx should render itself & its children with
     <button
       className="focus:outline-none h-full hover:text-red-500"
       onClick={[Function]}
-      title="Unsubscribe"
+      title="Unsubscribe from Thread"
       type="button"
     >
       <svg
-        aria-label="Unsubscribe"
+        aria-label="Unsubscribe from Thread"
         className="octicon octicon-bell-slash"
         fill="currentColor"
         focusable="false"


### PR DESCRIPTION
Clarifying what the `Unsubscribe` button does based on the docs at https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#set-a-thread-subscription

Added corresponding FAQ entry also - https://github.com/gitify-app/website/pull/111