### PR TITLE
refactor: use `@primer/css` directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@biomejs/biome": "2.2.0",
     "@discordapp/twemoji": "16.0.1",
     "@electron/notarize": "3.0.2",
+    "@primer/css": "22.0.2",
     "@primer/octicons-react": "19.15.5",
     "@primer/primitives": "11.1.0",
     "@primer/react": "36.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@electron/notarize':
         specifier: 3.0.2
         version: 3.0.2
+      '@primer/css':
+        specifier: 22.0.2
+        version: 22.0.2(@primer/primitives@11.1.0)
       '@primer/octicons-react':
         specifier: 19.15.5
         version: 19.15.5(react@19.1.1)
@@ -774,6 +777,12 @@ packages:
 
   '@primer/behaviors@1.8.0':
     resolution: {integrity: sha512-ZUfhWVY4ZBKc2Fh3fIa2Qwwa3SnOi914lY5wcmN+UNtsBxeXsjWNwpohJbwRwWZm+nJ3C1n9qJFWpHuBlDVU1A==}
+
+  '@primer/css@22.0.2':
+    resolution: {integrity: sha512-FfXd1ga05oewKjDRi9cPmy7BSnb/6QOjTIxAtDj94Hoyk+qJxHhgvhbcnZwBfL3WKP6HeUT3PnsT9k+43Bmg3Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@primer/primitives': 10.x || 11.x
 
   '@primer/live-region-element@0.7.1':
     resolution: {integrity: sha512-9uQCeBCb3wefz3kJNSo+PECc7T7TNB3k22JUdHY08Zlv9bd1rtsQgpazM5umcbZQrACzGbgufAfdbhGUBXI3jA==}
@@ -5489,6 +5498,10 @@ snapshots:
   '@pkgr/core@0.2.7': {}
 
   '@primer/behaviors@1.8.0': {}
+
+  '@primer/css@22.0.2(@primer/primitives@11.1.0)':
+    dependencies:
+      '@primer/primitives': 11.1.0
 
   '@primer/live-region-element@0.7.1':
     dependencies:

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -2,36 +2,7 @@
 @import "tailwindcss";
 
 /** GitHub Primer Design System */
-/* Size & Typography */
-@import "@primer/primitives/dist/css/primitives.css";
-
-/* Base */
-@import "@primer/primitives/dist/css/base/motion/motion.css";
-@import "@primer/primitives/dist/css/base/size/size.css";
-@import "@primer/primitives/dist/css/base/typography/typography.css";
-
-/* Functional */
-@import "@primer/primitives/dist/css/functional/size/border.css";
-@import "@primer/primitives/dist/css/functional/size/breakpoints.css";
-@import "@primer/primitives/dist/css/functional/size/size.css";
-@import "@primer/primitives/dist/css/functional/size/viewport.css";
-@import "@primer/primitives/dist/css/functional/typography/typography.css";
-
-/* Themes and Colors */
-@import "@primer/primitives/dist/css/functional/themes/dark-colorblind-high-contrast.css";
-@import "@primer/primitives/dist/css/functional/themes/dark-colorblind.css";
-@import "@primer/primitives/dist/css/functional/themes/dark-dimmed-high-contrast.css";
-@import "@primer/primitives/dist/css/functional/themes/dark-dimmed.css";
-@import "@primer/primitives/dist/css/functional/themes/dark-high-contrast.css";
-@import "@primer/primitives/dist/css/functional/themes/dark-tritanopia-high-contrast.css";
-@import "@primer/primitives/dist/css/functional/themes/dark-tritanopia.css";
-@import "@primer/primitives/dist/css/functional/themes/dark.css";
-@import "@primer/primitives/dist/css/functional/themes/light-colorblind-high-contrast.css";
-@import "@primer/primitives/dist/css/functional/themes/light-colorblind.css";
-@import "@primer/primitives/dist/css/functional/themes/light-high-contrast.css";
-@import "@primer/primitives/dist/css/functional/themes/light-tritanopia-high-contrast.css";
-@import "@primer/primitives/dist/css/functional/themes/light-tritanopia.css";
-@import "@primer/primitives/dist/css/functional/themes/light.css";
+@import "@primer/css/dist/primer.css";
 
 /** Tailwind CSS Configuration */
 @config '../../tailwind.config.ts';


### PR DESCRIPTION
Simplify our `@primer/css` use 