### PR TITLE
refactor(discussions): search syntax

### DIFF
--- a/src/utils/api/client.ts
+++ b/src/utils/api/client.ts
@@ -20,7 +20,8 @@ import { apiRequestAuth } from './request';
 import { print } from 'graphql/language/printer';
 import Constants from '../constants';
 import { QUERY_SEARCH_DISCUSSIONS } from './graphql/discussions';
-import { formatSearchQueryString, getGitHubAPIBaseUrl } from './utils';
+import { formatAsGitHubSearchSyntax } from './graphql/utils';
+import { getGitHubAPIBaseUrl } from './utils';
 
 /**
  * Get Hypermedia links to resources accessible in GitHub's REST API
@@ -249,7 +250,7 @@ export async function searchDiscussions(
   return apiRequestAuth(Constants.GITHUB_API_GRAPHQL_URL, 'POST', token, {
     query: print(QUERY_SEARCH_DISCUSSIONS),
     variables: {
-      queryStatement: formatSearchQueryString(
+      queryStatement: formatAsGitHubSearchSyntax(
         notification.repository.full_name,
         notification.subject.title,
         notification.updated_at,

--- a/src/utils/api/graphql/utils.test.ts
+++ b/src/utils/api/graphql/utils.test.ts
@@ -1,0 +1,17 @@
+import { formatAsGitHubSearchSyntax } from './utils';
+
+describe('utils/api/graphql/utils.ts', () => {
+  describe('formatAsGitHubCodeSearchSyntax', () => {
+    test('formats search query string correctly', () => {
+      const result = formatAsGitHubSearchSyntax(
+        'exampleRepo',
+        'exampleTitle',
+        '2024-02-20T12:00:00.000Z',
+      );
+
+      expect(result).toBe(
+        'exampleTitle in:title repo:exampleRepo updated:>2024-02-20T10:00:00.000Z',
+      );
+    });
+  });
+});

--- a/src/utils/api/graphql/utils.ts
+++ b/src/utils/api/graphql/utils.ts
@@ -1,0 +1,14 @@
+import { subHours } from 'date-fns';
+
+const SEARCH_RESULTS_WINDOW_HOURS = 2;
+
+export function formatAsGitHubSearchSyntax(
+  repo: string,
+  title: string,
+  lastUpdated: string,
+): string {
+  return `${title} in:title repo:${repo} updated:>${subHours(
+    lastUpdated,
+    SEARCH_RESULTS_WINDOW_HOURS,
+  ).toISOString()}`;
+}

--- a/src/utils/api/utils.test.ts
+++ b/src/utils/api/utils.test.ts
@@ -1,8 +1,4 @@
-import {
-  addHours,
-  formatSearchQueryString,
-  getGitHubAPIBaseUrl,
-} from './utils';
+import { getGitHubAPIBaseUrl } from './utils';
 
 describe('utils/api/utils.ts', () => {
   describe('generateGitHubAPIUrl', () => {
@@ -14,32 +10,6 @@ describe('utils/api/utils.ts', () => {
     it('should generate a GitHub API url - enterprise', () => {
       const result = getGitHubAPIBaseUrl('github.manos.im');
       expect(result.toString()).toBe('https://github.manos.im/api/v3/');
-    });
-  });
-
-  describe('formatSearchQueryString', () => {
-    test('formats search query string correctly', () => {
-      const result = formatSearchQueryString(
-        'exampleRepo',
-        'exampleTitle',
-        '2024-02-20T12:00:00.000Z',
-      );
-
-      expect(result).toBe(
-        'exampleTitle in:title repo:exampleRepo updated:>2024-02-20T10:00:00.000Z',
-      );
-    });
-  });
-
-  describe('addHours', () => {
-    test('adds hours correctly for positive values', () => {
-      const result = addHours('2024-02-20T12:00:00.000Z', 3);
-      expect(result).toBe('2024-02-20T15:00:00.000Z');
-    });
-
-    test('adds hours correctly for negative values', () => {
-      const result = addHours('2024-02-20T12:00:00.000Z', -2);
-      expect(result).toBe('2024-02-20T10:00:00.000Z');
     });
   });
 });

--- a/src/utils/api/utils.ts
+++ b/src/utils/api/utils.ts
@@ -10,15 +10,3 @@ export function getGitHubAPIBaseUrl(hostname: string): URL {
   }
   return url;
 }
-
-export function formatSearchQueryString(
-  repo: string,
-  title: string,
-  lastUpdated: string,
-): string {
-  return `${title} in:title repo:${repo} updated:>${addHours(lastUpdated, -2)}`;
-}
-
-export function addHours(date: string, hours: number): string {
-  return new Date(new Date(date).getTime() + hours * 36e5).toISOString();
-}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -99,9 +99,7 @@ async function getDiscussionUrl(
   if (discussion) {
     url.href = discussion.url;
 
-    const comments = discussion.comments.nodes;
-
-    const latestComment = getLatestDiscussionComment(comments);
+    const latestComment = getLatestDiscussionComment(discussion.comments.nodes);
 
     if (latestComment) {
       url.hash = `#discussioncomment-${latestComment.databaseId}`;
@@ -118,24 +116,20 @@ export async function fetchDiscussion(
   try {
     const response = await searchDiscussions(notification, token);
 
-    let discussions =
-      response.data?.data.search.nodes.filter(
-        (discussion) => discussion.title === notification.subject.title,
-      ) || [];
+    const discussions = response.data?.data.search.nodes.filter(
+      (discussion) =>
+        discussion.title === notification.subject.title &&
+        discussion.viewerSubscription === 'SUBSCRIBED',
+    );
 
-    if (discussions.length > 1) {
-      discussions = discussions.filter(
-        (discussion) => discussion.viewerSubscription === 'SUBSCRIBED',
-      );
-    }
-
-    return discussions[0];
+    return discussions[0] ?? null;
   } catch (err) {}
 }
 
 export function getLatestDiscussionComment(
   comments: DiscussionComment[],
 ): DiscussionComment | null {
+  console.log('ADAM - comments: ', JSON.stringify(comments));
   if (!comments || comments.length === 0) {
     return null;
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -129,7 +129,6 @@ export async function fetchDiscussion(
 export function getLatestDiscussionComment(
   comments: DiscussionComment[],
 ): DiscussionComment | null {
-  console.log('ADAM - comments: ', JSON.stringify(comments));
   if (!comments || comments.length === 0) {
     return null;
   }


### PR DESCRIPTION
🧼 further simplification - i feel we get enough filtering from the GraphQL response that we can avoid some client-side processing


- rename and move search syntax function into graphql/utils.ts
- simplify search syntax to remove updated:>timestamp+padding  
- simplify post results filtering subscription state (if you mark as done and then mark as undone, your subscription is set to IGNORED)
- fetch the first 5 discussions