### PR TITLE
fix: revert updated_at formatting

### DIFF
--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -464,16 +464,6 @@ describe('utils/helpers.ts', () => {
     });
 
     describe('formatNotificationUpdatedAt', () => {
-      it('should use last_read_at if available', () => {
-        const notification = {
-          ...mockSingleNotification,
-          last_read_at: '2021-06-23T16:00:00Z',
-          updated_at: '2021-06-23T17:00:00Z',
-        };
-
-        expect(formatNotificationUpdatedAt(notification)).toContain('ago');
-      });
-
       it('should use updated_at if last_read_at is null', () => {
         const notification = {
           ...mockSingleNotification,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -157,10 +157,8 @@ export function formatForDisplay(text: string[]): string {
 export function formatNotificationUpdatedAt(
   notification: Notification,
 ): string {
-  const date = notification.last_read_at ?? notification.updated_at;
-
   try {
-    return formatDistanceToNowStrict(parseISO(date), {
+    return formatDistanceToNowStrict(parseISO(notification.updated_at), {
       addSuffix: true,
     });
   } catch (e) {}


### PR DESCRIPTION
revert the enhancement from https://github.com/gitify-app/gitify/pull/1103 as it was causing some odd behavior for long-running issues/prs getting out of sync and showing the last read date rather than the new updated date