### PR TITLE
fix: theme state

### DIFF
--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -59,7 +59,7 @@ export const SettingsRoute: FC = () => {
         setTheme(updatedTheme);
       }
     });
-  }, []);
+  }, [settings.theme]);
 
   const quitApp = useCallback(() => {
     ipcRenderer.send('app-quit');


### PR DESCRIPTION
Fix an edge-case bug.

If you changed the theme within the app, and also changed your native system theme, the updates were not consistently being reflected unless you restarted.
