### PR TITLE
feat(auth): add `create oauth app` link to enterprise route

### DIFF
--- a/src/routes/LoginEnterprise.test.tsx
+++ b/src/routes/LoginEnterprise.test.tsx
@@ -93,7 +93,7 @@ describe('routes/LoginEnterprise.tsx', () => {
       expect(openExternalMock).toHaveBeenCalledTimes(0);
     });
 
-    it('should open if hostname configured', async () => {
+    it('should open in browser if hostname configured', async () => {
       render(
         <AppContext.Provider value={{ accounts: mockAccounts }}>
           <MemoryRouter>

--- a/src/routes/LoginEnterprise.test.tsx
+++ b/src/routes/LoginEnterprise.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import * as TestRenderer from 'react-test-renderer';
 const { ipcRenderer } = require('electron');
+import { shell } from 'electron';
 import { mockedEnterpriseAccounts } from '../__mocks__/mockedData';
 import { AppContext } from '../context/App';
 import type { AuthState } from '../types';
@@ -14,6 +15,8 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('routes/LoginEnterprise.tsx', () => {
+  const openExternalMock = jest.spyOn(shell, 'openExternal');
+
   const mockAccounts: AuthState = {
     enterpriseAccounts: [],
     user: null,
@@ -73,6 +76,40 @@ describe('routes/LoginEnterprise.tsx', () => {
     expect(validate(values).hostname).toBe('Invalid hostname.');
     expect(validate(values).clientId).toBe('Invalid client id.');
     expect(validate(values).clientSecret).toBe('Invalid client secret.');
+  });
+
+  describe("'Create new OAuth App' button", () => {
+    it('should be disabled if no hostname configured', async () => {
+      render(
+        <AppContext.Provider value={{ accounts: mockAccounts }}>
+          <MemoryRouter>
+            <LoginEnterpriseRoute />
+          </MemoryRouter>
+        </AppContext.Provider>,
+      );
+
+      fireEvent.click(screen.getByText('Create new OAuth App'));
+
+      expect(openExternalMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('should open if hostname configured', async () => {
+      render(
+        <AppContext.Provider value={{ accounts: mockAccounts }}>
+          <MemoryRouter>
+            <LoginEnterpriseRoute />
+          </MemoryRouter>
+        </AppContext.Provider>,
+      );
+
+      fireEvent.change(screen.getByLabelText('Hostname'), {
+        target: { value: 'company.github.com' },
+      });
+
+      fireEvent.click(screen.getByText('Create new OAuth App'));
+
+      expect(openExternalMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('should receive a logged-in enterprise account', () => {

--- a/src/routes/LoginEnterprise.tsx
+++ b/src/routes/LoginEnterprise.tsx
@@ -9,6 +9,8 @@ import { useNavigate } from 'react-router-dom';
 import { FieldInput } from '../components/fields/FieldInput';
 import { AppContext } from '../context/App';
 import type { AuthOptions } from '../types';
+import { getNewOAuthAppURL } from '../utils/auth';
+import { openExternalLink } from '../utils/comms';
 
 interface IValues {
   hostname?: string;
@@ -65,8 +67,15 @@ export const LoginEnterpriseRoute: FC = () => {
     }
   }, [enterpriseAccounts]);
 
+  const openLink = useCallback((url: string) => {
+    openExternalLink(url);
+  }, []);
+
   const renderForm = (formProps: FormRenderProps) => {
-    const { handleSubmit, submitting, pristine } = formProps;
+    const { handleSubmit, submitting, pristine, values } = formProps;
+
+    const buttonClasses =
+      'rounded bg-gray-300 font-semibold rounded text-sm text-center hover:bg-gray-500 hover:text-white dark:text-black focus:outline-none cursor-pointer';
 
     return (
       <form onSubmit={handleSubmit}>
@@ -74,6 +83,22 @@ export const LoginEnterpriseRoute: FC = () => {
           name="hostname"
           label="Hostname"
           placeholder="github.company.com"
+          helpText={
+            <div>
+              <div className="mb-1">
+                <button
+                  type="button"
+                  className={`px-2 py-1 text-xs ${buttonClasses}`}
+                  disabled={!values.hostname}
+                  onClick={() => openLink(getNewOAuthAppURL(values.hostname))}
+                >
+                  Create new OAuth App
+                </button>{' '}
+                then{' '}
+                <span className="italic">Generate a new client secret</span>.
+              </div>
+            </div>
+          }
         />
 
         <FieldInput name="clientId" label="Client ID" placeholder="123456789" />

--- a/src/routes/LoginEnterprise.tsx
+++ b/src/routes/LoginEnterprise.tsx
@@ -95,7 +95,7 @@ export const LoginEnterpriseRoute: FC = () => {
                   Create new OAuth App
                 </button>{' '}
                 then{' '}
-                <span className="italic">Generate a new client secret</span>.
+                <span className="italic">generate a new client secret</span>.
               </div>
             </div>
           }

--- a/src/routes/__snapshots__/LoginEnterprise.test.tsx.snap
+++ b/src/routes/__snapshots__/LoginEnterprise.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`routes/LoginEnterprise.tsx renders correctly 1`] = `
               <span
                 className="italic"
               >
-                Generate a new client secret
+                generate a new client secret
               </span>
               .
             </div>

--- a/src/routes/__snapshots__/LoginEnterprise.test.tsx.snap
+++ b/src/routes/__snapshots__/LoginEnterprise.test.tsx.snap
@@ -69,6 +69,33 @@ exports[`routes/LoginEnterprise.tsx renders correctly 1`] = `
           type="text"
           value=""
         />
+        <div
+          className="mt-3 text-gray-700 dark:text-gray-200 text-xs"
+        >
+          <div>
+            <div
+              className="mb-1"
+            >
+              <button
+                className="px-2 py-1 text-xs rounded bg-gray-300 font-semibold rounded text-sm text-center hover:bg-gray-500 hover:text-white dark:text-black focus:outline-none cursor-pointer"
+                disabled={true}
+                onClick={[Function]}
+                type="button"
+              >
+                Create new OAuth App
+              </button>
+               
+              then
+               
+              <span
+                className="italic"
+              >
+                Generate a new client secret
+              </span>
+              .
+            </div>
+          </div>
+        </div>
       </div>
       <div
         className="mb-4"

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -6,6 +6,7 @@ const browserWindow = new remote.BrowserWindow();
 import type { AuthState } from '../types';
 import * as apiRequests from './api/request';
 import * as auth from './auth';
+import { getNewOAuthAppURL } from './auth';
 
 describe('utils/auth.tsx', () => {
   describe('authGitHub', () => {
@@ -128,6 +129,24 @@ describe('utils/auth.tsx', () => {
           { hostname: 'github.gitify.io', token: '123-456' },
         ],
       });
+    });
+  });
+
+  describe('getNewOAuthAppURL', () => {
+    it('should generate new oauth app url - github cloud', () => {
+      expect(
+        getNewOAuthAppURL('github.com').startsWith(
+          'https://github.com/settings/applications/new',
+        ),
+      ).toBeTruthy();
+    });
+
+    it('should generate new oauth app url - github server', () => {
+      expect(
+        getNewOAuthAppURL('github.gitify.io').startsWith(
+          'https://github.gitify.io/settings/applications/new',
+        ),
+      ).toBeTruthy();
     });
   });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from '@electron/remote';
 
+import { format } from 'date-fns';
 import type {
   AuthResponse,
   AuthState,
@@ -136,3 +137,24 @@ export const addAccount = (
     ],
   };
 };
+
+export function getNewOAuthAppURL(hostname: string): string {
+  const date = format(new Date(), 'PP p');
+  const newOAuthAppURL = new URL(
+    `https://${hostname}/settings/applications/new`,
+  );
+  newOAuthAppURL.searchParams.append(
+    'oauth_application[name]',
+    `Gitify (Created on ${date})`,
+  );
+  newOAuthAppURL.searchParams.append(
+    'oauth_application[url]',
+    'https://www.gitify.io',
+  );
+  newOAuthAppURL.searchParams.append(
+    'oauth_application[callback_url]',
+    'https://www.gitify.io/callback',
+  );
+
+  return newOAuthAppURL.toString();
+}


### PR DESCRIPTION
Add help text to create a new OAuth Application.

![Screenshot 2024-05-17 at 8 24 23 AM](https://github.com/gitify-app/gitify/assets/386277/953734ee-19b2-4277-bb8c-5ab616530c67)


