### PR TITLE
refactor: mock openExternalLink comms fn

### DIFF
--- a/src/components/NotificationRow.test.tsx
+++ b/src/components/NotificationRow.test.tsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { shell } from 'electron';
 import { mockAuth, mockSettings } from '../__mocks__/state-mocks';
 import { AppContext } from '../context/App';
 import type { Milestone, UserType } from '../typesGitHub';
 import { mockSingleNotification } from '../utils/api/__mocks__/response-mocks';
+import * as comms from '../utils/comms';
 import * as helpers from '../utils/helpers';
 import { NotificationRow } from './NotificationRow';
 
@@ -460,6 +460,8 @@ describe('components/NotificationRow.tsx', () => {
     });
 
     it('should open notification user profile', () => {
+      const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
+
       const props = {
         notification: {
           ...mockSingleNotification,
@@ -490,8 +492,8 @@ describe('components/NotificationRow.tsx', () => {
       );
 
       fireEvent.click(screen.getByTitle('View User Profile'));
-      expect(shell.openExternal).toHaveBeenCalledTimes(1);
-      expect(shell.openExternal).toHaveBeenCalledWith(
+      expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
+      expect(openExternalLinkMock).toHaveBeenCalledWith(
         props.notification.subject.user.html_url,
       );
     });

--- a/src/components/Repository.test.tsx
+++ b/src/components/Repository.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { shell } from 'electron';
 import { AppContext } from '../context/App';
 import { mockGitHubNotifications } from '../utils/api/__mocks__/response-mocks';
+import * as comms from '../utils/comms';
 import { RepositoryNotifications } from './Repository';
 
 jest.mock('./NotificationRow', () => ({
@@ -20,8 +20,6 @@ describe('components/Repository.tsx', () => {
 
   beforeEach(() => {
     markRepoNotificationsRead.mockReset();
-
-    jest.spyOn(shell, 'openExternal');
   });
 
   it('should render itself & its children', () => {
@@ -34,6 +32,8 @@ describe('components/Repository.tsx', () => {
   });
 
   it('should open the browser when clicking on the repo name', () => {
+    const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
+
     render(
       <AppContext.Provider value={{}}>
         <RepositoryNotifications {...props} />
@@ -42,8 +42,8 @@ describe('components/Repository.tsx', () => {
 
     fireEvent.click(screen.getByText(props.repoName));
 
-    expect(shell.openExternal).toHaveBeenCalledTimes(1);
-    expect(shell.openExternal).toHaveBeenCalledWith(
+    expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
+    expect(openExternalLinkMock).toHaveBeenCalledWith(
       'https://github.com/gitify-app/notifications-test',
     );
   });

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { shell } from 'electron';
 import { MemoryRouter } from 'react-router-dom';
 import { mockAccountNotifications } from '../__mocks__/notifications-mocks';
 import { mockSettings } from '../__mocks__/state-mocks';
@@ -19,7 +18,6 @@ describe('components/Sidebar.tsx', () => {
   beforeEach(() => {
     fetchNotifications.mockReset();
 
-    jest.spyOn(shell, 'openExternal');
     jest.spyOn(window, 'clearInterval');
   });
 
@@ -127,6 +125,8 @@ describe('components/Sidebar.tsx', () => {
   });
 
   it('opens github in the notifications page', () => {
+    const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
+
     render(
       <AppContext.Provider
         value={{
@@ -140,8 +140,8 @@ describe('components/Sidebar.tsx', () => {
       </AppContext.Provider>,
     );
     fireEvent.click(screen.getByLabelText('4 Unread Notifications'));
-    expect(shell.openExternal).toHaveBeenCalledTimes(1);
-    expect(shell.openExternal).toHaveBeenCalledWith(
+    expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
+    expect(openExternalLinkMock).toHaveBeenCalledWith(
       'https://github.com/notifications',
     );
   });
@@ -161,6 +161,8 @@ describe('components/Sidebar.tsx', () => {
   });
 
   it('should open the gitify repository', () => {
+    const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
+
     render(
       <AppContext.Provider value={{ isLoggedIn: false, notifications: [] }}>
         <MemoryRouter>
@@ -169,8 +171,8 @@ describe('components/Sidebar.tsx', () => {
       </AppContext.Provider>,
     );
     fireEvent.click(screen.getByTestId('gitify-logo'));
-    expect(shell.openExternal).toHaveBeenCalledTimes(1);
-    expect(shell.openExternal).toHaveBeenCalledWith(
+    expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
+    expect(openExternalLinkMock).toHaveBeenCalledWith(
       'https://github.com/gitify-app/gitify',
     );
   });

--- a/src/routes/Accounts.test.tsx
+++ b/src/routes/Accounts.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { shell } from 'electron';
 import { MemoryRouter } from 'react-router-dom';
 import {
   mockAuth,
@@ -72,6 +71,8 @@ describe('routes/Accounts.tsx', () => {
 
   describe('Account interactions', () => {
     it('open profile in external browser', async () => {
+      const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
+
       await act(async () => {
         render(
           <AppContext.Provider
@@ -91,13 +92,15 @@ describe('routes/Accounts.tsx', () => {
 
       fireEvent.click(screen.getByTitle('Open Profile'));
 
-      expect(shell.openExternal).toHaveBeenCalledTimes(1);
-      expect(shell.openExternal).toHaveBeenCalledWith(
+      expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
+      expect(openExternalLinkMock).toHaveBeenCalledWith(
         'https://github.com/octocat',
       );
     });
 
     it('open host in external browser', async () => {
+      const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
+
       await act(async () => {
         render(
           <AppContext.Provider
@@ -117,11 +120,13 @@ describe('routes/Accounts.tsx', () => {
 
       fireEvent.click(screen.getByTitle('Open Host'));
 
-      expect(shell.openExternal).toHaveBeenCalledTimes(1);
-      expect(shell.openExternal).toHaveBeenCalledWith('https://github.com');
+      expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
+      expect(openExternalLinkMock).toHaveBeenCalledWith('https://github.com');
     });
 
     it('open developer settings in external browser', async () => {
+      const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
+
       await act(async () => {
         render(
           <AppContext.Provider
@@ -141,8 +146,8 @@ describe('routes/Accounts.tsx', () => {
 
       fireEvent.click(screen.getByTitle('Open Developer Settings'));
 
-      expect(shell.openExternal).toHaveBeenCalledTimes(1);
-      expect(shell.openExternal).toHaveBeenCalledWith(
+      expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
+      expect(openExternalLinkMock).toHaveBeenCalledWith(
         'https://github.com/settings/tokens',
       );
     });

--- a/src/routes/Settings.test.tsx
+++ b/src/routes/Settings.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { shell } from 'electron';
 import { MemoryRouter } from 'react-router-dom';
 import { mockAuth, mockSettings } from '../__mocks__/state-mocks';
 import { mockPlatform } from '../__mocks__/utils';
@@ -201,6 +200,8 @@ describe('routes/Settings.tsx', () => {
     });
 
     it('should open official docs for showOnlyParticipating tooltip', async () => {
+      const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
+
       await act(async () => {
         render(
           <AppContext.Provider
@@ -229,8 +230,8 @@ describe('routes/Settings.tsx', () => {
         ),
       );
 
-      expect(shell.openExternal).toHaveBeenCalledTimes(1);
-      expect(shell.openExternal).toHaveBeenCalledWith(
+      expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
+      expect(openExternalLinkMock).toHaveBeenCalledWith(
         'https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#about-participating-and-watching-notifications',
       );
     });
@@ -481,6 +482,8 @@ describe('routes/Settings.tsx', () => {
 
   describe('Footer section', () => {
     it('should open release notes', async () => {
+      const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
+
       await act(async () => {
         render(
           <AppContext.Provider
@@ -498,8 +501,8 @@ describe('routes/Settings.tsx', () => {
 
       fireEvent.click(screen.getByTitle('View release notes'));
 
-      expect(shell.openExternal).toHaveBeenCalledTimes(1);
-      expect(shell.openExternal).toHaveBeenCalledWith(
+      expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
+      expect(openExternalLinkMock).toHaveBeenCalledWith(
         'https://github.com/gitify-app/gitify/releases/tag/v0.0.1',
       );
     });


### PR DESCRIPTION
Mock openExternalLink comms fn instead of electron shell