### PR TITLE
fix: add datetime error handling

### DIFF
--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -8,6 +8,7 @@ import {
 import * as apiRequests from './api/request';
 import {
   formatForDisplay,
+  formatNotificationUpdatedAt,
   generateGitHubWebUrl,
   generateNotificationReferrerId,
   isEnterpriseHost,
@@ -533,6 +534,48 @@ describe('utils/helpers.ts', () => {
       expect(formatForDisplay(['not_planned', 'Issue'])).toBe(
         'Not Planned Issue',
       );
+    });
+
+    describe('formatNotificationUpdatedAt', () => {
+      it('should use last_read_at if available', () => {
+        const notification = {
+          ...mockSingleNotification,
+          last_read_at: '2021-06-23T16:00:00Z',
+          updated_at: '2021-06-23T17:00:00Z',
+        };
+
+        expect(formatNotificationUpdatedAt(notification)).toContain('ago');
+      });
+
+      it('should use updated_at if last_read_at is null', () => {
+        const notification = {
+          ...mockSingleNotification,
+          last_read_at: null,
+          updated_at: '2021-06-23T17:00:00Z',
+        };
+
+        expect(formatNotificationUpdatedAt(notification)).toContain('ago');
+      });
+
+      it('should return empty if all dates are null', () => {
+        const notification = {
+          ...mockSingleNotification,
+          last_read_at: null,
+          updated_at: null,
+        };
+
+        expect(formatNotificationUpdatedAt(notification)).toBe('');
+      });
+
+      it('should return empty if unable to parse dates', () => {
+        const notification = {
+          ...mockSingleNotification,
+          last_read_at: 'not an iso date',
+          updated_at: 'not an iso date',
+        };
+
+        expect(formatNotificationUpdatedAt(notification)).toBe('');
+      });
     });
   });
 });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -178,9 +178,9 @@ export function formatNotificationUpdatedAt(
     return formatDistanceToNow(parseISO(date), {
       addSuffix: true,
     });
-  } catch (e) {
-    return '';
-  }
+  } catch (e) {}
+
+  return '';
 }
 
 export async function openInBrowser(

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -174,9 +174,13 @@ export function formatNotificationUpdatedAt(
 ): string {
   const date = notification.last_read_at ?? notification.updated_at;
 
-  return formatDistanceToNow(parseISO(date), {
-    addSuffix: true,
-  });
+  try {
+    return formatDistanceToNow(parseISO(date), {
+      addSuffix: true,
+    });
+  } catch (e) {
+    return '';
+  }
 }
 
 export async function openInBrowser(


### PR DESCRIPTION
I'm take a bit of an educated guess, but this should catch any null or split issues with our use of date-fns lib

Fixes: #1166