### PR TITLE
fix: cleanup migration test output

### DIFF
--- a/src/utils/auth/migration.test.ts
+++ b/src/utils/auth/migration.test.ts
@@ -9,6 +9,8 @@ import {
   migrateAuthenticatedAccounts,
 } from './migration';
 
+jest.spyOn(console, 'log').mockImplementation(() => null);
+
 describe('utils/auth/migration.ts', () => {
   beforeEach(() => {
     // axios will default to using the XHR adapter which can't be intercepted
@@ -34,6 +36,7 @@ describe('utils/auth/migration.ts', () => {
       await migrateAuthenticatedAccounts();
 
       expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+      expect(console.log).toHaveBeenCalledTimes(2);
     });
   });
 


### PR DESCRIPTION
Cleaning up another test output:
<img width="547" alt="image" src="https://github.com/gitify-app/gitify/assets/19473034/8ed59065-ce94-4c85-961a-3c62c7c51de7">
