### PR TITLE
refactor: simplify useNotifications

### DIFF
--- a/src/__mocks__/mockedData.ts
+++ b/src/__mocks__/mockedData.ts
@@ -70,7 +70,7 @@ export const mockedCommenterUser: User = {
 };
 
 export const mockedSingleNotification: Notification = {
-  hostname: Constants.DEFAULT_AUTH_OPTIONS.hostname,
+  hostname: Constants.GITHUB_API_BASE_URL,
   id: '138661096',
   unread: true,
   reason: 'subscribed',
@@ -249,7 +249,7 @@ export const mockedGitHubNotifications = [
     url: 'https://api.github.com/notifications/threads/148827438',
     subscription_url:
       'https://api.github.com/notifications/threads/148827438/subscription',
-    hostname: Constants.DEFAULT_AUTH_OPTIONS.hostname,
+    hostname: Constants.GITHUB_API_BASE_URL,
   } as Notification,
 ];
 
@@ -359,7 +359,7 @@ export const mockedEnterpriseNotifications = [
     url: 'https://github.gitify.io/api/v3/notifications/threads/3',
     subscription_url:
       'https://github.gitify.io/api/v3/notifications/threads/3/subscription',
-    hostname: Constants.DEFAULT_AUTH_OPTIONS.hostname,
+    hostname: Constants.GITHUB_API_BASE_URL,
   } as Notification,
 ];
 

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -43,10 +43,13 @@ describe('hooks/useNotifications.ts', () => {
           expect(result.current.status).toBe('success');
         });
 
-        expect(result.current.notifications[0].hostname).toBe(
+        expect(result.current.notifications[0].hostname).toBe('api.github.com');
+        expect(result.current.notifications[0].notifications.length).toBe(2);
+
+        expect(result.current.notifications[1].hostname).toBe(
           'github.gitify.io',
         );
-        expect(result.current.notifications[1].hostname).toBe('github.com');
+        expect(result.current.notifications[1].notifications.length).toBe(2);
       });
 
       it('should fetch notifications with failures - github.com & enterprise', async () => {
@@ -117,11 +120,12 @@ describe('hooks/useNotifications.ts', () => {
         });
 
         await waitFor(() => {
-          expect(result.current.notifications[0].hostname).toBe(
-            'github.gitify.io',
-          );
+          expect(result.current.status).toBe('success');
         });
 
+        expect(result.current.notifications[0].hostname).toBe(
+          'github.gitify.io',
+        );
         expect(result.current.notifications[0].notifications.length).toBe(2);
       });
 
@@ -179,9 +183,10 @@ describe('hooks/useNotifications.ts', () => {
         });
 
         await waitFor(() => {
-          expect(result.current.notifications[0].hostname).toBe('github.com');
+          expect(result.current.status).toBe('success');
         });
 
+        expect(result.current.notifications[0].hostname).toBe('api.github.com');
         expect(result.current.notifications[0].notifications.length).toBe(2);
       });
 
@@ -379,7 +384,7 @@ describe('hooks/useNotifications.ts', () => {
           expect(result.current.status).toBe('success');
         });
 
-        expect(result.current.notifications[0].hostname).toBe('github.com');
+        expect(result.current.notifications[0].hostname).toBe('api.github.com');
         expect(result.current.notifications[0].notifications.length).toBe(6);
       });
     });
@@ -459,7 +464,7 @@ describe('hooks/useNotifications.ts', () => {
           expect(result.current.status).toBe('success');
         });
 
-        expect(result.current.notifications[0].hostname).toBe('github.com');
+        expect(result.current.notifications[0].hostname).toBe('api.github.com');
         expect(result.current.notifications[0].notifications.length).toBe(1);
       });
     });

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -105,22 +105,17 @@ export const useNotifications = (): NotificationsState => {
         ...getEnterpriseNotifications(),
       ])
         .then(([...responses]) => {
-          // Remove any undefined responses
-          const accountResponses = responses.filter(
-            (accountResponse) => !!accountResponse,
-          );
-          const accountsNotifications: AccountNotifications[] =
-            accountResponses.map((accountNotifications) => {
+          const accountsNotifications: AccountNotifications[] = responses
+            .filter((response) => !!response)
+            .map((accountNotifications) => {
               const { hostname } = new URL(accountNotifications.config.url);
               return {
-                hostname: hostname,
+                hostname,
                 notifications: accountNotifications.data.map(
-                  (notification: Notification) => {
-                    return {
-                      ...notification,
-                      hostname: hostname,
-                    };
-                  },
+                  (notification: Notification) => ({
+                    ...notification,
+                    hostname,
+                  }),
                 ),
               };
             });

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -79,13 +79,15 @@ export const useNotifications = (): NotificationsState => {
   const fetchNotifications = useCallback(
     async (accounts: AuthState, settings: SettingsState) => {
       function getGitHubNotifications() {
-        if (isGitHubLoggedIn(accounts)) {
-          return listNotificationsForAuthenticatedUser(
-            Constants.DEFAULT_AUTH_OPTIONS.hostname,
-            accounts.token,
-            settings,
-          );
+        if (!isGitHubLoggedIn(accounts)) {
+          return;
         }
+
+        return listNotificationsForAuthenticatedUser(
+          Constants.DEFAULT_AUTH_OPTIONS.hostname,
+          accounts.token,
+          settings,
+        );
       }
 
       function getEnterpriseNotifications() {

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -174,7 +174,6 @@ export const useNotifications = (): NotificationsState => {
           });
         })
         .catch((err: AxiosError<GitHubRESTError>) => {
-          console.error('ADAM', err);
           setStatus('error');
           setErrorDetails(determineFailureType(err));
         });

--- a/src/routes/__snapshots__/Notifications.test.tsx.snap
+++ b/src/routes/__snapshots__/Notifications.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`routes/Notifications.tsx should render itself & its children (show acco
     notifications={
       [
         {
-          "hostname": "github.com",
+          "hostname": "https://api.github.com",
           "id": "138661096",
           "last_read_at": "2017-05-20T17:06:51Z",
           "reason": "subscribed",
@@ -189,7 +189,7 @@ exports[`routes/Notifications.tsx should render itself & its children (show acco
           "url": "https://api.github.com/notifications/threads/138661096",
         },
         {
-          "hostname": "github.com",
+          "hostname": "https://api.github.com",
           "id": "148827438",
           "last_read_at": "2017-05-20T16:59:03Z",
           "reason": "author",
@@ -248,7 +248,7 @@ exports[`routes/Notifications.tsx should render itself & its children (with noti
     notifications={
       [
         {
-          "hostname": "github.com",
+          "hostname": "https://api.github.com",
           "id": "138661096",
           "last_read_at": "2017-05-20T17:06:51Z",
           "reason": "subscribed",
@@ -338,7 +338,7 @@ exports[`routes/Notifications.tsx should render itself & its children (with noti
           "url": "https://api.github.com/notifications/threads/138661096",
         },
         {
-          "hostname": "github.com",
+          "hostname": "https://api.github.com",
           "id": "148827438",
           "last_read_at": "2017-05-20T16:59:03Z",
           "reason": "author",
@@ -433,7 +433,7 @@ exports[`routes/Notifications.tsx should render itself & its children (with noti
           "url": "https://github.gitify.io/api/v3/notifications/threads/4",
         },
         {
-          "hostname": "github.com",
+          "hostname": "https://api.github.com",
           "id": "3",
           "last_read_at": "2017-05-20T14:20:55Z",
           "reason": "subscribed",

--- a/src/typesGitHub.ts
+++ b/src/typesGitHub.ts
@@ -79,7 +79,8 @@ export interface Notification {
   repository: Repository;
   url: string;
   subscription_url: string;
-  hostname: string; // This is not in the GitHub API, but we add it to the type to make it easier to work with
+  // TODO - rename this to apiBaseUrl
+  hostname: string; // This is not in the official GitHub API. We add this to make notification interactions easier.
 }
 
 export type UserDetails = User & UserProfile;


### PR DESCRIPTION
🧼 consolidate response handling for both github cloud and github server accounts.