### PR TITLE
fix: remove account notifications on logout

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -86,7 +86,7 @@ export const Sidebar: FC = () => {
 
         <SidebarButton
           title={`${notificationsCount} Unread Notifications`}
-          metric={notificationsCount}
+          metric={isLoggedIn ? notificationsCount : null}
           icon={BellIcon}
           onClick={() => openGitHubNotifications(primaryAccountHostname)}
         />

--- a/src/components/__snapshots__/Sidebar.test.tsx.snap
+++ b/src/components/__snapshots__/Sidebar.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
             </svg>
           </button>
           <button
-            class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-green-500 hover:text-green-700 py-1"
+            class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-white hover:text-gray-500 py-1"
             title="4 Unread Notifications"
             type="button"
           >
@@ -82,7 +82,6 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
                 d="M8 16a2 2 0 0 0 1.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 0 0 8 16ZM3 5a5 5 0 0 1 10 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.519 1.519 0 0 1 13.482 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947Zm5-3.5A3.5 3.5 0 0 0 4.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01l.001.006c0 .002.002.004.004.006l.006.004.007.001h10.964l.007-.001.006-.004.004-.006.001-.007a.017.017 0 0 0-.003-.01l-1.703-2.554a1.745 1.745 0 0 1-.294-.97V5A3.5 3.5 0 0 0 8 1.5Z"
               />
             </svg>
-            4
           </button>
           <button
             class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-white hover:text-gray-500 py-1"
@@ -217,7 +216,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
           </svg>
         </button>
         <button
-          class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-green-500 hover:text-green-700 py-1"
+          class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-white hover:text-gray-500 py-1"
           title="4 Unread Notifications"
           type="button"
         >
@@ -236,7 +235,6 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
               d="M8 16a2 2 0 0 0 1.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 0 0 8 16ZM3 5a5 5 0 0 1 10 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.519 1.519 0 0 1 13.482 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947Zm5-3.5A3.5 3.5 0 0 0 4.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01l.001.006c0 .002.002.004.004.006l.006.004.007.001h10.964l.007-.001.006-.004.004-.006.001-.007a.017.017 0 0 0-.003-.01l-1.703-2.554a1.745 1.745 0 0 1-.294-.97V5A3.5 3.5 0 0 0 8 1.5Z"
             />
           </svg>
-          4
         </button>
         <button
           class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-white hover:text-gray-500 py-1"
@@ -428,7 +426,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
             </svg>
           </button>
           <button
-            class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-green-500 hover:text-green-700 py-1"
+            class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-white hover:text-gray-500 py-1"
             title="4 Unread Notifications"
             type="button"
           >
@@ -447,7 +445,6 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
                 d="M8 16a2 2 0 0 0 1.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 0 0 8 16ZM3 5a5 5 0 0 1 10 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.519 1.519 0 0 1 13.482 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947Zm5-3.5A3.5 3.5 0 0 0 4.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01l.001.006c0 .002.002.004.004.006l.006.004.007.001h10.964l.007-.001.006-.004.004-.006.001-.007a.017.017 0 0 0-.003-.01l-1.703-2.554a1.745 1.745 0 0 1-.294-.97V5A3.5 3.5 0 0 0 8 1.5Z"
               />
             </svg>
-            4
           </button>
           <button
             class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-white hover:text-gray-500 py-1"
@@ -582,7 +579,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
           </svg>
         </button>
         <button
-          class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-green-500 hover:text-green-700 py-1"
+          class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-white hover:text-gray-500 py-1"
           title="4 Unread Notifications"
           type="button"
         >
@@ -601,7 +598,6 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
               d="M8 16a2 2 0 0 0 1.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 0 0 8 16ZM3 5a5 5 0 0 1 10 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.519 1.519 0 0 1 13.482 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947Zm5-3.5A3.5 3.5 0 0 0 4.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01l.001.006c0 .002.002.004.004.006l.006.004.007.001h10.964l.007-.001.006-.004.004-.006.001-.007a.017.017 0 0 0-.003-.01l-1.703-2.554a1.745 1.745 0 0 1-.294-.97V5A3.5 3.5 0 0 0 8 1.5Z"
             />
           </svg>
-          4
         </button>
         <button
           class="flex justify-evenly items-center w-full my-1 cursor-pointer text-xs font-extrabold focus:outline-none disabled:text-gray-500 disabled:cursor-default text-white hover:text-gray-500 py-1"

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -245,7 +245,6 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       removeAccountNotifications(account);
 
       // Remove from auth state
-
       const updatedAuth = removeAccount(auth, account);
       setAuth(updatedAuth);
       saveState({ auth: updatedAuth, settings });

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -101,6 +101,7 @@ interface AppContextState {
   notifications: AccountNotifications[];
   status: Status;
   globalError: GitifyError;
+  removeAccountNotifications: (account: Account) => Promise<void>;
   fetchNotifications: () => Promise<void>;
   markNotificationRead: (notification: Notification) => Promise<void>;
   markNotificationDone: (notification: Notification) => Promise<void>;
@@ -120,6 +121,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   const [auth, setAuth] = useState<AuthState>(defaultAuth);
   const [settings, setSettings] = useState<SettingsState>(defaultSettings);
   const {
+    removeAccountNotifications,
     fetchNotifications,
     notifications,
     globalError,
@@ -130,7 +132,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     markRepoNotificationsRead,
     markRepoNotificationsDone,
   } = useNotifications();
-
+  getNotificationCount;
   useEffect(() => {
     restoreSettings();
   }, []);
@@ -239,6 +241,11 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const logoutFromAccount = useCallback(
     async (account: Account) => {
+      // Remove notifications for account
+      removeAccountNotifications(account);
+
+      // Remove from auth state
+
       const updatedAuth = removeAccount(auth, account);
       setAuth(updatedAuth);
       saveState({ auth: updatedAuth, settings });

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import type {
+  Account,
   AccountNotifications,
   GitifyError,
   GitifyState,
@@ -24,6 +25,7 @@ import { removeNotifications } from '../utils/remove-notifications';
 
 interface NotificationsState {
   notifications: AccountNotifications[];
+  removeAccountNotifications: (account: Account) => Promise<void>;
   fetchNotifications: (state: GitifyState) => Promise<void>;
   markNotificationRead: (
     state: GitifyState,
@@ -55,6 +57,21 @@ export const useNotifications = (): NotificationsState => {
 
   const [notifications, setNotifications] = useState<AccountNotifications[]>(
     [],
+  );
+
+  const removeAccountNotifications = useCallback(
+    async (account: Account) => {
+      setStatus('loading');
+
+      const updatedNotifications = notifications.filter(
+        (notification) => notification.account !== account,
+      );
+
+      setNotifications(updatedNotifications);
+      setTrayIconColor(updatedNotifications);
+      setStatus('success');
+    },
+    [notifications],
   );
 
   const fetchNotifications = useCallback(
@@ -243,6 +260,7 @@ export const useNotifications = (): NotificationsState => {
     globalError,
     notifications,
 
+    removeAccountNotifications,
     fetchNotifications,
     markNotificationRead,
     markNotificationDone,


### PR DESCRIPTION
Upon logging out, notification counts metrics were still being shown in the Sidebar.

This PR ensures the upon logout the account is removed from account notifications state