### PR TITLE
feat: set app version as `dev` when building locally

### DIFF
--- a/src/routes/Settings.test.tsx
+++ b/src/routes/Settings.test.tsx
@@ -31,6 +31,11 @@ describe('routes/Settings.tsx', () => {
     Object.defineProperty(process, 'platform', {
       value: originalPlatform,
     });
+
+    // Restore the original node env value
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+    });
   });
 
   describe('General', () => {
@@ -481,6 +486,68 @@ describe('routes/Settings.tsx', () => {
   });
 
   describe('Footer section', () => {
+    describe('app version', () => {
+      let originalEnv: NodeJS.ProcessEnv;
+
+      beforeEach(() => {
+        // Save the original node env state
+        originalEnv = process.env;
+      });
+
+      afterEach(() => {
+        // Restore the original node env state
+        process.env = originalEnv;
+      });
+
+      it('should show production app version', async () => {
+        process.env = {
+          ...originalEnv,
+          NODE_ENV: 'production',
+        };
+
+        await act(async () => {
+          render(
+            <AppContext.Provider
+              value={{
+                auth: mockAuth,
+                settings: mockSettings,
+              }}
+            >
+              <MemoryRouter>
+                <SettingsRoute />
+              </MemoryRouter>
+            </AppContext.Provider>,
+          );
+        });
+
+        expect(screen.getByTitle('app-version')).toMatchSnapshot();
+      });
+
+      it('should show development app version', async () => {
+        process.env = {
+          ...originalEnv,
+          NODE_ENV: 'development',
+        };
+
+        await act(async () => {
+          render(
+            <AppContext.Provider
+              value={{
+                auth: mockAuth,
+                settings: mockSettings,
+              }}
+            >
+              <MemoryRouter>
+                <SettingsRoute />
+              </MemoryRouter>
+            </AppContext.Provider>,
+          );
+        });
+
+        expect(screen.getByTitle('app-version')).toMatchSnapshot();
+      });
+    });
+
     it('should open release notes', async () => {
       const openExternalLinkMock = jest.spyOn(comms, 'openExternalLink');
 

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -38,8 +38,13 @@ export const SettingsRoute: FC = () => {
 
   useEffect(() => {
     (async () => {
-      const result = await getAppVersion();
-      setAppVersion(result);
+      console.log('process.env.NODE_ENV', process.env.NODE_ENV);
+      if (process.env.NODE_ENV === 'development') {
+        setAppVersion('dev');
+      } else {
+        const result = await getAppVersion();
+        setAppVersion(`v${result}`);
+      }
     })();
 
     ipcRenderer.on('gitify:update-theme', (_, updatedTheme: Theme) => {
@@ -283,7 +288,7 @@ export const SettingsRoute: FC = () => {
           title="View release notes"
           onClick={() => openGitifyReleaseNotes(appVersion)}
         >
-          Gitify v{appVersion}
+          <span title="app-version">Gitify {appVersion}</span>
         </button>
         <div>
           <button

--- a/src/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/routes/__snapshots__/Settings.test.tsx.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`routes/Settings.tsx Footer section app version should show development app version 1`] = `
+<span
+  title="app-version"
+>
+  Gitify 
+  dev
+</span>
+`;
+
+exports[`routes/Settings.tsx Footer section app version should show production app version 1`] = `
+<span
+  title="app-version"
+>
+  Gitify 
+  v0.0.1
+</span>
+`;
+
 exports[`routes/Settings.tsx General should render itself & its children 1`] = `
 <div
   class="flex h-screen flex-1 flex-col dark:bg-gray-dark dark:text-white"
@@ -555,8 +573,12 @@ exports[`routes/Settings.tsx General should render itself & its children 1`] = `
       title="View release notes"
       type="button"
     >
-      Gitify v
-      0.0.1
+      <span
+        title="app-version"
+      >
+        Gitify 
+        v0.0.1
+      </span>
     </button>
     <div>
       <button

--- a/src/utils/links.test.ts
+++ b/src/utils/links.test.ts
@@ -37,7 +37,7 @@ describe('utils/links.ts', () => {
   });
 
   it('openGitifyReleaseNotes', () => {
-    openGitifyReleaseNotes('1.0.0');
+    openGitifyReleaseNotes('v1.0.0');
     expect(comms.openExternalLink).toHaveBeenCalledWith(
       'https://github.com/gitify-app/gitify/releases/tag/v1.0.0',
     );

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -11,7 +11,7 @@ export function openGitifyRepository() {
 
 export function openGitifyReleaseNotes(version: string) {
   openExternalLink(
-    `https://github.com/${Constants.REPO_SLUG}/releases/tag/v${version}` as Link,
+    `https://github.com/${Constants.REPO_SLUG}/releases/tag/${version}` as Link,
   );
 }
 


### PR DESCRIPTION
A small enhancement to help when doing local development remember which version of the app is running 😎 

![Screenshot 2024-06-14 at 9 39 24 AM](https://github.com/gitify-app/gitify/assets/386277/b902c7a2-850b-42b7-9938-796e00fcc108)
