### PR TITLE
chore(biome): disable useUniqueElementIds rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -55,7 +55,7 @@
             ]
           }
         },
-        "useUniqueElementIds": "warn"
+        "useUniqueElementIds": "off"
       },
       "style": {
         "useDefaultSwitchClause": "error",


### PR DESCRIPTION
## Summary
- Disable the `useUniqueElementIds` biome lint rule

## Rationale
This rule warns against hardcoded `id` attributes and suggests using React's `useId()` hook. However, this is inappropriate for an Electron app:

1. **No SSR** - `useId()` was designed to solve hydration mismatch issues between server and client. Gitify is a desktop app with no server rendering.
2. **No collision risk** - Components like filters render once per page, not in dynamic lists where ID collisions could occur.
3. **Worse DX** - Replaces readable IDs like `filter-state` with opaque generated IDs like `:r1:`, making debugging harder.

## Test plan
- [x] Lint passes with rule disabled