### PR TITLE
fix: patch menubar for windows position

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,5 +155,10 @@
   "packageManager": "pnpm@9.3.0",
   "lint-staged": {
     "*.{html,js,json,ts,tsx}": "biome format --fix"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "menubar@9.4.0": "patches/menubar@9.4.0.patch"
+    }
   }
 }

--- a/patches/menubar@9.4.0.patch
+++ b/patches/menubar@9.4.0.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/util/getWindowPosition.js b/lib/util/getWindowPosition.js
+index ea754091aeeb953db8a439a609f047ddf65b7cfc..00c21a8538530c4ea8e502a8c0efa1c9b5fbc78c 100644
+--- a/lib/util/getWindowPosition.js
++++ b/lib/util/getWindowPosition.js
+@@ -72,7 +72,7 @@ function getWindowPosition(tray) {
+                 return isLinux ? 'topRight' : 'trayCenter';
+             }
+             if (traySide === 'bottom') {
+-                return isLinux ? 'bottomRight' : 'trayBottomCenter';
++                return 'trayBottomCenter';
+             }
+             if (traySide === 'left') {
+                 return 'bottomLeft';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  menubar@9.4.0:
+    hash: tg6p5suscg27k4ubqfjwk3f7uu
+    path: patches/menubar@9.4.0.patch
+
 importers:
 
   .:
@@ -31,7 +36,7 @@ importers:
         version: 4.20.10
       menubar:
         specifier: 9.4.0
-        version: 9.4.0(electron@31.0.1)
+        version: 9.4.0(patch_hash=tg6p5suscg27k4ubqfjwk3f7uu)(electron@31.0.1)
       nprogress:
         specifier: 0.2.0
         version: 0.2.0
@@ -5662,7 +5667,7 @@ snapshots:
       escape-string-regexp: 4.0.0
     optional: true
 
-  menubar@9.4.0(electron@31.0.1):
+  menubar@9.4.0(patch_hash=tg6p5suscg27k4ubqfjwk3f7uu)(electron@31.0.1):
     dependencies:
       electron: 31.0.1
       electron-positioner: 4.1.0


### PR DESCRIPTION
Fixes #1162


Upstream fix raised @ https://github.com/max-mapper/menubar/pull/479.  Once released, we can remove the menubar@9.4.0 patch