### PR TITLE
refactor: extract error constants

### DIFF
--- a/src/__mocks__/partial-mocks.ts
+++ b/src/__mocks__/partial-mocks.ts
@@ -1,6 +1,6 @@
 import type { Hostname, Link } from '../types';
 import type { Notification, Subject, User } from '../typesGitHub';
-import Constants from '../utils/constants';
+import { Constants } from '../utils/constants';
 import { mockGitifyUser, mockToken } from './state-mocks';
 
 export function partialMockNotification(

--- a/src/__mocks__/state-mocks.ts
+++ b/src/__mocks__/state-mocks.ts
@@ -12,7 +12,7 @@ import {
   type Token,
 } from '../types';
 import type { EnterpriseAccount } from '../utils/auth/types';
-import Constants from '../utils/constants';
+import { Constants } from '../utils/constants';
 
 export const mockEnterpriseAccounts: EnterpriseAccount[] = [
   {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,7 +12,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { AppContext } from '../context/App';
 import { Size } from '../types';
 import { quitApp } from '../utils/comms';
-import Constants from '../utils/constants';
+import { Constants } from '../utils/constants';
 import { getFilterCount } from '../utils/helpers';
 import {
   openGitHubIssues,

--- a/src/components/settings/SystemSettings.tsx
+++ b/src/components/settings/SystemSettings.tsx
@@ -2,7 +2,7 @@ import { DeviceDesktopIcon } from '@primer/octicons-react';
 import { type FC, useContext } from 'react';
 import { AppContext } from '../../context/App';
 import type { OpenPreference } from '../../types';
-import Constants from '../../utils/constants';
+import { Constants } from '../../utils/constants';
 import { isLinux, isMacOS } from '../../utils/platform';
 import { Checkbox } from '../fields/Checkbox';
 import { RadioGroup } from '../fields/RadioGroup';

--- a/src/context/App.test.tsx
+++ b/src/context/App.test.tsx
@@ -6,7 +6,7 @@ import type { AuthState, Hostname, SettingsState, Token } from '../types';
 import { mockSingleNotification } from '../utils/api/__mocks__/response-mocks';
 import * as apiRequests from '../utils/api/request';
 import * as comms from '../utils/comms';
-import Constants from '../utils/constants';
+import { Constants } from '../utils/constants';
 import * as notifications from '../utils/notifications';
 import * as storage from '../utils/storage';
 import { AppContext, AppProvider, defaultSettings } from './App';

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -41,7 +41,7 @@ import {
   setKeyboardShortcut,
   updateTrayTitle,
 } from '../utils/comms';
-import Constants from '../utils/constants';
+import { Constants } from '../utils/constants';
 import { getNotificationCount } from '../utils/notifications';
 import { clearState, loadState, saveState } from '../utils/storage';
 import { setTheme } from '../utils/theme';

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -13,7 +13,7 @@ import {
   mockNotificationUser,
   mockSingleNotification,
 } from '../utils/api/__mocks__/response-mocks';
-import { Errors } from '../utils/constants';
+import { Errors } from '../utils/errors';
 import { useNotifications } from './useNotifications';
 
 describe('hooks/useNotifications.ts', () => {

--- a/src/routes/LoginWithOAuthApp.tsx
+++ b/src/routes/LoginWithOAuthApp.tsx
@@ -21,7 +21,7 @@ import {
   isValidHostname,
   isValidToken,
 } from '../utils/auth/utils';
-import Constants from '../utils/constants';
+import { Constants } from '../utils/constants';
 
 interface IValues {
   hostname?: Hostname;

--- a/src/routes/Notifications.test.tsx
+++ b/src/routes/Notifications.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import { mockAccountNotifications } from '../__mocks__/notifications-mocks';
 import { mockSettings } from '../__mocks__/state-mocks';
 import { AppContext } from '../context/App';
-import { Errors } from '../utils/constants';
+import { Errors } from '../utils/errors';
 import { NotificationsRoute } from './Notifications';
 
 jest.mock('../components/AccountNotifications', () => ({

--- a/src/routes/Notifications.tsx
+++ b/src/routes/Notifications.tsx
@@ -4,7 +4,7 @@ import { AllRead } from '../components/AllRead';
 import { Oops } from '../components/Oops';
 import { AppContext } from '../context/App';
 import { getAccountUUID } from '../utils/auth/utils';
-import { Errors } from '../utils/constants';
+import { Errors } from '../utils/errors';
 import { getNotificationCount } from '../utils/notifications';
 
 export const NotificationsRoute: FC = () => {

--- a/src/utils/api/errors.test.ts
+++ b/src/utils/api/errors.test.ts
@@ -1,7 +1,7 @@
 import { AxiosError, type AxiosResponse } from 'axios';
 import type { Link } from '../../types';
 import type { GitHubRESTError } from '../../typesGitHub';
-import { Errors } from '../constants';
+import { Errors } from '../errors';
 import { determineFailureType } from './errors';
 
 describe('utils/api/errors.ts', () => {

--- a/src/utils/api/errors.ts
+++ b/src/utils/api/errors.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import type { GitifyError } from '../../types';
 import type { GitHubRESTError } from '../../typesGitHub';
-import { Errors } from '../constants';
+import { Errors } from '../errors';
 
 export function determineFailureType(
   err: AxiosError<GitHubRESTError>,

--- a/src/utils/api/utils.ts
+++ b/src/utils/api/utils.ts
@@ -1,5 +1,5 @@
 import type { Hostname } from '../../types';
-import Constants from '../constants';
+import { Constants } from '../constants';
 import { isEnterpriseServerHost } from '../helpers';
 
 export function getGitHubAPIBaseUrl(hostname: Hostname): URL {

--- a/src/utils/auth/migration.test.ts
+++ b/src/utils/auth/migration.test.ts
@@ -3,7 +3,7 @@ import log from 'electron-log';
 import nock from 'nock';
 import { mockGitifyUser, mockToken } from '../../__mocks__/state-mocks';
 import type { AuthState, Hostname } from '../../types';
-import Constants from '../constants';
+import { Constants } from '../constants';
 import {
   convertAccounts,
   hasAccountsToMigrate,

--- a/src/utils/auth/migration.ts
+++ b/src/utils/auth/migration.ts
@@ -1,6 +1,6 @@
 import log from 'electron-log';
 import type { Account, AuthState } from '../../types';
-import Constants from '../constants';
+import { Constants } from '../constants';
 import { loadState, saveState } from '../storage';
 import { getUserData } from './utils';
 

--- a/src/utils/comms.ts
+++ b/src/utils/comms.ts
@@ -1,7 +1,7 @@
 import { ipcRenderer, shell } from 'electron';
 import { defaultSettings } from '../context/App';
 import { type Link, OpenPreference } from '../types';
-import Constants from './constants';
+import { Constants } from './constants';
 import { loadState } from './storage';
 
 export function openExternalLink(url: Link): void {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import type { ErrorType, GitifyError, Link } from '../types';
+import type { Link } from '../types';
 import type { ClientID, ClientSecret, Hostname } from '../types';
 
 export const Constants = {
@@ -36,36 +36,3 @@ export const Constants = {
       'https://docs.github.com/en/account-and-profile/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#about-participating-and-watching-notifications' as Link,
   },
 };
-
-export const Errors: Record<ErrorType, GitifyError> = {
-  BAD_CREDENTIALS: {
-    title: 'Bad Credentials',
-    descriptions: ['Your credentials are either invalid or expired.'],
-    emojis: ['🔓'],
-  },
-  MISSING_SCOPES: {
-    title: 'Missing Scopes',
-    descriptions: ['Your credentials are missing a required API scope.'],
-    emojis: ['🔭'],
-  },
-  NETWORK: {
-    title: 'Network Error',
-    descriptions: [
-      'Unable to connect to one or more of your GitHub environments.',
-      'Please check your network connection, including whether you require a VPN, and try again.',
-    ],
-    emojis: ['🛜'],
-  },
-  RATE_LIMITED: {
-    title: 'Rate Limited',
-    descriptions: ['Please wait a while before trying again.'],
-    emojis: ['😮‍💨'],
-  },
-  UNKNOWN: {
-    title: 'Oops! Something went wrong',
-    descriptions: ['Please try again later.'],
-    emojis: ['🤔', '🥲', '😳', '🫠', '🙃', '🙈'],
-  },
-};
-
-export default Constants;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,32 @@
+import type { ErrorType, GitifyError } from '../types';
+
+export const Errors: Record<ErrorType, GitifyError> = {
+  BAD_CREDENTIALS: {
+    title: 'Bad Credentials',
+    descriptions: ['Your credentials are either invalid or expired.'],
+    emojis: ['🔓'],
+  },
+  MISSING_SCOPES: {
+    title: 'Missing Scopes',
+    descriptions: ['Your credentials are missing a required API scope.'],
+    emojis: ['🔭'],
+  },
+  NETWORK: {
+    title: 'Network Error',
+    descriptions: [
+      'Unable to connect to one or more of your GitHub environments.',
+      'Please check your network connection, including whether you require a VPN, and try again.',
+    ],
+    emojis: ['🛜'],
+  },
+  RATE_LIMITED: {
+    title: 'Rate Limited',
+    descriptions: ['Please wait a while before trying again.'],
+    emojis: ['😮‍💨'],
+  },
+  UNKNOWN: {
+    title: 'Oops! Something went wrong',
+    descriptions: ['Please try again later.'],
+    emojis: ['🤔', '🥲', '😳', '🫠', '🙃', '🙈'],
+  },
+};

--- a/src/utils/links.test.ts
+++ b/src/utils/links.test.ts
@@ -5,7 +5,7 @@ import type { Repository } from '../typesGitHub';
 import { mockSingleNotification } from './api/__mocks__/response-mocks';
 import * as authUtils from './auth/utils';
 import * as comms from './comms';
-import Constants from './constants';
+import { Constants } from './constants';
 import * as helpers from './helpers';
 import {
   openAccountProfile,

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -2,7 +2,7 @@ import type { Account, Hostname, Link } from '../types';
 import type { Notification, Repository, SubjectUser } from '../typesGitHub';
 import { getDeveloperSettingsURL } from './auth/utils';
 import { openExternalLink } from './comms';
-import Constants from './constants';
+import { Constants } from './constants';
 import { generateGitHubWebUrl } from './helpers';
 
 export function openGitifyRepository() {

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -1,6 +1,6 @@
 import { mockSettings } from '../__mocks__/state-mocks';
 import type { Token } from '../types';
-import Constants from './constants';
+import { Constants } from './constants';
 import { clearState, loadState, saveState } from './storage';
 
 describe('utils/storage.ts', () => {


### PR DESCRIPTION
goal is to slowly working towards separating the gitify specific constants/types from the github (or other platform) constants/types