### PR TITLE
fix: set 'Cache-Control: no-cache' for GHE server

### DIFF
--- a/src/renderer/utils/api/__snapshots__/client.test.ts.snap
+++ b/src/renderer/utils/api/__snapshots__/client.test.ts.snap
@@ -22,7 +22,7 @@ exports[`renderer/utils/api/client.ts headNotifications should fetch notificatio
 {
   "Accept": "application/json",
   "Authorization": "token token-123-456",
-  "Cache-Control": "",
+  "Cache-Control": "no-cache",
   "Content-Type": "application/json",
 }
 `;
@@ -76,7 +76,7 @@ exports[`renderer/utils/api/client.ts listNotificationsForAuthenticatedUser shou
 {
   "Accept": "application/json",
   "Authorization": "token 1234568790",
-  "Cache-Control": "",
+  "Cache-Control": "no-cache",
   "Content-Type": "application/json",
 }
 `;

--- a/src/renderer/utils/api/request.ts
+++ b/src/renderer/utils/api/request.ts
@@ -94,6 +94,7 @@ function shouldRequestWithNoCache(url: string) {
 
   switch (parsedUrl.pathname) {
     case '/notifications':
+    case '/api/v3/notifications':
       return true;
     default:
       return false;


### PR DESCRIPTION
fix #1611 

Whether it is `github.com` or GHE Server, set the `Cache-Control: no-cache` header.
