### PR TITLE
feat: mark notification as read to allow transition effects time

### DIFF
--- a/src/components/NotificationRow.test.tsx
+++ b/src/components/NotificationRow.test.tsx
@@ -82,7 +82,7 @@ describe('components/NotificationRow.tsx', () => {
 
   describe('notification interactions', () => {
     it('should open a notification in the browser - click', () => {
-      const removeNotificationFromState = jest.fn();
+      const markNotificationRead = jest.fn();
 
       const props = {
         notification: mockSingleNotification,
@@ -93,7 +93,7 @@ describe('components/NotificationRow.tsx', () => {
         <AppContext.Provider
           value={{
             settings: { ...mockSettings, markAsDoneOnOpen: false },
-            removeNotificationFromState,
+            markNotificationRead,
             auth: mockAuth,
           }}
         >
@@ -103,11 +103,11 @@ describe('components/NotificationRow.tsx', () => {
 
       fireEvent.click(screen.getByRole('main'));
       expect(links.openNotification).toHaveBeenCalledTimes(1);
-      expect(removeNotificationFromState).toHaveBeenCalledTimes(1);
+      expect(markNotificationRead).toHaveBeenCalledTimes(1);
     });
 
     it('should open a notification in the browser - delay notification setting enabled', () => {
-      const removeNotificationFromState = jest.fn();
+      const markNotificationRead = jest.fn();
 
       const props = {
         notification: mockSingleNotification,
@@ -122,7 +122,7 @@ describe('components/NotificationRow.tsx', () => {
               markAsDoneOnOpen: false,
               delayNotificationState: true,
             },
-            removeNotificationFromState,
+            markNotificationRead,
             auth: mockAuth,
           }}
         >
@@ -132,11 +132,11 @@ describe('components/NotificationRow.tsx', () => {
 
       fireEvent.click(screen.getByRole('main'));
       expect(links.openNotification).toHaveBeenCalledTimes(1);
-      expect(removeNotificationFromState).toHaveBeenCalledTimes(1);
+      expect(markNotificationRead).toHaveBeenCalledTimes(1);
     });
 
     it('should open a notification in the browser - key down', () => {
-      const removeNotificationFromState = jest.fn();
+      const markNotificationRead = jest.fn();
 
       const props = {
         notification: mockSingleNotification,
@@ -147,7 +147,7 @@ describe('components/NotificationRow.tsx', () => {
         <AppContext.Provider
           value={{
             settings: { ...mockSettings, markAsDoneOnOpen: false },
-            removeNotificationFromState,
+            markNotificationRead,
             auth: mockAuth,
           }}
         >
@@ -157,7 +157,7 @@ describe('components/NotificationRow.tsx', () => {
 
       fireEvent.click(screen.getByRole('main'));
       expect(links.openNotification).toHaveBeenCalledTimes(1);
-      expect(removeNotificationFromState).toHaveBeenCalledTimes(1);
+      expect(markNotificationRead).toHaveBeenCalledTimes(1);
     });
 
     it('should open a notification in browser & mark it as done', () => {

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -32,7 +32,6 @@ export const NotificationRow: FC<INotificationRow> = ({
 }: INotificationRow) => {
   const {
     settings,
-    removeNotificationFromState,
     markNotificationRead,
     markNotificationDone,
     unsubscribeNotification,
@@ -49,15 +48,9 @@ export const NotificationRow: FC<INotificationRow> = ({
     if (settings.markAsDoneOnOpen) {
       markNotificationDone(notification);
     } else {
-      // no need to mark as read, github does it by default when opening it
-      removeNotificationFromState(settings, notification);
+      markNotificationRead(notification);
     }
-  }, [
-    notification,
-    markNotificationDone,
-    removeNotificationFromState,
-    settings,
-  ]);
+  }, [notification, markNotificationDone, markNotificationRead, settings]);
 
   const unsubscribeFromThread = (event: MouseEvent<HTMLElement>) => {
     // Don't trigger onClick of parent element.


### PR DESCRIPTION
Currently, there is no delay to allow the transition effect time to perform.  Switching back to an explicit "mark as read" buys us some time and now displays the notification transition effect