### PR TITLE
fix: discussions url

### DIFF
--- a/src/renderer/utils/helpers.ts
+++ b/src/renderer/utils/helpers.ts
@@ -123,7 +123,8 @@ export async function generateGitHubWebUrl(
 ): Promise<Link> {
   const url = new URL(notification.repository.html_url);
 
-  // FIXME upstream GitHub API has started returning subject urls for Discussion notification types,
+  // FIXME see #1583
+  // Upstream GitHub API has started returning subject urls for Discussion notification types,
   // however these URLs are broken.  Temporarily downgrading to use discussion lookup process.
   if (notification.subject.type === 'Discussion') {
     notification.subject.url = null;

--- a/src/renderer/utils/helpers.ts
+++ b/src/renderer/utils/helpers.ts
@@ -123,7 +123,8 @@ export async function generateGitHubWebUrl(
 ): Promise<Link> {
   const url = new URL(notification.repository.html_url);
 
-  // FIXME: upstream API is returning broken API URLs for Discussion types
+  // FIXME upstream GitHub API has started returning subject urls for Discussion notification types,
+  // however these URLs are broken.  Temporarily downgrading to use discussion lookup process.
   if (notification.subject.type === 'Discussion') {
     notification.subject.url = null;
     notification.subject.latest_comment_url = null;

--- a/src/renderer/utils/helpers.ts
+++ b/src/renderer/utils/helpers.ts
@@ -123,6 +123,12 @@ export async function generateGitHubWebUrl(
 ): Promise<Link> {
   const url = new URL(notification.repository.html_url);
 
+  // FIXME: upstream API is returning broken API URLs for Discussion types
+  if (notification.subject.type === 'Discussion') {
+    notification.subject.url = null;
+    notification.subject.latest_comment_url = null;
+  }
+
   try {
     if (notification.subject.latest_comment_url) {
       url.href = await getHtmlUrl(


### PR DESCRIPTION
It appears that Discussion notification objects now have `subject.url` and `subject.latest_comment.url` populated with an url value.

However, this value returns a 404 causing open interactions for discussions to break and default to the repository url.

Adding a temporary (hopefully) downgrade to revert to our GitHub GraphQL search discussions query to find the matching discussions url