### PR TITLE
build: use macos-latest runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-macos:
     name: Build macOS (electron-builder)
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release-macos:
     name: Publish macOS (electron-builder)
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-unit-tests:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Update to use `macos-latest` tag now that it's equal to `macos-14` now

Also update our tests workflow to run on macos instead of ubuntu, since the maintainer group are all macos users.