### PR TITLE
fix: account token encryption/decryption

### DIFF
--- a/src/renderer/context/App.tsx
+++ b/src/renderer/context/App.tsx
@@ -161,6 +161,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     );
 
     const updatedAuth: AuthState = {
+      ...auth,
       accounts: refreshedAccounts,
     };
 
@@ -199,6 +200,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     }
 
     const updatedAuth: AuthState = {
+      ...auth,
       accounts: migratedAccounts,
     };
 


### PR DESCRIPTION
Resolves #2420 

Even though we've had this migration code since v6.0.0, upon closer inspection we were previously only migrating on-startup in memory and never persisting back to storage (oops).

This should restore the migration logic, and importantly, persist the encrypted token back to disk for next time.

Also adds similar logic to write back refreshed accounts to local storage