### PR TITLE
build(release): remove gh_token env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           APPLEID_TEAM_ID: ${{ secrets.appleid_teamid }}
           CSC_LINK: ${{ secrets.mac_certs }}
           CSC_KEY_PASSWORD: ${{ secrets.mac_certs_password }}
-          GH_TOKEN: ${{ secrets.gh_token }}
+          GITHUB_TOKEN: ${{ secrets.github_token }}
           NOTARIZE: true
       - uses: actions/upload-artifact@v4
         with:
@@ -56,7 +56,7 @@ jobs:
           OAUTH_CLIENT_SECRET: ${{ secrets.oauth_client_secret }}
       - run: pnpm make:win --publish onTagOrDraft
         env:
-          GH_TOKEN: ${{ secrets.gh_token }}
+          GITHUB_TOKEN: ${{ secrets.github_token }}
       - uses: actions/upload-artifact@v4
         with:
           name: Gitify-release-win
@@ -81,7 +81,7 @@ jobs:
           OAUTH_CLIENT_SECRET: ${{ secrets.oauth_client_secret }}
       - run: pnpm make:linux --publish onTagOrDraft
         env:
-          GH_TOKEN: ${{ secrets.gh_token }}
+          GITHUB_TOKEN: ${{ secrets.github_token }}
       - uses: actions/upload-artifact@v4
         with:
           name: Gitify-release-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
           APPLEID_TEAM_ID: ${{ secrets.appleid_teamid }}
           CSC_LINK: ${{ secrets.mac_certs }}
           CSC_KEY_PASSWORD: ${{ secrets.mac_certs_password }}
-          GITHUB_TOKEN: ${{ secrets.github_token }}
           NOTARIZE: true
       - uses: actions/upload-artifact@v4
         with:
@@ -55,8 +54,6 @@ jobs:
           OAUTH_CLIENT_ID: ${{ secrets.oauth_client_id }}
           OAUTH_CLIENT_SECRET: ${{ secrets.oauth_client_secret }}
       - run: pnpm make:win --publish onTagOrDraft
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
       - uses: actions/upload-artifact@v4
         with:
           name: Gitify-release-win
@@ -80,8 +77,6 @@ jobs:
           OAUTH_CLIENT_ID: ${{ secrets.oauth_client_id }}
           OAUTH_CLIENT_SECRET: ${{ secrets.oauth_client_secret }}
       - run: pnpm make:linux --publish onTagOrDraft
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
       - uses: actions/upload-artifact@v4
         with:
           name: Gitify-release-linux


### PR DESCRIPTION
~use default auto provisioned GitHub actions token instead of my custom PAT~

remove gh_token env variable. should use `github_token`