### PR TITLE
chore: allow gtk 4 again

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,9 +11,6 @@ import { TrayIcons } from './icons';
 import MenuBuilder from './menu';
 import Updater from './updater';
 
-// https://github.com/electron/electron/issues/46538
-if (isLinux) app.commandLine?.appendSwitch('gtk-version', '3');
-
 log.initialize();
 
 const browserWindowOpts = {


### PR DESCRIPTION
The linked issue is reported to be resolved, so let's try allowing GTK 4 again.