### PR TITLE
fix: restore settings order

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -138,6 +138,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     markRepoNotificationsDone,
   } = useNotifications();
   getNotificationCount;
+
   useEffect(() => {
     restoreSettings();
   }, []);
@@ -266,15 +267,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     await migrateAuthenticatedAccounts();
     const existing = loadState();
 
-    if (existing.auth) {
-      setAuth({ ...defaultAuth, ...existing.auth });
-
-      // Refresh account data on app start
-      for (const account of existing.auth.accounts) {
-        await refreshAccount(account);
-      }
-    }
-
+    // Restore settings before accounts to ensure filters are available before fetching notifications
     if (existing.settings) {
       setKeyboardShortcut(existing.settings.keyboardShortcut);
       setAlternateIdleIcon(existing.settings.useAlternateIdleIcon);
@@ -282,6 +275,15 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
       webFrame.setZoomLevel(
         zoomPercentageToLevel(existing.settings.zoomPercentage),
       );
+    }
+
+    if (existing.auth) {
+      setAuth({ ...defaultAuth, ...existing.auth });
+
+      // Refresh account data on app start
+      for (const account of existing.auth.accounts) {
+        await refreshAccount(account);
+      }
     }
   }, []);
 


### PR DESCRIPTION
Upon first start, filters were not loaded before the first notification fetch occurred resulting in an inconsistent state.

This fixes it by simply restoring settings (and filters) before restoring accounts