### PR TITLE
feat: change icon navigation to go `home`

### DIFF
--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -60,7 +60,7 @@ describe('components/Sidebar.tsx', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('should open the gitify repository', () => {
+  it('should navigate home when clicking the gitify logo', () => {
     render(
       <AppContext.Provider
         value={{
@@ -78,10 +78,7 @@ describe('components/Sidebar.tsx', () => {
 
     fireEvent.click(screen.getByTestId('gitify-logo'));
 
-    expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
-    expect(openExternalLinkMock).toHaveBeenCalledWith(
-      'https://github.com/gitify-app/gitify',
-    );
+    expect(mockNavigate).toHaveBeenNthCalledWith(1, '/', { replace: true });
   });
 
   describe('quick links', () => {

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -76,8 +76,7 @@ describe('components/Sidebar.tsx', () => {
       </AppContext.Provider>,
     );
 
-    fireEvent.click(screen.getByTestId('gitify-logo'));
-
+    fireEvent.click(screen.getByTitle('Home'));
     expect(mockNavigate).toHaveBeenNthCalledWith(1, '/', { replace: true });
   });
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -78,7 +78,6 @@ export const Sidebar: FC = () => {
           className="mx-auto my-3 cursor-pointer outline-none"
           title="Home"
           onClick={() => navigate('/', { replace: true })}
-          data-testid="gitify-logo"
         >
           <LogoIcon size={Size.SMALL} aria-label="Open Gitify" />
         </button>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,7 +18,6 @@ import {
   openGitHubIssues,
   openGitHubNotifications,
   openGitHubPulls,
-  openGitifyRepository,
 } from '../utils/links';
 import { getNotificationCount } from '../utils/notifications';
 import { SidebarButton } from './buttons/SidebarButton';
@@ -77,8 +76,8 @@ export const Sidebar: FC = () => {
         <button
           type="button"
           className="mx-auto my-3 cursor-pointer outline-none"
-          title="Open Gitify on GitHub"
-          onClick={() => openGitifyRepository()}
+          title="Home"
+          onClick={() => navigate('/', { replace: true })}
           data-testid="gitify-logo"
         >
           <LogoIcon size={Size.SMALL} aria-label="Open Gitify" />

--- a/src/components/__snapshots__/Sidebar.test.tsx.snap
+++ b/src/components/__snapshots__/Sidebar.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
           <button
             class="mx-auto my-3 cursor-pointer outline-none"
             data-testid="gitify-logo"
-            title="Open Gitify on GitHub"
+            title="Home"
             type="button"
           >
             <svg
@@ -167,7 +167,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
         <button
           class="mx-auto my-3 cursor-pointer outline-none"
           data-testid="gitify-logo"
-          title="Open Gitify on GitHub"
+          title="Home"
           type="button"
         >
           <svg
@@ -377,7 +377,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
           <button
             class="mx-auto my-3 cursor-pointer outline-none"
             data-testid="gitify-logo"
-            title="Open Gitify on GitHub"
+            title="Home"
             type="button"
           >
             <svg
@@ -530,7 +530,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
         <button
           class="mx-auto my-3 cursor-pointer outline-none"
           data-testid="gitify-logo"
-          title="Open Gitify on GitHub"
+          title="Home"
           type="button"
         >
           <svg

--- a/src/components/__snapshots__/Sidebar.test.tsx.snap
+++ b/src/components/__snapshots__/Sidebar.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
         >
           <button
             class="mx-auto my-3 cursor-pointer outline-none"
-            data-testid="gitify-logo"
             title="Home"
             type="button"
           >
@@ -166,7 +165,6 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
       >
         <button
           class="mx-auto my-3 cursor-pointer outline-none"
-          data-testid="gitify-logo"
           title="Home"
           type="button"
         >
@@ -376,7 +374,6 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
         >
           <button
             class="mx-auto my-3 cursor-pointer outline-none"
-            data-testid="gitify-logo"
             title="Home"
             type="button"
           >
@@ -529,7 +526,6 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
       >
         <button
           class="mx-auto my-3 cursor-pointer outline-none"
-          data-testid="gitify-logo"
           title="Home"
           type="button"
         >

--- a/src/utils/links.test.ts
+++ b/src/utils/links.test.ts
@@ -15,7 +15,6 @@ import {
   openGitHubParticipatingDocs,
   openGitHubPulls,
   openGitifyReleaseNotes,
-  openGitifyRepository,
   openHost,
   openNotification,
   openRepository,
@@ -29,13 +28,6 @@ describe('utils/links.ts', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('openGitifyRepository', () => {
-    openGitifyRepository();
-    expect(openExternalLinkMock).toHaveBeenCalledWith(
-      'https://github.com/gitify-app/gitify',
-    );
   });
 
   it('openGitifyReleaseNotes', () => {

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -5,10 +5,6 @@ import { openExternalLink } from './comms';
 import { Constants } from './constants';
 import { generateGitHubWebUrl } from './helpers';
 
-export function openGitifyRepository() {
-  openExternalLink(`https://github.com/${Constants.REPO_SLUG}` as Link);
-}
-
 export function openGitifyReleaseNotes(version: string) {
   openExternalLink(
     `https://github.com/${Constants.REPO_SLUG}/releases/tag/${version}` as Link,


### PR DESCRIPTION
Change behavior for gitify icon to navigate home, instead of opening the gitify repository.  

Currently we can launch this by clicking on the application name + version in the Settings page.