### PR TITLE
test: rename suite

### DIFF
--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -216,8 +216,8 @@ describe('hooks/useNotifications.ts', () => {
       });
     });
 
-    describe('with colors', () => {
-      it('should fetch notifications with success - with colors', async () => {
+    describe('with detailed notifications', () => {
+      it('should fetch notifications with success', async () => {
         const accounts: AuthState = {
           ...mockAccounts,
           enterpriseAccounts: [],


### PR DESCRIPTION
Looks like I missed this when renaming `settings.colors` to `settings.detailedNotifications` 🙈 