### PR TITLE
refactor(discussions): use API to get latest comment and reply

### DIFF
--- a/src/__mocks__/mockedData.ts
+++ b/src/__mocks__/mockedData.ts
@@ -405,44 +405,6 @@ const mockDiscussionReplier: DiscussionAuthor = {
 export const mockDiscussionComments: DiscussionComments = {
   nodes: [
     {
-      databaseId: 2215656,
-      createdAt: '2022-02-20T18:33:39Z',
-      author: mockDiscussionAuthor,
-      replies: {
-        nodes: [],
-      },
-    },
-    {
-      databaseId: 2217789,
-      createdAt: '2022-02-21T03:30:42Z',
-      author: mockDiscussionAuthor,
-      replies: {
-        nodes: [],
-      },
-    },
-    {
-      databaseId: 2223243,
-      createdAt: '2022-02-21T18:26:27Z',
-      author: mockDiscussionAuthor,
-      replies: {
-        nodes: [
-          {
-            databaseId: 2232922,
-            createdAt: '2022-02-23T00:57:58Z',
-            author: mockDiscussionReplier,
-          },
-        ],
-      },
-    },
-    {
-      databaseId: 2232921,
-      createdAt: '2022-02-23T00:57:49Z',
-      author: mockDiscussionAuthor,
-      replies: {
-        nodes: [],
-      },
-    },
-    {
       databaseId: 2258799,
       createdAt: '2022-02-27T01:22:20Z',
       author: mockDiscussionAuthor,
@@ -451,35 +413,6 @@ export const mockDiscussionComments: DiscussionComments = {
           {
             databaseId: 2300902,
             createdAt: '2022-03-05T17:43:52Z',
-            author: mockDiscussionReplier,
-          },
-        ],
-      },
-    },
-    {
-      databaseId: 2297637,
-      createdAt: '2022-03-04T20:39:44Z',
-      author: mockDiscussionAuthor,
-
-      replies: {
-        nodes: [
-          {
-            databaseId: 2300893,
-            createdAt: '2022-03-05T17:41:04Z',
-            author: mockDiscussionReplier,
-          },
-        ],
-      },
-    },
-    {
-      databaseId: 2299763,
-      createdAt: '2022-03-05T11:05:42Z',
-      author: mockDiscussionAuthor,
-      replies: {
-        nodes: [
-          {
-            databaseId: 2300895,
-            createdAt: '2022-03-05T17:41:44Z',
             author: mockDiscussionReplier,
           },
         ],

--- a/src/utils/api/client.ts
+++ b/src/utils/api/client.ts
@@ -253,7 +253,7 @@ export async function searchDiscussions(
         notification.updated_at,
       ),
       firstDiscussions: 10,
-      lastComments: 100,
+      lastComments: 1,
       lastReplies: 1,
     },
   });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -117,10 +117,10 @@ async function getDiscussionUrl(
 
     const comments = discussion.comments.nodes;
 
-    const latestCommentId = getLatestDiscussionComment(comments)?.databaseId;
+    const latestComment = getLatestDiscussionComment(comments);
 
-    if (latestCommentId) {
-      url += `#discussioncomment-${latestCommentId}`;
+    if (latestComment) {
+      url += `#discussioncomment-${latestComment.databaseId}`;
     }
   }
 
@@ -139,10 +139,11 @@ export async function fetchDiscussion(
         (discussion) => discussion.title === notification.subject.title,
       ) || [];
 
-    if (discussions.length > 1)
+    if (discussions.length > 1) {
       discussions = discussions.filter(
         (discussion) => discussion.viewerSubscription === 'SUBSCRIBED',
       );
+    }
 
     return discussions[0];
   } catch (err) {}
@@ -155,10 +156,13 @@ export function getLatestDiscussionComment(
     return null;
   }
 
-  return comments
-    .flatMap((comment) => comment.replies.nodes)
-    .concat([comments[comments.length - 1]])
-    .reduce((a, b) => (a.createdAt > b.createdAt ? a : b));
+  // Return latest reply if available
+  if (comments[0].replies.nodes.length === 1) {
+    return comments[0].replies.nodes[0];
+  }
+
+  // Return latest comment if no replies
+  return comments[0];
 }
 
 export async function generateGitHubWebUrl(


### PR DESCRIPTION
Instead of comparing createdAt timestamps, we can use the GraphQL query variables to fetch the latest comment and latest reply