### PR TITLE
feat: support discussions for github server

### DIFF
--- a/src/utils/api/client.ts
+++ b/src/utils/api/client.ts
@@ -18,10 +18,9 @@ import type {
 import { apiRequestAuth } from './request';
 
 import { print } from 'graphql/language/printer';
-import Constants from '../constants';
 import { QUERY_SEARCH_DISCUSSIONS } from './graphql/discussions';
 import { formatAsGitHubSearchSyntax } from './graphql/utils';
-import { getGitHubAPIBaseUrl } from './utils';
+import { getGitHubAPIBaseUrl, getGitHubGraphQLUrl } from './utils';
 
 /**
  * Get Hypermedia links to resources accessible in GitHub's REST API
@@ -247,7 +246,8 @@ export async function searchDiscussions(
   notification: Notification,
   token: string,
 ): AxiosPromise<GraphQLSearch<Discussion>> {
-  return apiRequestAuth(Constants.GITHUB_API_GRAPHQL_URL, 'POST', token, {
+  const url = getGitHubGraphQLUrl(notification.hostname);
+  return apiRequestAuth(url.toString(), 'POST', token, {
     query: print(QUERY_SEARCH_DISCUSSIONS),
     variables: {
       queryStatement: formatAsGitHubSearchSyntax(

--- a/src/utils/api/utils.test.ts
+++ b/src/utils/api/utils.test.ts
@@ -8,20 +8,20 @@ describe('utils/api/utils.ts', () => {
     });
 
     it('should generate a GitHub API url - enterprise', () => {
-      const result = getGitHubAPIBaseUrl('github.manos.im');
-      expect(result.toString()).toBe('https://github.manos.im/api/v3/');
+      const result = getGitHubAPIBaseUrl('github.gitify.io');
+      expect(result.toString()).toBe('https://github.gitify.io/api/v3/');
     });
   });
 
-  describe('generateGitHubGraphQLAPIUrl', () => {
+  describe('getGitHubGraphQLUrl', () => {
     it('should generate a GitHub GraphQL url - non enterprise', () => {
       const result = getGitHubGraphQLUrl('github.com');
       expect(result.toString()).toBe('https://api.github.com/graphql');
     });
 
     it('should generate a GitHub GraphQL url - enterprise', () => {
-      const result = getGitHubGraphQLUrl('github.manos.im');
-      expect(result.toString()).toBe('https://github.manos.im/api/graphql');
+      const result = getGitHubGraphQLUrl('github.gitify.io');
+      expect(result.toString()).toBe('https://github.gitify.io/api/graphql');
     });
   });
 });

--- a/src/utils/api/utils.test.ts
+++ b/src/utils/api/utils.test.ts
@@ -1,7 +1,7 @@
-import { getGitHubAPIBaseUrl } from './utils';
+import { getGitHubAPIBaseUrl, getGitHubGraphQLUrl } from './utils';
 
 describe('utils/api/utils.ts', () => {
-  describe('generateGitHubAPIUrl', () => {
+  describe('getGitHubAPIBaseUrl', () => {
     it('should generate a GitHub API url - non enterprise', () => {
       const result = getGitHubAPIBaseUrl('github.com');
       expect(result.toString()).toBe('https://api.github.com/');
@@ -10,6 +10,18 @@ describe('utils/api/utils.ts', () => {
     it('should generate a GitHub API url - enterprise', () => {
       const result = getGitHubAPIBaseUrl('github.manos.im');
       expect(result.toString()).toBe('https://github.manos.im/api/v3/');
+    });
+  });
+
+  describe('generateGitHubGraphQLAPIUrl', () => {
+    it('should generate a GitHub GraphQL url - non enterprise', () => {
+      const result = getGitHubGraphQLUrl('github.com');
+      expect(result.toString()).toBe('https://api.github.com/graphql');
+    });
+
+    it('should generate a GitHub GraphQL url - enterprise', () => {
+      const result = getGitHubGraphQLUrl('github.manos.im');
+      expect(result.toString()).toBe('https://github.manos.im/api/graphql');
     });
   });
 });

--- a/src/utils/api/utils.ts
+++ b/src/utils/api/utils.ts
@@ -10,3 +10,14 @@ export function getGitHubAPIBaseUrl(hostname: string): URL {
   }
   return url;
 }
+
+export function getGitHubGraphQLUrl(hostname: string): URL {
+  const url = new URL(Constants.GITHUB_API_GRAPHQL_URL);
+
+  if (isEnterpriseHost(hostname)) {
+    url.hostname = hostname;
+    url.pathname = '/api/graphql';
+  }
+
+  return url;
+}


### PR DESCRIPTION
We were previously hardcoded to only use GitHub Cloud's GraphQL API.

This enhancement now supports GitHub Server users