### PR TITLE
refactor: zoom in and out icons

### DIFF
--- a/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/src/renderer/components/settings/AppearanceSettings.tsx
@@ -2,10 +2,10 @@ import { webFrame } from 'electron';
 import { type FC, useContext, useState } from 'react';
 
 import {
-  DashIcon,
   PaintbrushIcon,
-  PlusIcon,
-  XCircleIcon,
+  SyncIcon,
+  ZoomInIcon,
+  ZoomOutIcon,
 } from '@primer/octicons-react';
 import {
   Button,
@@ -109,7 +109,7 @@ export const AppearanceSettings: FC = () => {
             <IconButton
               aria-label="Zoom out"
               size="small"
-              icon={DashIcon}
+              icon={ZoomOutIcon}
               unsafeDisableTooltip={true}
               onClick={() =>
                 zoomPercentage > 0 &&
@@ -127,7 +127,7 @@ export const AppearanceSettings: FC = () => {
             <IconButton
               aria-label="Zoom in"
               size="small"
-              icon={PlusIcon}
+              icon={ZoomInIcon}
               unsafeDisableTooltip={true}
               onClick={() =>
                 zoomPercentage < 120 &&
@@ -142,7 +142,7 @@ export const AppearanceSettings: FC = () => {
               aria-label="Reset zoom"
               size="small"
               variant="danger"
-              icon={XCircleIcon}
+              icon={SyncIcon}
               unsafeDisableTooltip={true}
               onClick={() => webFrame.setZoomLevel(0)}
               data-testid="settings-zoom-reset"

--- a/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
@@ -281,7 +281,7 @@ exports[`renderer/routes/Settings.tsx should render itself & its children 1`] = 
               >
                 <svg
                   aria-hidden="true"
-                  class="octicon octicon-dash"
+                  class="octicon octicon-zoom-out"
                   display="inline-block"
                   fill="currentColor"
                   focusable="false"
@@ -292,7 +292,10 @@ exports[`renderer/routes/Settings.tsx should render itself & its children 1`] = 
                   width="16"
                 >
                   <path
-                    d="M2 7.75A.75.75 0 0 1 2.75 7h10a.75.75 0 0 1 0 1.5h-10A.75.75 0 0 1 2 7.75Z"
+                    d="M4.5 6.75h6a.75.75 0 0 1 0 1.5h-6a.75.75 0 0 1 0-1.5Z"
+                  />
+                  <path
+                    d="M0 7.5a7.5 7.5 0 1 1 13.307 4.747l2.473 2.473a.749.749 0 1 1-1.06 1.06l-2.473-2.473A7.5 7.5 0 0 1 0 7.5Zm7.5-6a6 6 0 1 0 0 12 6 6 0 0 0 0-12Z"
                   />
                 </svg>
               </button>
@@ -334,7 +337,7 @@ exports[`renderer/routes/Settings.tsx should render itself & its children 1`] = 
               >
                 <svg
                   aria-hidden="true"
-                  class="octicon octicon-plus"
+                  class="octicon octicon-zoom-in"
                   display="inline-block"
                   fill="currentColor"
                   focusable="false"
@@ -345,7 +348,10 @@ exports[`renderer/routes/Settings.tsx should render itself & its children 1`] = 
                   width="16"
                 >
                   <path
-                    d="M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z"
+                    d="M3.75 7.5a.75.75 0 0 1 .75-.75h2.25V4.5a.75.75 0 0 1 1.5 0v2.25h2.25a.75.75 0 0 1 0 1.5H8.25v2.25a.75.75 0 0 1-1.5 0V8.25H4.5a.75.75 0 0 1-.75-.75Z"
+                  />
+                  <path
+                    d="M7.5 0a7.5 7.5 0 0 1 5.807 12.247l2.473 2.473a.749.749 0 1 1-1.06 1.06l-2.473-2.473A7.5 7.5 0 1 1 7.5 0Zm-6 7.5a6 6 0 1 0 12 0 6 6 0 0 0-12 0Z"
                   />
                 </svg>
               </button>
@@ -363,7 +369,7 @@ exports[`renderer/routes/Settings.tsx should render itself & its children 1`] = 
               >
                 <svg
                   aria-hidden="true"
-                  class="octicon octicon-x-circle"
+                  class="octicon octicon-sync"
                   display="inline-block"
                   fill="currentColor"
                   focusable="false"
@@ -374,7 +380,7 @@ exports[`renderer/routes/Settings.tsx should render itself & its children 1`] = 
                   width="16"
                 >
                   <path
-                    d="M2.344 2.343h-.001a8 8 0 0 1 11.314 11.314A8.002 8.002 0 0 1 .234 10.089a8 8 0 0 1 2.11-7.746Zm1.06 10.253a6.5 6.5 0 1 0 9.108-9.275 6.5 6.5 0 0 0-9.108 9.275ZM6.03 4.97 8 6.94l1.97-1.97a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l1.97 1.97a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-1.97 1.97a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L6.94 8 4.97 6.03a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018Z"
+                    d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"
                   />
                 </svg>
               </button>


### PR DESCRIPTION
Use the https://primer.style/octicons/ Zoom In and Zoom Out icons, along with Sync (for reset)

| Before | After | 
| --- | --- |
| ![2025-04-23T15-51-59 228Z-Gitify-screenshot](https://github.com/user-attachments/assets/cafa498a-eda3-4b54-82a6-8d5ddd278998) | ![2025-04-23T15-50-44 019Z-Gitify-screenshot](https://github.com/user-attachments/assets/4719c8c0-bbb9-4c1f-a4fe-2600de6f4e85) |