### PR TITLE
build(husky): restore pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpx lint-staged


### PR DESCRIPTION
restore husky pre-commit that was accidentally removed in https://github.com/gitify-app/gitify/pull/1349