### PR TITLE
fix(discussions): fetch labels

### DIFF
--- a/src/renderer/utils/api/client.ts
+++ b/src/renderer/utils/api/client.ts
@@ -250,6 +250,7 @@ export async function searchDiscussions(
         firstDiscussions: 1,
         lastComments: 1,
         lastReplies: 1,
+        firstLabels: 100,
         includeIsAnswered: isAnsweredDiscussionFeatureSupported(
           notification.account,
         ),

--- a/src/renderer/utils/api/graphql/discussions.ts
+++ b/src/renderer/utils/api/graphql/discussions.ts
@@ -27,6 +27,7 @@ export const QUERY_SEARCH_DISCUSSIONS = gql`
     $firstDiscussions: Int
     $lastComments: Int
     $lastReplies: Int
+    $firstLabels: Int
     $includeIsAnswered: Boolean!
   ) {
     search(query: $queryStatement, type: DISCUSSION, first: $firstDiscussions) {
@@ -51,7 +52,7 @@ export const QUERY_SEARCH_DISCUSSIONS = gql`
               }
             }
           }
-          labels {
+          labels(first: $firstLabels) {
             nodes {
               name
             }


### PR DESCRIPTION
GitHub GraphQL API changed to require at least one pagination argument for `labels`