### PR TITLE
refactor: remove deprecated overlay scrollbar option

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,6 @@ const browserWindowOpts = {
   resizable: false,
   webPreferences: {
     enableRemoteModule: true,
-    overlayScrollbars: true,
     nodeIntegration: true,
     contextIsolation: false,
   },


### PR DESCRIPTION
No longer part of https://www.electronjs.org/docs/latest/api/structures/web-preferences

Googling around, seems like it was removed some time ago...