### PR TITLE
refactor: change chevron type for closed sections

### DIFF
--- a/src/components/AccountNotifications.tsx
+++ b/src/components/AccountNotifications.tsx
@@ -1,7 +1,7 @@
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
-  ChevronUpIcon,
+  ChevronRightIcon,
   FeedPersonIcon,
   GitPullRequestIcon,
   IssueOpenedIcon,
@@ -68,7 +68,7 @@ export const AccountNotifications: FC<IAccountNotifications> = (
       ? ChevronLeftIcon
       : showAccountNotifications
         ? ChevronDownIcon
-        : ChevronUpIcon;
+        : ChevronRightIcon;
 
   const toggleAccountNotificationsLabel =
     notifications.length === 0

--- a/src/components/RepositoryNotifications.tsx
+++ b/src/components/RepositoryNotifications.tsx
@@ -1,7 +1,7 @@
 import {
   CheckIcon,
   ChevronDownIcon,
-  ChevronUpIcon,
+  ChevronRightIcon,
   MarkGithubIcon,
   ReadIcon,
 } from '@primer/octicons-react';
@@ -41,7 +41,7 @@ export const RepositoryNotifications: FC<IRepositoryNotifications> = ({
 
   const ChevronIcon = showRepositoryNotifications
     ? ChevronDownIcon
-    : ChevronUpIcon;
+    : ChevronRightIcon;
 
   const toggleRepositoryNotificationsLabel = showRepositoryNotifications
     ? 'Hide repository notifications'

--- a/src/components/__snapshots__/AccountNotifications.test.tsx.snap
+++ b/src/components/__snapshots__/AccountNotifications.test.tsx.snap
@@ -2126,7 +2126,7 @@ exports[`components/AccountNotifications.tsx should toggle account notifications
           >
             <svg
               aria-label="Show account notifications"
-              class="octicon octicon-chevron-up"
+              class="octicon octicon-chevron-right"
               fill="currentColor"
               focusable="false"
               height="14"
@@ -2136,7 +2136,7 @@ exports[`components/AccountNotifications.tsx should toggle account notifications
               width="14"
             >
               <path
-                d="M6 4c-.2 0-.4.1-.5.2L2.2 7.5c-.3.3-.3.8 0 1.1.3.3.8.3 1.1 0L6 5.9l2.7 2.7c.3.3.8.3 1.1 0 .3-.3.3-.8 0-1.1L6.6 4.3C6.4 4.1 6.2 4 6 4Z"
+                d="M4.7 10c-.2 0-.4-.1-.5-.2-.3-.3-.3-.8 0-1.1L6.9 6 4.2 3.3c-.3-.3-.3-.8 0-1.1.3-.3.8-.3 1.1 0l3.3 3.2c.3.3.3.8 0 1.1L5.3 9.7c-.2.2-.4.3-.6.3Z"
               />
             </svg>
           </button>

--- a/src/components/__snapshots__/RepositoryNotifications.test.tsx.snap
+++ b/src/components/__snapshots__/RepositoryNotifications.test.tsx.snap
@@ -328,7 +328,7 @@ exports[`components/RepositoryNotifications.tsx should toggle repository notific
           >
             <svg
               aria-label="Show repository notifications"
-              class="octicon octicon-chevron-up"
+              class="octicon octicon-chevron-right"
               fill="currentColor"
               focusable="false"
               height="14"
@@ -338,7 +338,7 @@ exports[`components/RepositoryNotifications.tsx should toggle repository notific
               width="14"
             >
               <path
-                d="M6 4c-.2 0-.4.1-.5.2L2.2 7.5c-.3.3-.3.8 0 1.1.3.3.8.3 1.1 0L6 5.9l2.7 2.7c.3.3.8.3 1.1 0 .3-.3.3-.8 0-1.1L6.6 4.3C6.4 4.1 6.2 4 6 4Z"
+                d="M4.7 10c-.2 0-.4-.1-.5-.2-.3-.3-.3-.8 0-1.1L6.9 6 4.2 3.3c-.3-.3-.3-.8 0-1.1.3-.3.8-.3 1.1 0l3.3 3.2c.3.3.3.8 0 1.1L5.3 9.7c-.2.2-.4.3-.6.3Z"
               />
             </svg>
           </button>


### PR DESCRIPTION
Use a chevron right icon when the headers are collapsed.  More intuitive UX.