### PR TITLE
fix: tooltip z index to prevent items showing through

### DIFF
--- a/src/components/fields/Tooltip.tsx
+++ b/src/components/fields/Tooltip.tsx
@@ -19,7 +19,7 @@ export const Tooltip: FC<ITooltip> = (props: ITooltip) => {
     >
       <QuestionIcon className="text-blue-500 ml-1" />
       {showTooltip && (
-        <div className="absolute bg-white dark:bg-gray-sidebar border border-gray-300 rounded p-2 shadow">
+        <div className="absolute bg-white dark:bg-gray-sidebar border border-gray-300 rounded p-2 shadow z-10">
           <div className="text-gray-700 dark:text-white text-xs text-left">
             {props.tooltip}
           </div>

--- a/src/components/fields/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/fields/__snapshots__/Tooltip.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`components/fields/Tooltip.tsx should display on mouse enter / leave 1`]
     />
   </svg>
   <div
-    class="absolute bg-white dark:bg-gray-sidebar border border-gray-300 rounded p-2 shadow"
+    class="absolute bg-white dark:bg-gray-sidebar border border-gray-300 rounded p-2 shadow z-10"
   >
     <div
       class="text-gray-700 dark:text-white text-xs text-left"


### PR DESCRIPTION
**Before**
![Screenshot 2024-06-05 at 12 53 38 PM](https://github.com/gitify-app/gitify/assets/386277/7cb6d8bb-dd47-41ed-a8f1-103668a8cbb9)


**After**
![Screenshot 2024-06-05 at 12 53 09 PM](https://github.com/gitify-app/gitify/assets/386277/8e821506-dc22-4339-a0dc-5ae4b2c7640c)
