### PR TITLE
build: changelog automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,3 +87,35 @@ jobs:
           name: Gitify-release-linux
           path: dist/
           overwrite: true
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 🧼 Code Refactoring
+      labels:
+        - refactor
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🧪 Testing
+      labels:
+        - test
+    - title: 🏗️ Build System
+      labels:
+        - build
+    - title: 📦 Dependency Updates
+      labels:
+        - build
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
According to https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations - this _should_ help with our release notes process