### PR TITLE
refactor: rename isEnterpriseHost helper

### DIFF
--- a/src/utils/api/utils.ts
+++ b/src/utils/api/utils.ts
@@ -1,11 +1,11 @@
 import type { Hostname } from '../../types';
 import Constants from '../constants';
-import { isEnterpriseHost } from '../helpers';
+import { isEnterpriseServerHost } from '../helpers';
 
 export function getGitHubAPIBaseUrl(hostname: Hostname): URL {
   const url = new URL(Constants.GITHUB_API_BASE_URL);
 
-  if (isEnterpriseHost(hostname)) {
+  if (isEnterpriseServerHost(hostname)) {
     url.hostname = hostname;
     url.pathname = '/api/v3/';
   }
@@ -15,7 +15,7 @@ export function getGitHubAPIBaseUrl(hostname: Hostname): URL {
 export function getGitHubGraphQLUrl(hostname: Hostname): URL {
   const url = new URL(Constants.GITHUB_API_GRAPHQL_URL);
 
-  if (isEnterpriseHost(hostname)) {
+  if (isEnterpriseServerHost(hostname)) {
     url.hostname = hostname;
     url.pathname = '/api/graphql';
   }

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -16,7 +16,7 @@ import {
   generateNotificationReferrerId,
   getFilterCount,
   getPlatformFromHostname,
-  isEnterpriseHost,
+  isEnterpriseServerHost,
 } from './helpers';
 
 describe('utils/helpers.ts', () => {
@@ -40,15 +40,19 @@ describe('utils/helpers.ts', () => {
     });
   });
 
-  describe('isEnterpriseHost', () => {
+  describe('isEnterpriseServerHost', () => {
     it('should return true for enterprise host', () => {
-      expect(isEnterpriseHost('github.gitify.app' as Hostname)).toBe(true);
-      expect(isEnterpriseHost('api.github.gitify.app' as Hostname)).toBe(true);
+      expect(isEnterpriseServerHost('github.gitify.app' as Hostname)).toBe(
+        true,
+      );
+      expect(isEnterpriseServerHost('api.github.gitify.app' as Hostname)).toBe(
+        true,
+      );
     });
 
     it('should return false for non-enterprise host', () => {
-      expect(isEnterpriseHost('github.com' as Hostname)).toBe(false);
-      expect(isEnterpriseHost('api.github.com' as Hostname)).toBe(false);
+      expect(isEnterpriseServerHost('github.com' as Hostname)).toBe(false);
+      expect(isEnterpriseServerHost('api.github.com' as Hostname)).toBe(false);
     });
   });
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -17,7 +17,7 @@ export function getPlatformFromHostname(hostname: string): PlatformType {
     : 'GitHub Enterprise Server';
 }
 
-export function isEnterpriseHost(hostname: Hostname): boolean {
+export function isEnterpriseServerHost(hostname: Hostname): boolean {
   return !hostname.endsWith(Constants.DEFAULT_AUTH_OPTIONS.hostname);
 }
 


### PR DESCRIPTION
Clarify helper is for checking if a hostname is for GitHub Enterprise Server, rather than GitHub Cloud (free, enterprise, etc)