### PR TITLE
feat: only extract linked issues for User PRs

### DIFF
--- a/src/utils/subject.test.ts
+++ b/src/utils/subject.test.ts
@@ -10,6 +10,7 @@ import type {
   DiscussionAuthor,
   DiscussionStateType,
   Notification,
+  PullRequest,
   Repository,
 } from '../typesGitHub';
 import {
@@ -17,7 +18,7 @@ import {
   getGitifySubjectDetails,
   getLatestReviewForReviewers,
   getWorkflowRunAttributes,
-  parseLinkedIssuesFromPrBody,
+  parseLinkedIssuesFromPr,
 } from './subject';
 
 const mockAuthor = partialMockUser('some-author');
@@ -982,13 +983,36 @@ describe('utils/subject.ts', () => {
 
       describe('Pull Request With Linked Issues', () => {
         it('returns empty if no pr body', () => {
-          const result = parseLinkedIssuesFromPrBody(null);
+          const mockPr = {
+            user: {
+              type: 'User',
+            },
+            body: null,
+          } as PullRequest;
+
+          const result = parseLinkedIssuesFromPr(mockPr);
+          expect(result).toEqual([]);
+        });
+
+        it('returns empty if pr from non-user', () => {
+          const mockPr = {
+            user: {
+              type: 'Bot',
+            },
+            body: 'This PR is linked to #1, #2, and #3',
+          } as PullRequest;
+          const result = parseLinkedIssuesFromPr(mockPr);
           expect(result).toEqual([]);
         });
 
         it('returns linked issues', () => {
-          const mockPrBody = 'This PR is linked to #1, #2, and #3';
-          const result = parseLinkedIssuesFromPrBody(mockPrBody);
+          const mockPr = {
+            user: {
+              type: 'User',
+            },
+            body: 'This PR is linked to #1, #2, and #3',
+          } as PullRequest;
+          const result = parseLinkedIssuesFromPr(mockPr);
           expect(result).toEqual(['#1', '#2', '#3']);
         });
       });

--- a/src/utils/subject.ts
+++ b/src/utils/subject.ts
@@ -6,6 +6,7 @@ import type {
   GitifyPullRequestReview,
   GitifySubject,
   Notification,
+  PullRequest,
   PullRequestReview,
   PullRequestStateType,
   SubjectUser,
@@ -267,8 +268,7 @@ async function getGitifySubjectForPullRequest(
   }
 
   const reviews = await getLatestReviewForReviewers(notification);
-  const linkedIssues =
-    pr.user.type === 'User' ? parseLinkedIssuesFromPrBody(pr.body) : [];
+  const linkedIssues = parseLinkedIssuesFromPr(pr);
 
   return {
     state: prState,
@@ -337,16 +337,16 @@ export async function getLatestReviewForReviewers(
   });
 }
 
-export function parseLinkedIssuesFromPrBody(body: string): string[] {
+export function parseLinkedIssuesFromPr(pr: PullRequest): string[] {
   const linkedIssues: string[] = [];
 
-  if (!body) {
+  if (!pr.body || pr.user.type !== 'User') {
     return linkedIssues;
   }
 
   const regexPattern = /\s*#(\d+)\s*/gi;
 
-  const matches = body.matchAll(regexPattern);
+  const matches = pr.body.matchAll(regexPattern);
 
   for (const match of matches) {
     if (match[0]) {

--- a/src/utils/subject.ts
+++ b/src/utils/subject.ts
@@ -267,7 +267,8 @@ async function getGitifySubjectForPullRequest(
   }
 
   const reviews = await getLatestReviewForReviewers(notification);
-  const linkedIssues = parseLinkedIssuesFromPrBody(pr.body);
+  const linkedIssues =
+    pr.user.type === 'User' ? parseLinkedIssuesFromPrBody(pr.body) : [];
 
   return {
     state: prState,


### PR DESCRIPTION
Bot generated PRs (eg: RenovateBot) contain release notes which typically have lots of linked issues.

this PR limits linked issue extraction to those generated by a User