### PR TITLE
fix: prevent default filters from getting overwritten

### DIFF
--- a/src/renderer/routes/Filters.tsx
+++ b/src/renderer/routes/Filters.tsx
@@ -22,7 +22,7 @@ export const FiltersRoute: FC = () => {
   const { settings, clearFilters, updateSetting } = useContext(AppContext);
 
   const updateReasonFilter = (reason: Reason, checked: boolean) => {
-    let reasons: Reason[] = settings.filterReasons;
+    let reasons: Reason[] = [...settings.filterReasons];
 
     if (checked) {
       reasons.push(reason);


### PR DESCRIPTION
"Clear Filters" button was not unchecking selected filters because of a reference between `settings` and `defaultSettings`. i.e., whenever filters changed, the filter reasons in the `defaultFilters` object also mutated, which is not desirable.

Using the spread operator to get selected filters fixes this issue.

**Video of bug:**

https://github.com/user-attachments/assets/1719e109-ca10-4c29-afe0-7a3d5337660e

