### PR TITLE
fix: use IssueOpenedIcon for linked issues

### DIFF
--- a/src/renderer/components/metrics/MetricGroup.tsx
+++ b/src/renderer/components/metrics/MetricGroup.tsx
@@ -2,7 +2,7 @@ import { type FC, useContext } from 'react';
 
 import {
   CommentIcon,
-  IssueClosedIcon,
+  IssueOpenedIcon,
   MilestoneIcon,
   TagIcon,
 } from '@primer/octicons-react';
@@ -40,8 +40,8 @@ export const MetricGroup: FC<IMetricGroup> = ({
       <Box className="flex gap-1">
         {notification.subject?.linkedIssues?.length > 0 && (
           <MetricPill
-            color={IconColor.GREEN}
-            icon={IssueClosedIcon}
+            color={IconColor.GRAY}
+            icon={IssueOpenedIcon}
             metric={notification.subject.linkedIssues.length}
             title={linkedIssuesPillDescription}
           />

--- a/src/renderer/components/metrics/__snapshots__/MetricGroup.test.tsx.snap
+++ b/src/renderer/components/metrics/__snapshots__/MetricGroup.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
           >
             <svg
               aria-hidden="true"
-              class="octicon octicon-issue-closed text-gitify-icon-open"
+              class="octicon octicon-issue-opened text-gitify-icon-muted"
               display="inline-block"
               fill="currentColor"
               focusable="false"
@@ -35,10 +35,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
               width="12"
             >
               <path
-                d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+                d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
               />
               <path
-                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+                d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
               />
             </svg>
             <span
@@ -182,7 +182,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
         >
           <svg
             aria-hidden="true"
-            class="octicon octicon-issue-closed text-gitify-icon-open"
+            class="octicon octicon-issue-opened text-gitify-icon-muted"
             display="inline-block"
             fill="currentColor"
             focusable="false"
@@ -193,10 +193,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
             width="12"
           >
             <path
-              d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+              d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
             />
             <path
-              d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
             />
           </svg>
           <span
@@ -397,7 +397,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
           >
             <svg
               aria-hidden="true"
-              class="octicon octicon-issue-closed text-gitify-icon-open"
+              class="octicon octicon-issue-opened text-gitify-icon-muted"
               display="inline-block"
               fill="currentColor"
               focusable="false"
@@ -408,10 +408,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
               width="12"
             >
               <path
-                d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+                d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
               />
               <path
-                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+                d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
               />
             </svg>
             <span
@@ -555,7 +555,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
         >
           <svg
             aria-hidden="true"
-            class="octicon octicon-issue-closed text-gitify-icon-open"
+            class="octicon octicon-issue-opened text-gitify-icon-muted"
             display="inline-block"
             fill="currentColor"
             focusable="false"
@@ -566,10 +566,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
             width="12"
           >
             <path
-              d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+              d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
             />
             <path
-              d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
             />
           </svg>
           <span
@@ -770,7 +770,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
           >
             <svg
               aria-hidden="true"
-              class="octicon octicon-issue-closed text-gitify-icon-open"
+              class="octicon octicon-issue-opened text-gitify-icon-muted"
               display="inline-block"
               fill="currentColor"
               focusable="false"
@@ -781,10 +781,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
               width="12"
             >
               <path
-                d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+                d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
               />
               <path
-                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+                d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
               />
             </svg>
             <span
@@ -891,7 +891,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
         >
           <svg
             aria-hidden="true"
-            class="octicon octicon-issue-closed text-gitify-icon-open"
+            class="octicon octicon-issue-opened text-gitify-icon-muted"
             display="inline-block"
             fill="currentColor"
             focusable="false"
@@ -902,10 +902,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx comment pills should render
             width="12"
           >
             <path
-              d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+              d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
             />
             <path
-              d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
             />
           </svg>
           <span
@@ -1069,7 +1069,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx label pills should render l
           >
             <svg
               aria-hidden="true"
-              class="octicon octicon-issue-closed text-gitify-icon-open"
+              class="octicon octicon-issue-opened text-gitify-icon-muted"
               display="inline-block"
               fill="currentColor"
               focusable="false"
@@ -1080,10 +1080,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx label pills should render l
               width="12"
             >
               <path
-                d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+                d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
               />
               <path
-                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+                d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
               />
             </svg>
             <span
@@ -1265,7 +1265,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx label pills should render l
         >
           <svg
             aria-hidden="true"
-            class="octicon octicon-issue-closed text-gitify-icon-open"
+            class="octicon octicon-issue-opened text-gitify-icon-muted"
             display="inline-block"
             fill="currentColor"
             focusable="false"
@@ -1276,10 +1276,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx label pills should render l
             width="12"
           >
             <path
-              d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+              d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
             />
             <path
-              d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
             />
           </svg>
           <span
@@ -1518,7 +1518,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx linked issue pills should r
           >
             <svg
               aria-hidden="true"
-              class="octicon octicon-issue-closed text-gitify-icon-open"
+              class="octicon octicon-issue-opened text-gitify-icon-muted"
               display="inline-block"
               fill="currentColor"
               focusable="false"
@@ -1529,10 +1529,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx linked issue pills should r
               width="12"
             >
               <path
-                d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+                d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
               />
               <path
-                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+                d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
               />
             </svg>
             <span
@@ -1639,7 +1639,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx linked issue pills should r
         >
           <svg
             aria-hidden="true"
-            class="octicon octicon-issue-closed text-gitify-icon-open"
+            class="octicon octicon-issue-opened text-gitify-icon-muted"
             display="inline-block"
             fill="currentColor"
             focusable="false"
@@ -1650,10 +1650,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx linked issue pills should r
             width="12"
           >
             <path
-              d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+              d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
             />
             <path
-              d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
             />
           </svg>
           <span
@@ -1817,7 +1817,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx linked issue pills should r
           >
             <svg
               aria-hidden="true"
-              class="octicon octicon-issue-closed text-gitify-icon-open"
+              class="octicon octicon-issue-opened text-gitify-icon-muted"
               display="inline-block"
               fill="currentColor"
               focusable="false"
@@ -1828,10 +1828,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx linked issue pills should r
               width="12"
             >
               <path
-                d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+                d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
               />
               <path
-                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+                d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
               />
             </svg>
             <span
@@ -1938,7 +1938,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx linked issue pills should r
         >
           <svg
             aria-hidden="true"
-            class="octicon octicon-issue-closed text-gitify-icon-open"
+            class="octicon octicon-issue-opened text-gitify-icon-muted"
             display="inline-block"
             fill="currentColor"
             focusable="false"
@@ -1949,10 +1949,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx linked issue pills should r
             width="12"
           >
             <path
-              d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+              d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
             />
             <path
-              d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
             />
           </svg>
           <span
@@ -2116,7 +2116,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
           >
             <svg
               aria-hidden="true"
-              class="octicon octicon-issue-closed text-gitify-icon-open"
+              class="octicon octicon-issue-opened text-gitify-icon-muted"
               display="inline-block"
               fill="currentColor"
               focusable="false"
@@ -2127,10 +2127,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
               width="12"
             >
               <path
-                d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+                d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
               />
               <path
-                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+                d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
               />
             </svg>
             <span
@@ -2344,7 +2344,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
         >
           <svg
             aria-hidden="true"
-            class="octicon octicon-issue-closed text-gitify-icon-open"
+            class="octicon octicon-issue-opened text-gitify-icon-muted"
             display="inline-block"
             fill="currentColor"
             focusable="false"
@@ -2355,10 +2355,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
             width="12"
           >
             <path
-              d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+              d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
             />
             <path
-              d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
             />
           </svg>
           <span
@@ -2629,7 +2629,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
           >
             <svg
               aria-hidden="true"
-              class="octicon octicon-issue-closed text-gitify-icon-open"
+              class="octicon octicon-issue-opened text-gitify-icon-muted"
               display="inline-block"
               fill="currentColor"
               focusable="false"
@@ -2640,10 +2640,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
               width="12"
             >
               <path
-                d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+                d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
               />
               <path
-                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+                d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
               />
             </svg>
             <span
@@ -2857,7 +2857,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
         >
           <svg
             aria-hidden="true"
-            class="octicon octicon-issue-closed text-gitify-icon-open"
+            class="octicon octicon-issue-opened text-gitify-icon-muted"
             display="inline-block"
             fill="currentColor"
             focusable="false"
@@ -2868,10 +2868,10 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
             width="12"
           >
             <path
-              d="M11.28 6.78a.75.75 0 0 0-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l3.5-3.5Z"
+              d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
             />
             <path
-              d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 1 0-13 0 6.5 6.5 0 0 0 13 0Z"
+              d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
             />
           </svg>
           <span

--- a/src/renderer/components/settings/NotificationSettings.tsx
+++ b/src/renderer/components/settings/NotificationSettings.tsx
@@ -5,7 +5,7 @@ import {
   CheckIcon,
   CommentIcon,
   GitPullRequestIcon,
-  IssueClosedIcon,
+  IssueOpenedIcon,
   MilestoneIcon,
   TagIcon,
 } from '@primer/octicons-react';
@@ -105,7 +105,7 @@ export const NotificationSettings: FC = () => {
                   <Box className="pl-4">
                     <Stack direction="vertical" gap="none">
                       <Stack direction="horizontal" gap="condensed">
-                        <IssueClosedIcon size={Size.SMALL} />
+                        <IssueOpenedIcon size={Size.SMALL} />
                         linked issues
                       </Stack>
                       <Stack direction="horizontal" gap="condensed">
@@ -150,7 +150,7 @@ export const NotificationSettings: FC = () => {
                       </li>
                       <li>
                         <Stack direction="horizontal" gap="condensed">
-                          <IssueClosedIcon size={Size.SMALL} />
+                          <IssueOpenedIcon size={Size.SMALL} />
                           Issue
                         </Stack>
                       </li>


### PR DESCRIPTION
Closes https://github.com/gitify-app/gitify/issues/2193

Changes linked issue icon in PRs to use [IssueOpenedIcon](https://primer.style/octicons/icon/issue-opened-24/).

Before:
<img width="480" height="76" alt="Screenshot 2025-08-29 at 11 04 49 AM" src="https://github.com/user-attachments/assets/390235c5-4579-444b-b254-f90abf66268e" />

After:
<img width="492" height="90" alt="Screenshot 2025-08-29 at 3 07 22 PM" src="https://github.com/user-attachments/assets/d894056e-76b1-440b-b7c3-7a1cbfe01a1c" />
