### PR TITLE
fix: openLinks on first login screen

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -46,7 +46,7 @@ import { clearState, loadState, saveState } from '../utils/storage';
 import { setTheme } from '../utils/theme';
 import { zoomPercentageToLevel } from '../utils/zoom';
 
-const defaultAuth: AuthState = {
+export const defaultAuth: AuthState = {
   accounts: [],
   token: null,
   enterpriseAccounts: [],
@@ -268,11 +268,6 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     )) {
       const res = await headNotifications(account.hostname, account.token);
       account.version = res.headers['x-github-enterprise-version'];
-    }
-
-    if (!(existing.auth || existing.settings)) {
-      setSettings(defaultSettings);
-      saveState({ auth: defaultAuth, settings: defaultSettings });
     }
   }, []);
 

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -269,6 +269,11 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       const res = await headNotifications(account.hostname, account.token);
       account.version = res.headers['x-github-enterprise-version'];
     }
+
+    if (!(existing.auth || existing.settings)) {
+      setSettings(defaultSettings);
+      saveState({ auth: defaultAuth, settings: defaultSettings });
+    }
   }, []);
 
   const fetchNotificationsWithAccounts = useCallback(

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,9 +1,13 @@
+import { defaultAuth, defaultSettings } from '../context/App';
 import type { GitifyState } from '../types';
 import { Constants } from './constants';
 
 export function loadState(): GitifyState {
   const existing = localStorage.getItem(Constants.STORAGE_KEY);
-  const { auth, settings } = (existing && JSON.parse(existing)) || {};
+  const { auth, settings } = (existing && JSON.parse(existing)) || {
+    auth: defaultAuth,
+    settings: defaultSettings,
+  };
   return { auth, settings };
 }
 


### PR DESCRIPTION
There was a bug that the "Create new OAuth App" button did not respond when pressing it to login again after deleting data.

This happens because loadState() is executed when opening the link, but once the data is deleted, localStorage becomes empty and loadState() returns null.
So I fixed this bug by saving the defalut states (defaultAuth and defaultSettings) when localStorage is empty.


After starting the app with `pnpm start` and then pressing the "Create new OAuth App" button, the error displayed was as follows
```
[44950:0809/151522.895514:INFO:CONSOLE(2)] "Uncaught TypeError: Cannot read properties of undefined (reading 'openLinks')", source: file:///Users/shiron/projects/gitify/build/js/app.js (2)
```
