### PR TITLE
feat: add conditional render on "Mark as Done" Btn

### DIFF
--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -10,7 +10,7 @@ import { AppContext } from '../context/App';
 import { Opacity, Size } from '../types';
 import type { Notification } from '../typesGitHub';
 import { cn } from '../utils/cn';
-import { formatForDisplay } from '../utils/helpers';
+import { formatForDisplay, isEnterpriseServerHost } from '../utils/helpers';
 import {
   getNotificationTypeIcon,
   getNotificationTypeIconColor,
@@ -125,16 +125,18 @@ export const NotificationRow: FC<INotificationRow> = ({
       </div>
 
       <HoverGroup>
-        <InteractionButton
-          title="Mark as Done"
-          icon={CheckIcon}
-          size={Size.MEDIUM}
-          onClick={() => {
-            setAnimateExit(!settings.delayNotificationState);
-            setShowAsRead(settings.delayNotificationState);
-            markNotificationDone(notification);
-          }}
-        />
+        {!isEnterpriseServerHost(notification.account.hostname) && (
+          <InteractionButton
+            title="Mark as Done"
+            icon={CheckIcon}
+            size={Size.MEDIUM}
+            onClick={() => {
+              setAnimateExit(!settings.delayNotificationState);
+              setShowAsRead(settings.delayNotificationState);
+              markNotificationDone(notification);
+            }}
+          />
+        )}
         <InteractionButton
           title="Mark as Read"
           icon={ReadIcon}

--- a/src/components/NotificationRow.tsx
+++ b/src/components/NotificationRow.tsx
@@ -47,7 +47,10 @@ export const NotificationRow: FC<INotificationRow> = ({
 
     openNotification(notification);
 
-    if (settings.markAsDoneOnOpen) {
+    if (
+      settings.markAsDoneOnOpen &&
+      !isEnterpriseServerHost(notification.account.hostname)
+    ) {
       markNotificationDone(notification);
     } else {
       markNotificationRead(notification);
@@ -105,7 +108,7 @@ export const NotificationRow: FC<INotificationRow> = ({
         <NotificationHeader notification={notification} />
 
         <div
-          className="flex gap-1 items-center mb-1 truncate text-sm"
+          className="flex items-center gap-1 mb-1 text-sm truncate"
           role="main"
           title={notificationTitle}
         >

--- a/src/components/RepositoryNotifications.tsx
+++ b/src/components/RepositoryNotifications.tsx
@@ -10,6 +10,7 @@ import { AppContext } from '../context/App';
 import { Opacity, Size } from '../types';
 import type { Notification } from '../typesGitHub';
 import { cn } from '../utils/cn';
+import { isEnterpriseServerHost } from '../utils/helpers';
 import { openRepository } from '../utils/links';
 import { HoverGroup } from './HoverGroup';
 import { NotificationRow } from './NotificationRow';
@@ -79,18 +80,20 @@ export const RepositoryNotifications: FC<IRepositoryNotifications> = ({
         </div>
 
         <HoverGroup>
-          <InteractionButton
-            title="Mark Repository as Done"
-            icon={CheckIcon}
-            size={Size.MEDIUM}
-            onClick={(event: MouseEvent<HTMLElement>) => {
-              // Don't trigger onClick of parent element.
-              event.stopPropagation();
-              setAnimateExit(!settings.delayNotificationState);
-              setShowAsRead(settings.delayNotificationState);
-              markRepoNotificationsDone(repoNotifications[0]);
-            }}
-          />
+          {!isEnterpriseServerHost(repoNotifications[0].account.hostname) && (
+            <InteractionButton
+              title="Mark Repository as Done"
+              icon={CheckIcon}
+              size={Size.MEDIUM}
+              onClick={(event: MouseEvent<HTMLElement>) => {
+                // Don't trigger onClick of parent element.
+                event.stopPropagation();
+                setAnimateExit(!settings.delayNotificationState);
+                setShowAsRead(settings.delayNotificationState);
+                markRepoNotificationsDone(repoNotifications[0]);
+              }}
+            />
+          )}
           <InteractionButton
             title="Mark Repository as Read"
             icon={ReadIcon}


### PR DESCRIPTION
Entreprise API doesn't provide "Mark as Done". So i have done this PR to remove "Mark as Done" Btns.
closes : https://github.com/gitify-app/gitify/issues/1412