### PR TITLE
fix: regression in all read ui

### DIFF
--- a/src/components/AllRead.tsx
+++ b/src/components/AllRead.tsx
@@ -11,7 +11,7 @@ export const AllRead = () => {
   );
 
   return (
-    <div className="flex flex-col items-center justify-center bg-white p-4 text-black dark:bg-gray-dark dark:text-white">
+    <div className="flex flex-1 flex-col items-center justify-center bg-white p-4 text-black dark:bg-gray-dark dark:text-white">
       <h1 className="mb-5 text-5xl">{emoji}</h1>
 
       <h2 className="mb-2 text-xl font-semibold">No new notifications.</h2>

--- a/src/components/__snapshots__/AllRead.test.tsx.snap
+++ b/src/components/__snapshots__/AllRead.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`components/AllRead.tsx should render itself & its children 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="flex flex-col items-center justify-center bg-white p-4 text-black dark:bg-gray-dark dark:text-white"
+        class="flex flex-1 flex-col items-center justify-center bg-white p-4 text-black dark:bg-gray-dark dark:text-white"
       >
         <h1
           class="mb-5 text-5xl"
@@ -23,7 +23,7 @@ exports[`components/AllRead.tsx should render itself & its children 1`] = `
   </body>,
   "container": <div>
     <div
-      class="flex flex-col items-center justify-center bg-white p-4 text-black dark:bg-gray-dark dark:text-white"
+      class="flex flex-1 flex-col items-center justify-center bg-white p-4 text-black dark:bg-gray-dark dark:text-white"
     >
       <h1
         class="mb-5 text-5xl"


### PR DESCRIPTION
fix regression from #1238 for AllRead UI not being vertically centered