### PR TITLE
fix: FAQ link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Gitify is licensed under the MIT Open Source license. For more information, see 
 
 <!-- LINK LABELS -->
 [website]: https://www.gitify.io
-[faqs]: https://www.gitify.io/faqs
+[faqs]: https://www.gitify.io/faq/
 [github]: https://github.com/gitify-app/gitify
 [github-actions]: https://github.com/gitify-app/gitify/actions
 [github-releases]: https://github.com/gitify-app/gitify/releases/latest

--- a/package.json
+++ b/package.json
@@ -155,6 +155,6 @@
   },
   "packageManager": "pnpm@9.2.0",
   "lint-staged": {
-    "*.{html,js,json,md,ts,tsx}": "biome format --write"
+    "*.{html,js,json,ts,tsx}": "biome format --write"
   }
 }


### PR DESCRIPTION
### Description
This PR fixes the FAQ link in the README.md file and updates the package.json `lint-staged` script to remove `.md` files.
Biome does not support markdown in its language support list (see here: https://biomejs.dev/internals/language-support/) hence the `lint-stage` script was failing for any change in the `README.md` file.

- Fix FAQ link in README.md
- Remove `.md` from `lint-staged` script
