### PR TITLE
ci: run staged files' tests only

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
 pnpx lint-staged
-pnpm test

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,11 +5,6 @@ const config: Config = {
   setupFiles: ['<rootDir>/src/__helpers__/setupEnvVars.js'],
   testEnvironment: 'jsdom',
   collectCoverage: true,
-  coverageThreshold: {
-    global: {
-      lines: 90,
-    },
-  },
   moduleNameMapper: {
     // Force CommonJS build for http adapter to be available.
     // via https://github.com/axios/axios/issues/5101#issuecomment-1276572468

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
   },
   "packageManager": "pnpm@9.5.0",
   "lint-staged": {
-    "*.{js,json,ts,tsx}": "biome format --fix"
+    "*.{js,json,ts,tsx}": "biome format --fix",
+    "*.{js,ts,tsx}": "pnpm test -- --onlyChanged -u --passWithNoTests"
   }
 }


### PR DESCRIPTION
Running all tests (before each commit) just takes way too long 😢 
However, this interferes with the coverage threshold, which should be fine since we still have coveralls on a per PR basis.