### PR TITLE
build: configure twemoji changelog to be upstream fork

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,11 @@
       "description": "Remove word `dependency` from commit messages and PR titles",
       "matchDatasources": ["npm"],
       "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "description": "Fetch changelog details for twemoji packages",
+      "matchPackageNames": ["@discordapp/twemoji"],
+      "sourceUrl": "https://github.com/jdjdecked/twemoji"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Fetch changelog notes for https://github.com/discord/twemoji from https://github.com/jdecked/twemoji
