### PR TITLE
feat(accounts): set primary account

### DIFF
--- a/src/routes/Accounts.tsx
+++ b/src/routes/Accounts.tsx
@@ -3,6 +3,8 @@ import {
   PersonIcon,
   PlusIcon,
   SignOutIcon,
+  StarFillIcon,
+  StarIcon,
 } from '@primer/octicons-react';
 
 import { type FC, useCallback, useContext } from 'react';
@@ -12,17 +14,19 @@ import { AuthMethodIcon } from '../components/icons/AuthMethodIcon';
 import { PlatformIcon } from '../components/icons/PlatformIcon';
 import { AppContext } from '../context/App';
 import { BUTTON_CLASS_NAME } from '../styles/gitify';
-import { type Account, Size } from '../types';
+import { type Account, IconColor, Size } from '../types';
 import { getAccountUUID } from '../utils/auth/utils';
+import { cn } from '../utils/cn';
 import { updateTrayIcon, updateTrayTitle } from '../utils/comms';
 import {
   openAccountProfile,
   openDeveloperSettings,
   openHost,
 } from '../utils/links';
+import { saveState } from '../utils/storage';
 
 export const AccountsRoute: FC = () => {
-  const { auth, logoutFromAccount } = useContext(AppContext);
+  const { auth, settings, logoutFromAccount } = useContext(AppContext);
   const navigate = useNavigate();
 
   const logoutAccount = useCallback(
@@ -34,6 +38,12 @@ export const AccountsRoute: FC = () => {
     },
     [logoutFromAccount],
   );
+
+  const setAsPrimaryAccount = useCallback((account: Account) => {
+    auth.accounts = [account, ...auth.accounts.filter((a) => a !== account)];
+    saveState({ auth, settings });
+    navigate('/accounts', { replace: true });
+  }, []);
 
   const loginWithPersonalAccessToken = useCallback(() => {
     return navigate('/login-personal-access-token', { replace: true });
@@ -48,7 +58,7 @@ export const AccountsRoute: FC = () => {
       <Header icon={PersonIcon}>Accounts</Header>
       <div className="flex-grow overflow-x-auto px-8">
         <div className="mt-4 flex flex-col text-sm">
-          {auth.accounts.map((account) => (
+          {auth.accounts.map((account, i) => (
             <div
               key={getAccountUUID(account)}
               className="mb-4 flex items-center justify-between rounded-md bg-gray-100 p-2 dark:bg-gray-sidebar"
@@ -94,6 +104,31 @@ export const AccountsRoute: FC = () => {
                 </div>
               </div>
               <div>
+                <button
+                  type="button"
+                  className={cn(BUTTON_CLASS_NAME, 'cursor-default')}
+                  title="Primary account"
+                  hidden={i !== 0}
+                >
+                  <StarFillIcon
+                    size={Size.XLARGE}
+                    className={IconColor.YELLOW}
+                    aria-label="Primary account"
+                  />
+                </button>
+                <button
+                  type="button"
+                  className={BUTTON_CLASS_NAME}
+                  title="Set as primary account"
+                  onClick={() => setAsPrimaryAccount(account)}
+                  hidden={i === 0}
+                >
+                  <StarIcon
+                    size={Size.XLARGE}
+                    className={IconColor.YELLOW}
+                    aria-label="Set as primary account"
+                  />
+                </button>
                 <button
                   type="button"
                   className={BUTTON_CLASS_NAME}

--- a/src/routes/__snapshots__/Accounts.test.tsx.snap
+++ b/src/routes/__snapshots__/Accounts.test.tsx.snap
@@ -143,6 +143,49 @@ exports[`routes/Accounts.tsx General should render itself & its children 1`] = `
         </div>
         <div>
           <button
+            class="hover:text-gray-500 py-1 px-2 my-1 mx-2 focus:outline-none cursor-default"
+            title="Primary account"
+            type="button"
+          >
+            <svg
+              aria-label="Primary account"
+              class="text-yellow-500 dark:text-yellow-300"
+              fill="currentColor"
+              focusable="false"
+              height="20"
+              role="img"
+              style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+              viewBox="0 0 16 16"
+              width="20"
+            >
+              <path
+                d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
+              />
+            </svg>
+          </button>
+          <button
+            class="hover:text-gray-500 py-1 px-2 my-1 mx-2 focus:outline-none"
+            hidden=""
+            title="Set as primary account"
+            type="button"
+          >
+            <svg
+              aria-label="Set as primary account"
+              class="text-yellow-500 dark:text-yellow-300"
+              fill="currentColor"
+              focusable="false"
+              height="20"
+              role="img"
+              style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+              viewBox="0 0 16 16"
+              width="20"
+            >
+              <path
+                d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z"
+              />
+            </svg>
+          </button>
+          <button
             class="hover:text-gray-500 py-1 px-2 my-1 mx-2 focus:outline-none"
             title="Logout octocat"
             type="button"
@@ -248,6 +291,49 @@ exports[`routes/Accounts.tsx General should render itself & its children 1`] = `
         </div>
         <div>
           <button
+            class="hover:text-gray-500 py-1 px-2 my-1 mx-2 focus:outline-none cursor-default"
+            hidden=""
+            title="Primary account"
+            type="button"
+          >
+            <svg
+              aria-label="Primary account"
+              class="text-yellow-500 dark:text-yellow-300"
+              fill="currentColor"
+              focusable="false"
+              height="20"
+              role="img"
+              style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+              viewBox="0 0 16 16"
+              width="20"
+            >
+              <path
+                d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
+              />
+            </svg>
+          </button>
+          <button
+            class="hover:text-gray-500 py-1 px-2 my-1 mx-2 focus:outline-none"
+            title="Set as primary account"
+            type="button"
+          >
+            <svg
+              aria-label="Set as primary account"
+              class="text-yellow-500 dark:text-yellow-300"
+              fill="currentColor"
+              focusable="false"
+              height="20"
+              role="img"
+              style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+              viewBox="0 0 16 16"
+              width="20"
+            >
+              <path
+                d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z"
+              />
+            </svg>
+          </button>
+          <button
             class="hover:text-gray-500 py-1 px-2 my-1 mx-2 focus:outline-none"
             title="Logout octocat"
             type="button"
@@ -352,6 +438,49 @@ exports[`routes/Accounts.tsx General should render itself & its children 1`] = `
           </div>
         </div>
         <div>
+          <button
+            class="hover:text-gray-500 py-1 px-2 my-1 mx-2 focus:outline-none cursor-default"
+            hidden=""
+            title="Primary account"
+            type="button"
+          >
+            <svg
+              aria-label="Primary account"
+              class="text-yellow-500 dark:text-yellow-300"
+              fill="currentColor"
+              focusable="false"
+              height="20"
+              role="img"
+              style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+              viewBox="0 0 16 16"
+              width="20"
+            >
+              <path
+                d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
+              />
+            </svg>
+          </button>
+          <button
+            class="hover:text-gray-500 py-1 px-2 my-1 mx-2 focus:outline-none"
+            title="Set as primary account"
+            type="button"
+          >
+            <svg
+              aria-label="Set as primary account"
+              class="text-yellow-500 dark:text-yellow-300"
+              fill="currentColor"
+              focusable="false"
+              height="20"
+              role="img"
+              style="display: inline-block; user-select: none; vertical-align: text-bottom; overflow: visible;"
+              viewBox="0 0 16 16"
+              width="20"
+            >
+              <path
+                d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z"
+              />
+            </svg>
+          </button>
           <button
             class="hover:text-gray-500 py-1 px-2 my-1 mx-2 focus:outline-none"
             title="Logout octocat"


### PR DESCRIPTION
Simple implementation to set the "primary account" (ie: first account), which is used for defining the hostname to use in the sidebar quick links

![2024-08-05T17-48-51 006Z-gitify-screenshot](https://github.com/user-attachments/assets/d6698422-9441-436c-a50f-482d7e2d5ef5)
