### PR TITLE
refactor: clear separation between mock utils

### DIFF
--- a/src/renderer/__mocks__/account-mocks.ts
+++ b/src/renderer/__mocks__/account-mocks.ts
@@ -8,6 +8,15 @@ import type {
 } from '../types';
 import { mockGitifyUser } from './user-mocks';
 
+export const mockGitHubAppAccount: Account = {
+  platform: 'GitHub Cloud',
+  method: 'GitHub App',
+  token: 'token-987654321' as Token,
+  hostname: Constants.DEFAULT_AUTH_OPTIONS.hostname,
+  user: mockGitifyUser,
+  hasRequiredScopes: true,
+};
+
 export const mockPersonalAccessTokenAccount: Account = {
   platform: 'GitHub Cloud',
   method: 'Personal Access Token',
@@ -20,7 +29,7 @@ export const mockPersonalAccessTokenAccount: Account = {
 export const mockOAuthAccount: Account = {
   platform: 'GitHub Enterprise Server',
   method: 'OAuth App',
-  token: '1234568790' as Token,
+  token: 'token-1234568790' as Token,
   hostname: 'github.gitify.io' as Hostname,
   user: mockGitifyUser,
   hasRequiredScopes: true,
@@ -39,24 +48,13 @@ export const mockGitHubCloudAccount: Account = {
 export const mockGitHubEnterpriseServerAccount: Account = {
   platform: 'GitHub Enterprise Server',
   method: 'Personal Access Token',
-  token: '1234568790' as Token,
+  token: 'token-1234568790' as Token,
   hostname: 'github.gitify.io' as Hostname,
   user: mockGitifyUser,
   hasRequiredScopes: true,
 };
 
-export const mockGitHubAppAccount: Account = {
-  platform: 'GitHub Cloud',
-  method: 'GitHub App',
-  token: '987654321' as Token,
-  hostname: Constants.DEFAULT_AUTH_OPTIONS.hostname,
-  user: mockGitifyUser,
-  hasRequiredScopes: true,
-};
-
-export function createMockAccountWithError(
-  error: GitifyError,
-): AccountNotifications {
+export function mockAccountWithError(error: GitifyError): AccountNotifications {
   return {
     account: mockGitHubCloudAccount,
     notifications: [],

--- a/src/renderer/__mocks__/notifications-mocks.ts
+++ b/src/renderer/__mocks__/notifications-mocks.ts
@@ -1,34 +1,185 @@
-import { Constants } from '../constants';
 import type {
   AccountNotifications,
   GitifyNotification,
+  GitifyNotificationUser,
+  GitifyOwner,
   GitifyReason,
   GitifyRepository,
   GitifySubject,
-  Hostname,
   Link,
 } from '../types';
 import {
-  mockEnterpriseNotifications,
-  mockGitHubNotifications,
-  mockSingleNotification,
-} from '../utils/api/__mocks__/response-mocks';
-import {
+  mockGitHubAppAccount,
   mockGitHubCloudAccount,
   mockGitHubEnterpriseServerAccount,
 } from './account-mocks';
-import { mockToken } from './state-mocks';
-import { mockGitifyUser } from './user-mocks';
 
-export const mockAccountNotifications: AccountNotifications[] = [
+const mockGitHubOwner: GitifyOwner = {
+  login: 'gitify-app',
+  avatarUrl:
+    'https://avatars.githubusercontent.com/u/133795385?s=200&v=4' as Link,
+  type: 'User',
+};
+
+const mockGitHubRepository: GitifyRepository = {
+  name: 'notifications-test',
+  fullName: 'gitify-app/notifications-test',
+  owner: mockGitHubOwner,
+  htmlUrl: 'https://github.com/gitify-app/notifications-test' as Link,
+};
+
+const mockSubjectUser: GitifyNotificationUser = {
+  login: 'gitify-app',
+  htmlUrl: 'https://github.com/gitify-app' as Link,
+  avatarUrl:
+    'https://avatars.githubusercontent.com/u/133795385?s=200&v=4' as Link,
+  type: 'User',
+};
+
+/**
+ * Mock Gitify Notifications for GitHub Cloud account
+ *
+ * 2 Notifications
+ * Hostname: 'github.com'
+ * Repository: 'gitify-app/notifications-test'
+ */
+export const mockGitHubCloudGitifyNotifications: GitifyNotification[] = [
   {
     account: mockGitHubCloudAccount,
-    notifications: mockGitHubNotifications,
+    order: 0,
+    id: '138661096',
+    unread: true,
+    reason: {
+      code: 'subscribed',
+      title: 'Updated',
+      description: "You're watching the repository.",
+    },
+    updatedAt: '2017-05-20T17:51:57Z',
+    subject: {
+      title: 'I am a robot and this is a test!',
+      url: 'https://api.github.com/repos/gitify-app/notifications-test/issues/1' as Link,
+      latestCommentUrl:
+        'https://api.github.com/repos/gitify-app/notifications-test/issues/comments/302888448' as Link,
+      type: 'Issue',
+      state: 'OPEN',
+      user: mockSubjectUser,
+      reviews: [
+        {
+          state: 'APPROVED',
+          users: ['octocat'],
+        },
+        {
+          state: 'CHANGES_REQUESTED',
+          users: ['gitify-app'],
+        },
+        {
+          state: 'PENDING',
+          users: ['gitify-user'],
+        },
+      ],
+    },
+    repository: mockGitHubRepository,
+  },
+  {
+    account: mockGitHubCloudAccount,
+    order: 1,
+    id: '148827438',
+    unread: true,
+    reason: {
+      code: 'author',
+      title: 'Authored',
+      description: 'You created the thread.',
+    },
+    updatedAt: '2017-05-20T17:06:34Z',
+    subject: {
+      title: 'Improve the UI',
+      url: 'https://api.github.com/repos/gitify-app/notifications-test/issues/4' as Link,
+      latestCommentUrl:
+        'https://api.github.com/repos/gitify-app/notifications-test/issues/comments/302885965' as Link,
+      type: 'Issue',
+      reviews: null,
+    },
+    repository: mockGitHubRepository,
+  },
+];
+
+const mockEnterpriseOwner: GitifyOwner = {
+  login: 'myorg',
+  avatarUrl: 'https://github.gitify.io/avatars/u/4?' as Link,
+  type: 'Organization',
+};
+
+const mockEnterpriseRepository: GitifyRepository = {
+  name: 'notifications-test',
+  fullName: 'myorg/notifications-test',
+  owner: mockEnterpriseOwner,
+  htmlUrl: 'https://github.gitify.io/myorg/notifications-test' as Link,
+};
+
+/**
+ * Mock Gitify Notifications for GitHub Enterprise account
+ *
+ * 2 Notifications
+ * Hostname: 'github.gitify.io'
+ * Repository: 'myorg/notifications-test'
+ */
+export const mockGithubEnterpriseGitifyNotifications: GitifyNotification[] = [
+  {
+    account: mockGitHubEnterpriseServerAccount,
+    order: 0,
+    id: '3',
+    unread: true,
+    reason: {
+      code: 'subscribed',
+      title: 'Updated',
+      description: "You're watching the repository.",
+    },
+    updatedAt: '2017-05-20T13:02:48Z',
+    subject: {
+      title: 'Release 0.0.1',
+      url: 'https://github.gitify.io/api/v3/repos/myorg/notifications-test/releases/3' as Link,
+      latestCommentUrl:
+        'https://github.gitify.io/api/v3/repos/myorg/notifications-test/releases/3' as Link,
+      type: 'Release',
+      reviews: null,
+    },
+    repository: mockEnterpriseRepository,
+  },
+  {
+    account: mockGitHubEnterpriseServerAccount,
+    order: 1,
+    id: '4',
+    unread: true,
+    reason: {
+      code: 'subscribed',
+      title: 'Updated',
+      description: "You're watching the repository.",
+    },
+    updatedAt: '2017-05-20T15:52:20Z',
+    subject: {
+      title: 'Bump Version',
+      url: 'https://github.gitify.io/api/v3/repos/myorg/notifications-test/pulls/4' as Link,
+      latestCommentUrl:
+        'https://github.gitify.io/api/v3/repos/myorg/notifications-test/issues/comments/21' as Link,
+      type: 'PullRequest',
+      reviews: null,
+    },
+    repository: mockEnterpriseRepository,
+  },
+];
+
+export const mockGitifyNotification: GitifyNotification =
+  mockGitHubCloudGitifyNotifications[0];
+
+export const mockMultipleAccountNotifications: AccountNotifications[] = [
+  {
+    account: mockGitHubCloudAccount,
+    notifications: mockGitHubCloudGitifyNotifications,
     error: null,
   },
   {
     account: mockGitHubEnterpriseServerAccount,
-    notifications: mockEnterpriseNotifications,
+    notifications: mockGithubEnterpriseGitifyNotifications,
     error: null,
   },
 ];
@@ -36,29 +187,23 @@ export const mockAccountNotifications: AccountNotifications[] = [
 export const mockSingleAccountNotifications: AccountNotifications[] = [
   {
     account: mockGitHubCloudAccount,
-    notifications: [mockSingleNotification],
+    notifications: [mockGitifyNotification],
     error: null,
   },
 ];
 
-export function createPartialMockNotification(
+export function mockPartialGitifyNotification(
   subject: Partial<GitifySubject>,
   repository?: Partial<GitifyRepository>,
 ): GitifyNotification {
   const mockNotification: Partial<GitifyNotification> = {
-    account: {
-      method: 'Personal Access Token',
-      platform: 'GitHub Cloud',
-      hostname: Constants.GITHUB_API_BASE_URL as Hostname,
-      token: mockToken,
-      user: mockGitifyUser,
-      hasRequiredScopes: true,
-    },
+    account: mockGitHubAppAccount,
     reason: {
       code: 'subscribed',
       title: 'Updated',
       description: "You're watching the repository.",
     } as GitifyReason,
+    updatedAt: '2026-01-01T17:00:00Z',
     subject: subject as GitifySubject,
     repository: {
       name: 'notifications-test',
@@ -76,7 +221,7 @@ export function createPartialMockNotification(
   return mockNotification as GitifyNotification;
 }
 
-export function createMockNotificationForRepoName(
+export function mockGitifyNotificationForRepoName(
   id: string,
   repoFullName: string | null,
 ): GitifyNotification {

--- a/src/renderer/__mocks__/user-mocks.ts
+++ b/src/renderer/__mocks__/user-mocks.ts
@@ -1,6 +1,4 @@
 import type { GitifyNotificationUser, GitifyUser, Link } from '../types';
-import type { AuthorFieldsFragment } from '../utils/api/graphql/generated/graphql';
-import type { RawUser } from '../utils/api/types';
 
 export const mockGitifyUser: GitifyUser = {
   login: 'octocat',
@@ -9,18 +7,7 @@ export const mockGitifyUser: GitifyUser = {
   avatar: 'https://avatars.githubusercontent.com/u/583231?v=4' as Link,
 };
 
-export function createPartialMockUser(login: string): RawUser {
-  const mockUser: Partial<RawUser> = {
-    login: login,
-    html_url: `https://github.com/${login}` as Link,
-    avatar_url: 'https://avatars.githubusercontent.com/u/583231?v=4' as Link,
-    type: 'User',
-  };
-
-  return mockUser as RawUser;
-}
-
-export function createMockGitifyNotificationUser(
+export function mockGitifyNotificationUser(
   login: string,
 ): GitifyNotificationUser {
   return {
@@ -29,14 +16,4 @@ export function createMockGitifyNotificationUser(
     avatarUrl: 'https://avatars.githubusercontent.com/u/583231?v=4' as Link,
     type: 'User',
   };
-}
-
-/**
- * Creates a mock author for use in GraphQL response mocks.
- */
-export function createMockGraphQLAuthor(login: string): AuthorFieldsFragment {
-  return {
-    ...createMockGitifyNotificationUser(login),
-    __typename: 'User',
-  } as AuthorFieldsFragment;
 }

--- a/src/renderer/components/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
 import { renderWithAppContext } from '../__helpers__/test-utils';
-import { mockAccountNotifications } from '../__mocks__/notifications-mocks';
+import { mockMultipleAccountNotifications } from '../__mocks__/notifications-mocks';
 import { mockSettings } from '../__mocks__/state-mocks';
 import * as comms from '../utils/comms';
 import { Sidebar } from './Sidebar';
@@ -98,7 +98,7 @@ describe('renderer/components/Sidebar.tsx', () => {
           <Sidebar />
         </MemoryRouter>,
         {
-          notifications: mockAccountNotifications,
+          notifications: mockMultipleAccountNotifications,
         },
       );
 
@@ -159,7 +159,7 @@ describe('renderer/components/Sidebar.tsx', () => {
           <Sidebar />
         </MemoryRouter>,
         {
-          notifications: mockAccountNotifications,
+          notifications: mockMultipleAccountNotifications,
         },
       );
 
@@ -177,7 +177,7 @@ describe('renderer/components/Sidebar.tsx', () => {
           <Sidebar />
         </MemoryRouter>,
         {
-          notifications: mockAccountNotifications,
+          notifications: mockMultipleAccountNotifications,
         },
       );
 

--- a/src/renderer/components/filters/FilterSection.test.tsx
+++ b/src/renderer/components/filters/FilterSection.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { MarkGithubIcon } from '@primer/octicons-react';
 
 import { renderWithAppContext } from '../../__helpers__/test-utils';
-import { mockAccountNotifications } from '../../__mocks__/notifications-mocks';
+import { mockMultipleAccountNotifications } from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
 import { stateFilter } from '../../utils/notifications/filters';
 import { FilterSection } from './FilterSection';
@@ -33,7 +33,7 @@ describe('renderer/components/filters/FilterSection.tsx', () => {
             ...mockSettings,
             detailedNotifications: true,
           },
-          notifications: mockAccountNotifications,
+          notifications: mockMultipleAccountNotifications,
         },
       );
 
@@ -57,7 +57,7 @@ describe('renderer/components/filters/FilterSection.tsx', () => {
             ...mockSettings,
             detailedNotifications: false,
           },
-          notifications: mockAccountNotifications,
+          notifications: mockMultipleAccountNotifications,
         },
       );
 

--- a/src/renderer/components/filters/ReasonFilter.test.tsx
+++ b/src/renderer/components/filters/ReasonFilter.test.tsx
@@ -1,11 +1,11 @@
 import { renderWithAppContext } from '../../__helpers__/test-utils';
-import { mockAccountNotifications } from '../../__mocks__/notifications-mocks';
+import { mockMultipleAccountNotifications } from '../../__mocks__/notifications-mocks';
 import { ReasonFilter } from './ReasonFilter';
 
 describe('renderer/components/filters/ReasonFilter.tsx', () => {
   it('should render itself & its children', () => {
     const tree = renderWithAppContext(<ReasonFilter />, {
-      notifications: mockAccountNotifications,
+      notifications: mockMultipleAccountNotifications,
     });
 
     expect(tree).toMatchSnapshot();

--- a/src/renderer/components/filters/StateFilter.test.tsx
+++ b/src/renderer/components/filters/StateFilter.test.tsx
@@ -1,11 +1,11 @@
 import { renderWithAppContext } from '../../__helpers__/test-utils';
-import { mockAccountNotifications } from '../../__mocks__/notifications-mocks';
+import { mockMultipleAccountNotifications } from '../../__mocks__/notifications-mocks';
 import { StateFilter } from './StateFilter';
 
 describe('renderer/components/filters/StateFilter.tsx', () => {
   it('should render itself & its children', () => {
     const tree = renderWithAppContext(<StateFilter />, {
-      notifications: mockAccountNotifications,
+      notifications: mockMultipleAccountNotifications,
     });
 
     expect(tree).toMatchSnapshot();

--- a/src/renderer/components/filters/SubjectTypeFilter.test.tsx
+++ b/src/renderer/components/filters/SubjectTypeFilter.test.tsx
@@ -1,11 +1,11 @@
 import { renderWithAppContext } from '../../__helpers__/test-utils';
-import { mockAccountNotifications } from '../../__mocks__/notifications-mocks';
+import { mockMultipleAccountNotifications } from '../../__mocks__/notifications-mocks';
 import { SubjectTypeFilter } from './SubjectTypeFilter';
 
 describe('renderer/components/filters/SubjectTypeFilter.tsx', () => {
   it('should render itself & its children', () => {
     const tree = renderWithAppContext(<SubjectTypeFilter />, {
-      notifications: mockAccountNotifications,
+      notifications: mockMultipleAccountNotifications,
     });
 
     expect(tree).toMatchSnapshot();

--- a/src/renderer/components/filters/UserTypeFilter.test.tsx
+++ b/src/renderer/components/filters/UserTypeFilter.test.tsx
@@ -1,11 +1,11 @@
 import { renderWithAppContext } from '../../__helpers__/test-utils';
-import { mockAccountNotifications } from '../../__mocks__/notifications-mocks';
+import { mockMultipleAccountNotifications } from '../../__mocks__/notifications-mocks';
 import { UserTypeFilter } from './UserTypeFilter';
 
 describe('renderer/components/filters/UserTypeFilter.tsx', () => {
   it('should render itself & its children', () => {
     const tree = renderWithAppContext(<UserTypeFilter />, {
-      notifications: mockAccountNotifications,
+      notifications: mockMultipleAccountNotifications,
     });
 
     expect(tree).toMatchSnapshot();

--- a/src/renderer/components/metrics/MetricGroup.test.tsx
+++ b/src/renderer/components/metrics/MetricGroup.test.tsx
@@ -1,13 +1,13 @@
 import { renderWithAppContext } from '../../__helpers__/test-utils';
+import { mockGitifyNotification } from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
 import type { GitifyMilestone } from '../../types';
-import { mockSingleNotification } from '../../utils/api/__mocks__/response-mocks';
 import { MetricGroup } from './MetricGroup';
 
 describe('renderer/components/metrics/MetricGroup.tsx', () => {
   describe('showPills disabled', () => {
     it('should not render any pills when showPills is disabled', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
 
       const props = {
         notification: mockNotification,
@@ -22,7 +22,7 @@ describe('renderer/components/metrics/MetricGroup.tsx', () => {
 
   describe('linked issue pills', () => {
     it('should render issues pill when linked to one issue/pr', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.linkedIssues = ['#1'];
 
       const props = {
@@ -34,7 +34,7 @@ describe('renderer/components/metrics/MetricGroup.tsx', () => {
     });
 
     it('should render issues pill when linked to multiple issues/prs', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.linkedIssues = ['#1', '#2'];
 
       const props = {
@@ -48,7 +48,7 @@ describe('renderer/components/metrics/MetricGroup.tsx', () => {
 
   describe('comment pills', () => {
     it('should render when no comments', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.comments = null;
 
       const props = {
@@ -60,7 +60,7 @@ describe('renderer/components/metrics/MetricGroup.tsx', () => {
     });
 
     it('should render when 1 comment', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.comments = 1;
 
       const props = {
@@ -72,7 +72,7 @@ describe('renderer/components/metrics/MetricGroup.tsx', () => {
     });
 
     it('should render when more than 1 comments', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.comments = 2;
 
       const props = {
@@ -86,7 +86,7 @@ describe('renderer/components/metrics/MetricGroup.tsx', () => {
 
   describe('label pills', () => {
     it('should render labels pill', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.labels = ['enhancement', 'good-first-issue'];
 
       const props = {
@@ -100,7 +100,7 @@ describe('renderer/components/metrics/MetricGroup.tsx', () => {
 
   describe('milestone pills', () => {
     it('should render open milestone pill', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.milestone = {
         title: 'Milestone 1',
         state: 'OPEN',
@@ -115,7 +115,7 @@ describe('renderer/components/metrics/MetricGroup.tsx', () => {
     });
 
     it('should render closed milestone pill', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.milestone = {
         title: 'Milestone 1',
         state: 'CLOSED',

--- a/src/renderer/components/notifications/AccountNotifications.test.tsx
+++ b/src/renderer/components/notifications/AccountNotifications.test.tsx
@@ -6,9 +6,9 @@ import {
   renderWithAppContext,
 } from '../../__helpers__/test-utils';
 import { mockGitHubCloudAccount } from '../../__mocks__/account-mocks';
+import { mockGitHubCloudGitifyNotifications } from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
 import { GroupBy } from '../../types';
-import { mockGitHubNotifications } from '../../utils/api/__mocks__/response-mocks';
 import * as links from '../../utils/links';
 import { AccountNotifications } from './AccountNotifications';
 
@@ -24,7 +24,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
   it('should render itself - group notifications by repositories', () => {
     const props = {
       account: mockGitHubCloudAccount,
-      notifications: mockGitHubNotifications,
+      notifications: mockGitHubCloudGitifyNotifications,
       showAccountHeader: true,
       error: null,
     };
@@ -39,7 +39,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
   it('should render itself - group notifications by date', () => {
     const props = {
       account: mockGitHubCloudAccount,
-      notifications: mockGitHubNotifications,
+      notifications: mockGitHubCloudGitifyNotifications,
       showAccountHeader: true,
       error: null,
     };
@@ -179,7 +179,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
   it('should toggle account notifications visibility', async () => {
     const props = {
       account: mockGitHubCloudAccount,
-      notifications: mockGitHubNotifications,
+      notifications: mockGitHubCloudGitifyNotifications,
       showAccountHeader: true,
       error: null,
     };

--- a/src/renderer/components/notifications/NotificationFooter.test.tsx
+++ b/src/renderer/components/notifications/NotificationFooter.test.tsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event';
 
 import { renderWithAppContext } from '../../__helpers__/test-utils';
 import { mockGitHubCloudAccount } from '../../__mocks__/account-mocks';
+import { mockGitifyNotification } from '../../__mocks__/notifications-mocks';
 import type { GitifyNotificationUser, Link } from '../../types';
-import { mockSingleNotification } from '../../utils/api/__mocks__/response-mocks';
 import * as comms from '../../utils/comms';
 import { NotificationFooter } from './NotificationFooter';
 
@@ -19,7 +19,7 @@ describe('renderer/components/notifications/NotificationFooter.tsx', () => {
 
   it('should render itself & its children', async () => {
     const props = {
-      notification: mockSingleNotification,
+      notification: mockGitifyNotification,
     };
 
     const tree = renderWithAppContext(<NotificationFooter {...props} />);
@@ -29,7 +29,7 @@ describe('renderer/components/notifications/NotificationFooter.tsx', () => {
 
   describe('security alerts should use github icon for avatar', () => {
     it('Repository Dependabot Alerts Thread', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.type = 'RepositoryDependabotAlertsThread';
 
       const props = {
@@ -42,7 +42,7 @@ describe('renderer/components/notifications/NotificationFooter.tsx', () => {
     });
 
     it('Repository Vulnerability Alert', async () => {
-      const mockNotification = mockSingleNotification;
+      const mockNotification = mockGitifyNotification;
       mockNotification.subject.type = 'RepositoryVulnerabilityAlert';
 
       const props = {
@@ -56,7 +56,7 @@ describe('renderer/components/notifications/NotificationFooter.tsx', () => {
   });
 
   it('should default to known avatar if no user found', async () => {
-    const mockNotification = mockSingleNotification;
+    const mockNotification = mockGitifyNotification;
     mockNotification.subject.user = null;
 
     const props = {
@@ -75,14 +75,14 @@ describe('renderer/components/notifications/NotificationFooter.tsx', () => {
 
     const props = {
       notification: {
-        ...mockSingleNotification,
+        ...mockGitifyNotification,
         subject: {
-          ...mockSingleNotification.subject,
+          ...mockGitifyNotification.subject,
           user: {
             login: 'some-user',
             htmlUrl: 'https://github.com/some-user' as Link,
             avatarUrl:
-              'https://avatars.githubusercontent.com/u/123456789?v=4' as Link,
+              'https://avatars.githubusercontent.com/u/583231?v=4' as Link,
             type: 'User' as GitifyNotificationUser['type'],
           },
           reviews: null,

--- a/src/renderer/components/notifications/NotificationHeader.test.tsx
+++ b/src/renderer/components/notifications/NotificationHeader.test.tsx
@@ -2,9 +2,9 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { renderWithAppContext } from '../../__helpers__/test-utils';
+import { mockGitifyNotification } from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
 import { GroupBy } from '../../types';
-import { mockSingleNotification } from '../../utils/api/__mocks__/response-mocks';
 import * as comms from '../../utils/comms';
 import { NotificationHeader } from './NotificationHeader';
 
@@ -15,7 +15,7 @@ describe('renderer/components/notifications/NotificationHeader.tsx', () => {
 
   it('should render itself & its children - group by repositories', async () => {
     const props = {
-      notification: mockSingleNotification,
+      notification: mockGitifyNotification,
     };
 
     const tree = renderWithAppContext(<NotificationHeader {...props} />, {
@@ -28,7 +28,7 @@ describe('renderer/components/notifications/NotificationHeader.tsx', () => {
   describe('should render itself & its children - group by date', () => {
     it('with notification number', async () => {
       const props = {
-        notification: mockSingleNotification,
+        notification: mockGitifyNotification,
       };
 
       const tree = renderWithAppContext(<NotificationHeader {...props} />, {
@@ -40,7 +40,7 @@ describe('renderer/components/notifications/NotificationHeader.tsx', () => {
 
     it('with showNumber setting disabled', async () => {
       const props = {
-        notification: mockSingleNotification,
+        notification: mockGitifyNotification,
       };
 
       const tree = renderWithAppContext(<NotificationHeader {...props} />, {
@@ -57,8 +57,8 @@ describe('renderer/components/notifications/NotificationHeader.tsx', () => {
     it('without notification number', async () => {
       const props = {
         notification: {
-          ...mockSingleNotification,
-          subject: { ...mockSingleNotification.subject, number: null },
+          ...mockGitifyNotification,
+          subject: { ...mockGitifyNotification.subject, number: null },
         },
       };
 
@@ -76,7 +76,7 @@ describe('renderer/components/notifications/NotificationHeader.tsx', () => {
       .mockImplementation();
 
     const props = {
-      notification: mockSingleNotification,
+      notification: mockGitifyNotification,
     };
 
     renderWithAppContext(<NotificationHeader {...props} />, {

--- a/src/renderer/components/notifications/NotificationRow.test.tsx
+++ b/src/renderer/components/notifications/NotificationRow.test.tsx
@@ -3,9 +3,9 @@ import userEvent from '@testing-library/user-event';
 
 import { renderWithAppContext } from '../../__helpers__/test-utils';
 import { mockGitHubCloudAccount } from '../../__mocks__/account-mocks';
+import { mockGitifyNotification } from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
 import { GroupBy } from '../../types';
-import { mockSingleNotification } from '../../utils/api/__mocks__/response-mocks';
 import * as comms from '../../utils/comms';
 import * as links from '../../utils/links';
 import { NotificationRow } from './NotificationRow';
@@ -23,7 +23,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
 
   it('should render itself & its children - group by date', async () => {
     const props = {
-      notification: mockSingleNotification,
+      notification: mockGitifyNotification,
       account: mockGitHubCloudAccount,
     };
 
@@ -36,7 +36,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
 
   it('should render itself & its children - group by repositories', async () => {
     const props = {
-      notification: mockSingleNotification,
+      notification: mockGitifyNotification,
       account: mockGitHubCloudAccount,
     };
 
@@ -49,7 +49,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
 
   it('should render itself & its children - hide numbers', async () => {
     const props = {
-      notification: mockSingleNotification,
+      notification: mockGitifyNotification,
       account: mockGitHubCloudAccount,
     };
 
@@ -63,7 +63,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
   it('should render itself & its children - notification is read', async () => {
     const props = {
       notification: {
-        ...mockSingleNotification,
+        ...mockGitifyNotification,
         unread: false,
       },
       account: mockGitHubCloudAccount,
@@ -79,7 +79,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
       const markNotificationsAsReadMock = jest.fn();
 
       const props = {
-        notification: mockSingleNotification,
+        notification: mockGitifyNotification,
         account: mockGitHubCloudAccount,
       };
 
@@ -98,7 +98,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
       const markNotificationsAsReadMock = jest.fn();
 
       const props = {
-        notification: mockSingleNotification,
+        notification: mockGitifyNotification,
         account: mockGitHubCloudAccount,
       };
 
@@ -121,7 +121,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
       const markNotificationsAsDoneMock = jest.fn();
 
       const props = {
-        notification: mockSingleNotification,
+        notification: mockGitifyNotification,
         account: mockGitHubCloudAccount,
       };
 
@@ -140,7 +140,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
       const markNotificationsAsReadMock = jest.fn();
 
       const props = {
-        notification: mockSingleNotification,
+        notification: mockGitifyNotification,
         account: mockGitHubCloudAccount,
       };
 
@@ -158,7 +158,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
       const markNotificationsAsDoneMock = jest.fn();
 
       const props = {
-        notification: mockSingleNotification,
+        notification: mockGitifyNotification,
         account: mockGitHubCloudAccount,
       };
 
@@ -176,7 +176,7 @@ describe('renderer/components/notifications/NotificationRow.tsx', () => {
       const unsubscribeNotificationMock = jest.fn();
 
       const props = {
-        notification: mockSingleNotification,
+        notification: mockGitifyNotification,
         account: mockGitHubCloudAccount,
       };
 

--- a/src/renderer/components/notifications/RepositoryNotifications.test.tsx
+++ b/src/renderer/components/notifications/RepositoryNotifications.test.tsx
@@ -3,9 +3,9 @@ import userEvent from '@testing-library/user-event';
 
 import { renderWithAppContext } from '../../__helpers__/test-utils';
 import { mockGitHubCloudAccount } from '../../__mocks__/account-mocks';
+import { mockGitHubCloudGitifyNotifications } from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
 import type { Link } from '../../types';
-import { mockGitHubNotifications } from '../../utils/api/__mocks__/response-mocks';
 import * as comms from '../../utils/comms';
 import { RepositoryNotifications } from './RepositoryNotifications';
 
@@ -20,7 +20,7 @@ describe('renderer/components/notifications/RepositoryNotifications.tsx', () => 
   const props = {
     account: mockGitHubCloudAccount,
     repoName: 'gitify-app/notifications-test',
-    repoNotifications: mockGitHubNotifications,
+    repoNotifications: mockGitHubCloudGitifyNotifications,
   };
 
   afterEach(() => {
@@ -67,7 +67,7 @@ describe('renderer/components/notifications/RepositoryNotifications.tsx', () => 
     await userEvent.click(screen.getByTestId('repository-mark-as-read'));
 
     expect(markNotificationsAsReadMock).toHaveBeenCalledWith(
-      mockGitHubNotifications,
+      mockGitHubCloudGitifyNotifications,
     );
   });
 
@@ -80,7 +80,7 @@ describe('renderer/components/notifications/RepositoryNotifications.tsx', () => 
     await userEvent.click(screen.getByTestId('repository-mark-as-done'));
 
     expect(markNotificationsAsDoneMock).toHaveBeenCalledWith(
-      mockGitHubNotifications,
+      mockGitHubCloudGitifyNotifications,
     );
   });
 

--- a/src/renderer/context/App.test.tsx
+++ b/src/renderer/context/App.test.tsx
@@ -2,11 +2,11 @@ import { act, fireEvent, waitFor } from '@testing-library/react';
 import { useContext } from 'react';
 
 import { renderWithAppContext } from '../__helpers__/test-utils';
+import { mockGitifyNotification } from '../__mocks__/notifications-mocks';
 import { mockSettings } from '../__mocks__/state-mocks';
 import { Constants } from '../constants';
 import { useNotifications } from '../hooks/useNotifications';
 import type { AuthState, Hostname, SettingsState, Token } from '../types';
-import { mockSingleNotification } from '../utils/api/__mocks__/response-mocks';
 import * as apiRequests from '../utils/api/request';
 import * as notifications from '../utils/notifications/notifications';
 import * as storage from '../utils/storage';
@@ -133,7 +133,7 @@ describe('renderer/context/App.tsx', () => {
 
     it('should call markNotificationsAsRead', async () => {
       const { button } = renderContextButton('markNotificationsAsRead', [
-        mockSingleNotification,
+        mockGitifyNotification,
       ]);
 
       fireEvent.click(button);
@@ -141,14 +141,14 @@ describe('renderer/context/App.tsx', () => {
       expect(markNotificationsAsReadMock).toHaveBeenCalledTimes(1);
       expect(markNotificationsAsReadMock).toHaveBeenCalledWith(
         mockDefaultState,
-        [mockSingleNotification],
+        [mockGitifyNotification],
       );
       expect(setTrayIconColorAndTitleSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should call markNotificationsAsDone', async () => {
       const { button } = renderContextButton('markNotificationsAsDone', [
-        mockSingleNotification,
+        mockGitifyNotification,
       ]);
 
       fireEvent.click(button);
@@ -156,7 +156,7 @@ describe('renderer/context/App.tsx', () => {
       expect(markNotificationsAsDoneMock).toHaveBeenCalledTimes(1);
       expect(markNotificationsAsDoneMock).toHaveBeenCalledWith(
         mockDefaultState,
-        [mockSingleNotification],
+        [mockGitifyNotification],
       );
       expect(setTrayIconColorAndTitleSpy).toHaveBeenCalledTimes(1);
     });
@@ -164,7 +164,7 @@ describe('renderer/context/App.tsx', () => {
     it('should call unsubscribeNotification', async () => {
       const { button } = renderContextButton(
         'unsubscribeNotification',
-        mockSingleNotification,
+        mockGitifyNotification,
       );
 
       fireEvent.click(button);
@@ -172,7 +172,7 @@ describe('renderer/context/App.tsx', () => {
       expect(unsubscribeNotificationMock).toHaveBeenCalledTimes(1);
       expect(unsubscribeNotificationMock).toHaveBeenCalledWith(
         mockDefaultState,
-        mockSingleNotification,
+        mockGitifyNotification,
       );
       expect(setTrayIconColorAndTitleSpy).toHaveBeenCalledTimes(1);
     });

--- a/src/renderer/hooks/useNotifications.test.ts
+++ b/src/renderer/hooks/useNotifications.test.ts
@@ -3,8 +3,8 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import axios, { AxiosError } from 'axios';
 import nock from 'nock';
 
+import { mockGitifyNotification } from '../__mocks__/notifications-mocks';
 import { mockAuth, mockSettings, mockState } from '../__mocks__/state-mocks';
-import { mockSingleNotification } from '../utils/api/__mocks__/response-mocks';
 import { Errors } from '../utils/errors';
 import * as logger from '../utils/logger';
 import { useNotifications } from './useNotifications';
@@ -21,10 +21,10 @@ describe('renderer/hooks/useNotifications.ts', () => {
     rendererLogErrorSpy.mockReset();
 
     // Reset mock notification state between tests since it's mutated
-    mockSingleNotification.unread = true;
+    mockGitifyNotification.unread = true;
   });
 
-  const id = mockSingleNotification.id;
+  const id = mockGitifyNotification.id;
 
   describe('fetchNotifications', () => {
     it('should fetch non-detailed notifications with success', async () => {
@@ -213,7 +213,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
 
       act(() => {
         result.current.markNotificationsAsRead(mockState, [
-          mockSingleNotification,
+          mockGitifyNotification,
         ]);
       });
 
@@ -233,7 +233,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
 
       act(() => {
         result.current.markNotificationsAsRead(mockState, [
-          mockSingleNotification,
+          mockGitifyNotification,
         ]);
       });
 
@@ -256,7 +256,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
 
       act(() => {
         result.current.markNotificationsAsDone(mockState, [
-          mockSingleNotification,
+          mockGitifyNotification,
         ]);
       });
 
@@ -276,7 +276,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
 
       act(() => {
         result.current.markNotificationsAsDone(mockState, [
-          mockSingleNotification,
+          mockGitifyNotification,
         ]);
       });
 
@@ -308,7 +308,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
       act(() => {
         result.current.unsubscribeNotification(
           mockState,
-          mockSingleNotification,
+          mockGitifyNotification,
         );
       });
 
@@ -341,7 +341,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
               markAsDoneOnUnsubscribe: true,
             },
           },
-          mockSingleNotification,
+          mockGitifyNotification,
         );
       });
 
@@ -368,7 +368,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
       act(() => {
         result.current.unsubscribeNotification(
           mockState,
-          mockSingleNotification,
+          mockGitifyNotification,
         );
       });
 

--- a/src/renderer/routes/Notifications.test.tsx
+++ b/src/renderer/routes/Notifications.test.tsx
@@ -1,5 +1,5 @@
 import { renderWithAppContext } from '../__helpers__/test-utils';
-import { mockAccountNotifications } from '../__mocks__/notifications-mocks';
+import { mockMultipleAccountNotifications } from '../__mocks__/notifications-mocks';
 import { mockSettings } from '../__mocks__/state-mocks';
 import { Errors } from '../utils/errors';
 import { NotificationsRoute } from './Notifications';
@@ -19,7 +19,7 @@ jest.mock('../components/Oops', () => ({
 describe('renderer/routes/Notifications.tsx', () => {
   it('should render itself & its children (with notifications)', () => {
     const tree = renderWithAppContext(<NotificationsRoute />, {
-      notifications: mockAccountNotifications,
+      notifications: mockMultipleAccountNotifications,
     });
 
     expect(tree).toMatchSnapshot();
@@ -32,7 +32,7 @@ describe('renderer/routes/Notifications.tsx', () => {
 
   it('should render itself & its children (show account header)', () => {
     const tree = renderWithAppContext(<NotificationsRoute />, {
-      notifications: [mockAccountNotifications[0]],
+      notifications: [mockMultipleAccountNotifications[0]],
       settings: { ...mockSettings, showAccountHeader: true },
     });
     expect(tree).toMatchSnapshot();

--- a/src/renderer/utils/api/__mocks__/response-mocks.ts
+++ b/src/renderer/utils/api/__mocks__/response-mocks.ts
@@ -1,170 +1,122 @@
-import {
-  mockGitHubCloudAccount,
-  mockGitHubEnterpriseServerAccount,
-} from '../../../__mocks__/account-mocks';
+import type { Link } from '../../../types';
 import type {
-  GitifyNotification,
-  GitifyNotificationUser,
-  GitifyOwner,
-  GitifyRepository,
-  Link,
-} from '../../../types';
+  AuthorFieldsFragment,
+  DiscussionDetailsFragment,
+  DiscussionStateReason,
+  IssueDetailsFragment,
+  IssueState,
+  IssueStateReason,
+  PullRequestDetailsFragment,
+  PullRequestState,
+} from '../graphql/generated/graphql';
 import type { RawUser } from '../types';
 
-export const mockNotificationUser = {
-  id: 123456789,
-  login: 'octocat',
-  avatar_url: 'https://avatars.githubusercontent.com/u/583231?v=4' as Link,
-  url: 'https://api.github.com/users/octocat' as Link,
-  html_url: 'https://github.com/octocat' as Link,
-  type: 'User',
-} satisfies Partial<RawUser>;
+/**
+ * Creates a mock raw user [REST API]
+ */
+export function mockRawUser(login: string): RawUser {
+  const mockUser: Partial<RawUser> = {
+    login: login,
+    html_url: `https://github.com/${login}` as Link,
+    avatar_url: 'https://avatars.githubusercontent.com/u/583231?v=4' as Link,
+    type: 'User',
+  };
 
-// 2 Notifications
-// Hostname : 'github.com'
-// Repository : 'gitify-app/notifications-test'
-const mockGitHubOwner: GitifyOwner = {
-  login: 'gitify-app',
-  avatarUrl:
-    'https://avatars.githubusercontent.com/u/133795385?s=200&v=4' as Link,
-  type: 'User',
-};
+  return mockUser as RawUser;
+}
 
-const mockGitHubRepository: GitifyRepository = {
-  name: 'notifications-test',
-  fullName: 'gitify-app/notifications-test',
-  owner: mockGitHubOwner,
-  htmlUrl: 'https://github.com/gitify-app/notifications-test' as Link,
-};
+/**
+ * Creates a mock author fragment [GraphQL API]
+ */
+export const mockAuthor = mockAuthorResponseNode('notification-author');
+export const mockCommenter = mockAuthorResponseNode('notification-commenter');
+export const mockReplier = mockAuthorResponseNode('notification-replier');
 
-const mockSubjectUser: GitifyNotificationUser = {
-  login: 'gitify-app',
-  htmlUrl: 'https://github.com/gitify-app' as Link,
-  avatarUrl:
-    'https://avatars.githubusercontent.com/u/133795385?s=200&v=4' as Link,
-  type: 'User',
-};
+export function mockAuthorResponseNode(login: string): AuthorFieldsFragment {
+  return {
+    login: login,
+    htmlUrl: `https://github.com/${login}` as Link,
+    avatarUrl: 'https://avatars.githubusercontent.com/u/583231?v=4' as Link,
+    type: 'User',
+    __typename: 'User',
+  } as AuthorFieldsFragment;
+}
 
-export const mockGitHubNotifications: GitifyNotification[] = [
-  {
-    account: mockGitHubCloudAccount,
-    order: 0,
-    id: '138661096',
-    unread: true,
-    reason: {
-      code: 'subscribed',
-      title: 'Updated',
-      description: "You're watching the repository.",
+/**
+ * Creates a mock discussion fragment [GraphQL API]
+ */
+export function mockDiscussionResponseNode(mocks: {
+  stateReason?: DiscussionStateReason;
+  isAnswered: boolean;
+}): DiscussionDetailsFragment {
+  return {
+    __typename: 'Discussion',
+    number: 123,
+    title: 'This is a mock discussion',
+    url: 'https://github.com/gitify-app/notifications-test/discussions/123' as Link,
+    stateReason: mocks.stateReason,
+    isAnswered: mocks.isAnswered,
+    author: mockAuthor,
+    comments: {
+      nodes: [],
+      totalCount: 0,
     },
-    updatedAt: '2017-05-20T17:51:57Z',
-    subject: {
-      title: 'I am a robot and this is a test!',
-      url: 'https://api.github.com/repos/gitify-app/notifications-test/issues/1' as Link,
-      latestCommentUrl:
-        'https://api.github.com/repos/gitify-app/notifications-test/issues/comments/302888448' as Link,
-      type: 'Issue',
-      state: 'OPEN',
-      user: mockSubjectUser,
-      reviews: [
-        {
-          state: 'APPROVED',
-          users: ['octocat'],
-        },
-        {
-          state: 'CHANGES_REQUESTED',
-          users: ['gitify-app'],
-        },
-        {
-          state: 'PENDING',
-          users: ['gitify-user'],
-        },
-      ],
-    },
-    repository: mockGitHubRepository,
-  },
-  {
-    account: mockGitHubCloudAccount,
-    order: 1,
-    id: '148827438',
-    unread: true,
-    reason: {
-      code: 'author',
-      title: 'Authored',
-      description: 'You created the thread.',
-    },
-    updatedAt: '2017-05-20T17:06:34Z',
-    subject: {
-      title: 'Improve the UI',
-      url: 'https://api.github.com/repos/gitify-app/notifications-test/issues/4' as Link,
-      latestCommentUrl:
-        'https://api.github.com/repos/gitify-app/notifications-test/issues/comments/302885965' as Link,
-      type: 'Issue',
-      reviews: null,
-    },
-    repository: mockGitHubRepository,
-  },
-];
+    labels: null,
+  };
+}
 
-// 2 Notifications
-// Hostname : 'github.gitify.io'
-// Repository : 'myorg/notifications-test'
-const mockEnterpriseOwner: GitifyOwner = {
-  login: 'myorg',
-  avatarUrl: 'https://github.gitify.io/avatars/u/4?' as Link,
-  type: 'Organization',
-};
+/**
+ * Creates a mock issue fragment [GraphQL API]
+ */
+export function mockIssueResponseNode(mocks: {
+  state: IssueState;
+  stateReason?: IssueStateReason;
+}): IssueDetailsFragment {
+  return {
+    __typename: 'Issue',
+    number: 123,
+    title: 'PR Title',
+    state: mocks.state,
+    stateReason: mocks.stateReason,
+    url: 'https://github.com/gitify-app/notifications-test/issues/123',
+    author: mockAuthor,
+    labels: { nodes: [] },
+    comments: { totalCount: 0, nodes: [] },
+    milestone: null,
+  };
+}
 
-const mockEnterpriseRepository: GitifyRepository = {
-  name: 'notifications-test',
-  fullName: 'myorg/notifications-test',
-  owner: mockEnterpriseOwner,
-  htmlUrl: 'https://github.gitify.io/myorg/notifications-test' as Link,
-};
-
-export const mockEnterpriseNotifications: GitifyNotification[] = [
-  {
-    account: mockGitHubEnterpriseServerAccount,
-    order: 0,
-    id: '3',
-    unread: true,
-    reason: {
-      code: 'subscribed',
-      title: 'Updated',
-      description: "You're watching the repository.",
+/**
+ * Creates a mock pull request fragment [GraphQL API]
+ */
+export function mockPullRequestResponseNode(mocks: {
+  state: PullRequestState;
+  isDraft?: boolean;
+  merged?: boolean;
+  isInMergeQueue?: boolean;
+}): PullRequestDetailsFragment {
+  return {
+    __typename: 'PullRequest',
+    number: 123,
+    title: 'Test PR',
+    state: mocks.state,
+    isDraft: mocks.isDraft ?? false,
+    merged: mocks.merged ?? false,
+    isInMergeQueue: mocks.isInMergeQueue ?? false,
+    url: 'https://github.com/gitify-app/notifications-test/pulls/123',
+    author: mockAuthor,
+    labels: { nodes: [] },
+    comments: {
+      totalCount: 0,
+      nodes: [],
     },
-    updatedAt: '2017-05-20T13:02:48Z',
-    subject: {
-      title: 'Release 0.0.1',
-      url: 'https://github.gitify.io/api/v3/repos/myorg/notifications-test/releases/3' as Link,
-      latestCommentUrl:
-        'https://github.gitify.io/api/v3/repos/myorg/notifications-test/releases/3' as Link,
-      type: 'Release',
-      reviews: null,
+    reviews: {
+      totalCount: 0,
+      nodes: [],
     },
-    repository: mockEnterpriseRepository,
-  },
-  {
-    account: mockGitHubEnterpriseServerAccount,
-    order: 1,
-    id: '4',
-    unread: true,
-    reason: {
-      code: 'subscribed',
-      title: 'Updated',
-      description: "You're watching the repository.",
+    milestone: null,
+    closingIssuesReferences: {
+      nodes: [],
     },
-    updatedAt: '2017-05-20T15:52:20Z',
-    subject: {
-      title: 'Bump Version',
-      url: 'https://github.gitify.io/api/v3/repos/myorg/notifications-test/pulls/4' as Link,
-      latestCommentUrl:
-        'https://github.gitify.io/api/v3/repos/myorg/notifications-test/issues/comments/21' as Link,
-      type: 'PullRequest',
-      reviews: null,
-    },
-    repository: mockEnterpriseRepository,
-  },
-];
-
-export const mockSingleNotification: GitifyNotification =
-  mockGitHubNotifications[0];
+  };
+}

--- a/src/renderer/utils/api/client.test.ts
+++ b/src/renderer/utils/api/client.test.ts
@@ -1,7 +1,10 @@
 import axios, { type AxiosPromise, type AxiosResponse } from 'axios';
 
 import { mockGitHubCloudAccount } from '../../__mocks__/account-mocks';
-import { createPartialMockNotification } from '../../__mocks__/notifications-mocks';
+import {
+  mockGitHubCloudGitifyNotifications,
+  mockPartialGitifyNotification,
+} from '../../__mocks__/notifications-mocks';
 import { mockToken } from '../../__mocks__/state-mocks';
 import { Constants } from '../../constants';
 import type { Hostname, Link, SettingsState, Token } from '../../types';
@@ -10,7 +13,6 @@ import {
   mockAuthHeaders,
   mockNonCachedAuthHeaders,
 } from './__mocks__/request-mocks';
-import { mockGitHubNotifications } from './__mocks__/response-mocks';
 import {
   fetchAuthenticatedUserDetails,
   fetchDiscussionByNumber,
@@ -209,7 +211,7 @@ describe('renderer/utils/api/client.ts', () => {
       'performGraphQLRequest',
     );
 
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       title: 'Some discussion',
       url: 'https://api.github.com/repos/gitify-app/gitify/discussion/123' as Link,
       type: 'Discussion',
@@ -224,7 +226,7 @@ describe('renderer/utils/api/client.ts', () => {
 
     expect(performGraphQLRequestSpy).toHaveBeenCalledWith(
       'https://api.github.com/graphql',
-      mockToken,
+      mockNotification.account.token,
       FetchDiscussionByNumberDocument,
       {
         owner: mockNotification.repository.owner.login,
@@ -244,7 +246,7 @@ describe('renderer/utils/api/client.ts', () => {
       'performGraphQLRequest',
     );
 
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       title: 'Some issue',
       url: 'https://api.github.com/repos/gitify-app/gitify/issues/123' as Link,
       type: 'Issue',
@@ -259,7 +261,7 @@ describe('renderer/utils/api/client.ts', () => {
 
     expect(performGraphQLRequestSpy).toHaveBeenCalledWith(
       'https://api.github.com/graphql',
-      mockToken,
+      mockNotification.account.token,
       FetchIssueByNumberDocument,
       {
         owner: mockNotification.repository.owner.login,
@@ -277,7 +279,7 @@ describe('renderer/utils/api/client.ts', () => {
       'performGraphQLRequest',
     );
 
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       title: 'Some pull request',
       url: 'https://api.github.com/repos/gitify-app/gitify/pulls/123' as Link,
       type: 'PullRequest',
@@ -292,7 +294,7 @@ describe('renderer/utils/api/client.ts', () => {
 
     expect(performGraphQLRequestSpy).toHaveBeenCalledWith(
       'https://api.github.com/graphql',
-      mockToken,
+      mockNotification.account.token,
       FetchPullRequestByNumberDocument,
       {
         owner: mockNotification.repository.owner.login,
@@ -313,7 +315,7 @@ describe('renderer/utils/api/client.ts', () => {
         'performGraphQLRequestString',
       );
 
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Some commit',
         url: 'https://api.github.com/repos/gitify-app/gitify/commit/123' as Link,
         type: 'Commit',
@@ -356,7 +358,7 @@ describe('renderer/utils/api/client.ts', () => {
         headers: {},
       } as ExecutionResultWithHeaders<unknown>);
 
-      await fetchNotificationDetailsForList(mockGitHubNotifications);
+      await fetchNotificationDetailsForList(mockGitHubCloudGitifyNotifications);
 
       expect(performGraphQLRequestStringSpy).toHaveBeenCalledWith(
         'https://api.github.com/graphql',

--- a/src/renderer/utils/errors.test.ts
+++ b/src/renderer/utils/errors.test.ts
@@ -1,4 +1,4 @@
-import { createMockAccountWithError } from '../__mocks__/account-mocks';
+import { mockAccountWithError } from '../__mocks__/account-mocks';
 import type { AccountNotifications } from '../types';
 import {
   areAllAccountErrorsSame,
@@ -14,8 +14,8 @@ describe('renderer/utils/errors.ts', () => {
 
     it('returns false when some accounts have no error', () => {
       const items: AccountNotifications[] = [
-        createMockAccountWithError(Errors.NETWORK),
-        createMockAccountWithError(null),
+        mockAccountWithError(Errors.NETWORK),
+        mockAccountWithError(null),
       ];
 
       expect(doesAllAccountsHaveErrors(items)).toBe(false);
@@ -23,8 +23,8 @@ describe('renderer/utils/errors.ts', () => {
 
     it('returns true when every account has an error', () => {
       const items: AccountNotifications[] = [
-        createMockAccountWithError(Errors.NETWORK),
-        createMockAccountWithError(Errors.RATE_LIMITED),
+        mockAccountWithError(Errors.NETWORK),
+        mockAccountWithError(Errors.RATE_LIMITED),
       ];
 
       expect(doesAllAccountsHaveErrors(items)).toBe(true);
@@ -39,8 +39,8 @@ describe('renderer/utils/errors.ts', () => {
     it('returns true when all errors are identical object reference', () => {
       const err = Errors.NETWORK;
       const items: AccountNotifications[] = [
-        createMockAccountWithError(err),
-        createMockAccountWithError(err),
+        mockAccountWithError(err),
+        mockAccountWithError(err),
       ];
 
       expect(areAllAccountErrorsSame(items)).toBe(true);
@@ -48,8 +48,8 @@ describe('renderer/utils/errors.ts', () => {
 
     it('returns false when errors differ', () => {
       const items: AccountNotifications[] = [
-        createMockAccountWithError(Errors.NETWORK),
-        createMockAccountWithError(Errors.RATE_LIMITED),
+        mockAccountWithError(Errors.NETWORK),
+        mockAccountWithError(Errors.RATE_LIMITED),
       ];
 
       expect(areAllAccountErrorsSame(items)).toBe(false);
@@ -57,8 +57,8 @@ describe('renderer/utils/errors.ts', () => {
 
     it('returns false when one account has null error', () => {
       const items: AccountNotifications[] = [
-        createMockAccountWithError(Errors.NETWORK),
-        createMockAccountWithError(null),
+        mockAccountWithError(Errors.NETWORK),
+        mockAccountWithError(null),
       ];
 
       expect(areAllAccountErrorsSame(items)).toBe(false);

--- a/src/renderer/utils/helpers.test.ts
+++ b/src/renderer/utils/helpers.test.ts
@@ -4,9 +4,9 @@ import {
   ChevronRightIcon,
 } from '@primer/octicons-react';
 
+import { mockGitifyNotification } from '../__mocks__/notifications-mocks';
 import { mockToken } from '../__mocks__/state-mocks';
 import type { GitifySubject, Hostname, Link, SubjectType } from '../types';
-import { mockSingleNotification } from './api/__mocks__/response-mocks';
 import * as apiClient from './api/client';
 import {
   generateGitHubWebUrl,
@@ -55,7 +55,7 @@ describe('renderer/utils/helpers.ts', () => {
 
   describe('generateNotificationReferrerId', () => {
     it('should generate the notification_referrer_id', () => {
-      const referrerId = generateNotificationReferrerId(mockSingleNotification);
+      const referrerId = generateNotificationReferrerId(mockGitifyNotification);
       expect(referrerId).toBe(
         'MDE4Ok5vdGlmaWNhdGlvblRocmVhZDEzODY2MTA5NjoxMjM0NTY3ODk=',
       );
@@ -90,7 +90,7 @@ describe('renderer/utils/helpers.ts', () => {
       } as GitifySubject;
 
       const result = await generateGitHubWebUrl({
-        ...mockSingleNotification,
+        ...mockGitifyNotification,
         subject: subject,
       });
 
@@ -116,7 +116,7 @@ describe('renderer/utils/helpers.ts', () => {
       getHtmlUrlSpy.mockResolvedValue(mockHtmlUrl);
 
       const result = await generateGitHubWebUrl({
-        ...mockSingleNotification,
+        ...mockGitifyNotification,
         subject: subject,
       });
 
@@ -145,7 +145,7 @@ describe('renderer/utils/helpers.ts', () => {
       getHtmlUrlSpy.mockResolvedValue(mockHtmlUrl);
 
       const result = await generateGitHubWebUrl({
-        ...mockSingleNotification,
+        ...mockGitifyNotification,
         subject: subject,
       });
 

--- a/src/renderer/utils/links.test.ts
+++ b/src/renderer/utils/links.test.ts
@@ -1,8 +1,8 @@
 import { mockGitHubCloudAccount } from '../__mocks__/account-mocks';
-import { createMockGitifyNotificationUser } from '../__mocks__/user-mocks';
+import { mockGitifyNotification } from '../__mocks__/notifications-mocks';
+import { mockGitifyNotificationUser } from '../__mocks__/user-mocks';
 import { Constants } from '../constants';
 import type { GitifyRepository, Hostname, Link } from '../types';
-import { mockSingleNotification } from './api/__mocks__/response-mocks';
 import * as authUtils from './auth/utils';
 import * as comms from './comms';
 import * as helpers from './helpers';
@@ -70,7 +70,7 @@ describe('renderer/utils/links.ts', () => {
   });
 
   it('openUserProfile', () => {
-    const mockUser = createMockGitifyNotificationUser('mock-user');
+    const mockUser = mockGitifyNotificationUser('mock-user');
 
     openUserProfile(mockUser);
 
@@ -108,12 +108,12 @@ describe('renderer/utils/links.ts', () => {
   });
 
   it('openNotification', async () => {
-    const mockNotificationUrl = mockSingleNotification.repository.htmlUrl;
+    const mockNotificationUrl = mockGitifyNotification.repository.htmlUrl;
     jest
       .spyOn(helpers, 'generateGitHubWebUrl')
       .mockResolvedValue(mockNotificationUrl);
 
-    await openNotification(mockSingleNotification);
+    await openNotification(mockGitifyNotification);
 
     expect(openExternalLinkSpy).toHaveBeenCalledWith(mockNotificationUrl);
   });

--- a/src/renderer/utils/logger.test.ts
+++ b/src/renderer/utils/logger.test.ts
@@ -1,6 +1,6 @@
 import * as logger from '../../shared/logger';
 
-import { mockSingleNotification } from './api/__mocks__/response-mocks';
+import { mockGitifyNotification } from '../__mocks__/notifications-mocks';
 import { rendererLogError, rendererLogInfo, rendererLogWarn } from './logger';
 
 describe('renderer/utils/logger.ts', () => {
@@ -21,7 +21,7 @@ describe('renderer/utils/logger.ts', () => {
   });
 
   it('logs info with notification', () => {
-    rendererLogInfo('foo', 'bar', mockSingleNotification);
+    rendererLogInfo('foo', 'bar', mockGitifyNotification);
     expect(logInfoSpy).toHaveBeenCalledWith('foo', 'bar', [
       'Issue',
       'gitify-app/notifications-test',
@@ -30,7 +30,7 @@ describe('renderer/utils/logger.ts', () => {
   });
 
   it('logs warn with notification', () => {
-    rendererLogWarn('foo', 'bar', mockSingleNotification);
+    rendererLogWarn('foo', 'bar', mockGitifyNotification);
     expect(logWarnSpy).toHaveBeenCalledWith('foo', 'bar', [
       'Issue',
       'gitify-app/notifications-test',
@@ -39,7 +39,7 @@ describe('renderer/utils/logger.ts', () => {
   });
 
   it('logs error with notification', () => {
-    rendererLogError('foo', 'bar', mockError, mockSingleNotification);
+    rendererLogError('foo', 'bar', mockError, mockGitifyNotification);
     expect(logErrorSpy).toHaveBeenCalledWith('foo', 'bar', mockError, [
       'Issue',
       'gitify-app/notifications-test',

--- a/src/renderer/utils/notifications/filters/filter.test.ts
+++ b/src/renderer/utils/notifications/filters/filter.test.ts
@@ -1,4 +1,4 @@
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../../__mocks__/state-mocks';
 import { defaultSettings } from '../../../context/defaults';
 import type {
@@ -20,7 +20,7 @@ describe('renderer/utils/notifications/filters/filter.ts', () => {
 
   describe('filterNotifications', () => {
     const mockNotifications = [
-      createPartialMockNotification(
+      mockPartialGitifyNotification(
         {
           title: 'User authored notification',
           user: {
@@ -34,13 +34,14 @@ describe('renderer/utils/notifications/filters/filter.ts', () => {
         {
           owner: {
             login: 'gitify-app',
-            avatarUrl: 'https://avatars.githubusercontent.com/u/1' as Link,
+            avatarUrl:
+              'https://avatars.githubusercontent.com/u/133795385?s=200&v=4' as Link,
             type: 'Organization',
           } as GitifyOwner,
           fullName: 'gitify-app/gitify',
         },
       ),
-      createPartialMockNotification(
+      mockPartialGitifyNotification(
         {
           title: 'Bot authored notification',
           user: {
@@ -54,7 +55,8 @@ describe('renderer/utils/notifications/filters/filter.ts', () => {
         {
           owner: {
             login: 'github',
-            avatarUrl: 'https://avatars.githubusercontent.com/u/2' as Link,
+            avatarUrl:
+              'https://avatars.githubusercontent.com/u/133795385?s=200&v=4' as Link,
             type: 'Organization',
           } as GitifyOwner,
           fullName: 'github/github',

--- a/src/renderer/utils/notifications/filters/search.test.ts
+++ b/src/renderer/utils/notifications/filters/search.test.ts
@@ -1,4 +1,4 @@
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import type { GitifyOwner, Link } from '../../../types';
 import {
   ALL_SEARCH_QUALIFIERS,
@@ -35,7 +35,7 @@ describe('renderer/utils/notifications/filters/search.ts', () => {
   });
 
   describe('filterNotificationBySearchTerm', () => {
-    const mockNotification = createPartialMockNotification(
+    const mockNotification = mockPartialGitifyNotification(
       {
         title: 'User authored notification',
         user: {
@@ -49,7 +49,8 @@ describe('renderer/utils/notifications/filters/search.ts', () => {
       {
         owner: {
           login: 'gitify-app',
-          avatarUrl: 'https://avatars.githubusercontent.com/u/1' as Link,
+          avatarUrl:
+            'https://avatars.githubusercontent.com/u/133795385?s=200&v=4' as Link,
           type: 'Organization',
         } as GitifyOwner,
         fullName: 'gitify-app/gitify',

--- a/src/renderer/utils/notifications/group.test.ts
+++ b/src/renderer/utils/notifications/group.test.ts
@@ -1,4 +1,4 @@
-import { createMockNotificationForRepoName } from '../../__mocks__/notifications-mocks';
+import { mockGitifyNotificationForRepoName } from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
 import type { GitifyNotification } from '../../types';
 import { GroupBy } from '../../types';
@@ -37,9 +37,9 @@ describe('renderer/utils/notifications/group.ts', () => {
   describe('groupNotificationsByRepository', () => {
     it('groups notifications by repository fullName', () => {
       const notifications: GitifyNotification[] = [
-        createMockNotificationForRepoName('1', 'owner/repo-a'),
-        createMockNotificationForRepoName('2', 'owner/repo-b'),
-        createMockNotificationForRepoName('3', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('1', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('2', 'owner/repo-b'),
+        mockGitifyNotificationForRepoName('3', 'owner/repo-a'),
       ];
 
       const result = groupNotificationsByRepository(notifications);
@@ -51,10 +51,10 @@ describe('renderer/utils/notifications/group.ts', () => {
 
     it('preserves first-seen repository order', () => {
       const notifications: GitifyNotification[] = [
-        createMockNotificationForRepoName('1', 'owner/repo-c'),
-        createMockNotificationForRepoName('2', 'owner/repo-a'),
-        createMockNotificationForRepoName('3', 'owner/repo-b'),
-        createMockNotificationForRepoName('4', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('1', 'owner/repo-c'),
+        mockGitifyNotificationForRepoName('2', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('3', 'owner/repo-b'),
+        mockGitifyNotificationForRepoName('4', 'owner/repo-a'),
       ];
 
       const result = groupNotificationsByRepository(notifications);
@@ -65,9 +65,9 @@ describe('renderer/utils/notifications/group.ts', () => {
 
     it('skips notifications without repository data', () => {
       const notifications: GitifyNotification[] = [
-        createMockNotificationForRepoName('1', 'owner/repo-a'),
-        createMockNotificationForRepoName('2', null),
-        createMockNotificationForRepoName('3', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('1', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('2', null),
+        mockGitifyNotificationForRepoName('3', 'owner/repo-a'),
       ];
 
       const result = groupNotificationsByRepository(notifications);
@@ -86,8 +86,8 @@ describe('renderer/utils/notifications/group.ts', () => {
 
     it('returns empty map when all notifications lack repository data', () => {
       const notifications: GitifyNotification[] = [
-        createMockNotificationForRepoName('1', null),
-        createMockNotificationForRepoName('2', null),
+        mockGitifyNotificationForRepoName('1', null),
+        mockGitifyNotificationForRepoName('2', null),
       ];
 
       const result = groupNotificationsByRepository(notifications);
@@ -100,10 +100,10 @@ describe('renderer/utils/notifications/group.ts', () => {
     it('returns repository-grouped order when groupBy is REPOSITORY', () => {
       const settings = { ...mockSettings, groupBy: GroupBy.REPOSITORY };
       const notifications: GitifyNotification[] = [
-        createMockNotificationForRepoName('1', 'owner/repo-b'),
-        createMockNotificationForRepoName('2', 'owner/repo-a'),
-        createMockNotificationForRepoName('3', 'owner/repo-b'),
-        createMockNotificationForRepoName('4', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('1', 'owner/repo-b'),
+        mockGitifyNotificationForRepoName('2', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('3', 'owner/repo-b'),
+        mockGitifyNotificationForRepoName('4', 'owner/repo-a'),
       ];
 
       const result = getFlattenedNotificationsByRepo(notifications, settings);
@@ -115,9 +115,9 @@ describe('renderer/utils/notifications/group.ts', () => {
     it('returns natural account order when groupBy is DATE', () => {
       const settings = { ...mockSettings, groupBy: GroupBy.DATE };
       const notifications: GitifyNotification[] = [
-        createMockNotificationForRepoName('1', 'owner/repo-b'),
-        createMockNotificationForRepoName('2', 'owner/repo-a'),
-        createMockNotificationForRepoName('3', 'owner/repo-b'),
+        mockGitifyNotificationForRepoName('1', 'owner/repo-b'),
+        mockGitifyNotificationForRepoName('2', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('3', 'owner/repo-b'),
       ];
 
       const result = getFlattenedNotificationsByRepo(notifications, settings);
@@ -138,9 +138,9 @@ describe('renderer/utils/notifications/group.ts', () => {
     it('handles notifications without repository data when grouped', () => {
       const settings = { ...mockSettings, groupBy: GroupBy.REPOSITORY };
       const notifications: GitifyNotification[] = [
-        createMockNotificationForRepoName('1', 'owner/repo-a'),
-        createMockNotificationForRepoName('2', null),
-        createMockNotificationForRepoName('3', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('1', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('2', null),
+        mockGitifyNotificationForRepoName('3', 'owner/repo-a'),
       ];
 
       const result = getFlattenedNotificationsByRepo(notifications, settings);
@@ -152,9 +152,9 @@ describe('renderer/utils/notifications/group.ts', () => {
     it('preserves notifications without repository data when not grouped', () => {
       const settings = { ...mockSettings, groupBy: GroupBy.DATE };
       const notifications: GitifyNotification[] = [
-        createMockNotificationForRepoName('1', 'owner/repo-a'),
-        createMockNotificationForRepoName('2', null),
-        createMockNotificationForRepoName('3', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('1', 'owner/repo-a'),
+        mockGitifyNotificationForRepoName('2', null),
+        mockGitifyNotificationForRepoName('3', 'owner/repo-a'),
       ];
 
       const result = getFlattenedNotificationsByRepo(notifications, settings);

--- a/src/renderer/utils/notifications/handlers/checkSuite.test.ts
+++ b/src/renderer/utils/notifications/handlers/checkSuite.test.ts
@@ -1,4 +1,4 @@
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../../__mocks__/state-mocks';
 import type { GitifyNotification } from '../../../types';
 import {
@@ -11,7 +11,7 @@ import { checkSuiteHandler, getCheckSuiteAttributes } from './checkSuite';
 describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
   describe('enrich', () => {
     it('cancelled check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run cancelled for main branch',
         type: 'CheckSuite',
       });
@@ -30,7 +30,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('failed check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run failed for main branch',
         type: 'CheckSuite',
       });
@@ -49,7 +49,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('failed at startup check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run failed at startup for main branch',
         type: 'CheckSuite',
       });
@@ -68,7 +68,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('multiple attempts failed check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run, Attempt #3 failed for main branch',
         type: 'CheckSuite',
       });
@@ -87,7 +87,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('skipped check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run skipped for main branch',
         type: 'CheckSuite',
       });
@@ -106,7 +106,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('successful check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run succeeded for main branch',
         type: 'CheckSuite',
       });
@@ -125,7 +125,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('unknown check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run unknown-status for main branch',
         type: 'CheckSuite',
       });
@@ -140,7 +140,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('unhandled check suite title', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'A title that is not in the structure we expect',
         type: 'CheckSuite',
       });
@@ -175,7 +175,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     it.each(
       Object.entries(cases) as Array<[GitifyCheckSuiteStatus, IconColor]>,
     )('iconType for check suite with status %s', (checkSuiteStatus, checkSuiteIconType) => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         type: 'CheckSuite',
         state: checkSuiteStatus,
       });
@@ -206,7 +206,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     it.each(
       Object.entries(cases) as Array<[GitifyCheckSuiteStatus, IconColor]>,
     )('iconColor for check suite with status %s', (checkSuiteStatus, checkSuiteIconColor) => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         type: 'CheckSuite',
         state: checkSuiteStatus,
       });
@@ -235,7 +235,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
 
   describe('getCheckSuiteState', () => {
     it('cancelled check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run cancelled for feature/foo branch',
         type: 'CheckSuite',
       });
@@ -252,7 +252,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('failed check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run failed for main branch',
         type: 'CheckSuite',
       });
@@ -269,7 +269,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('multiple attempts failed check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run, Attempt #3 failed for main branch',
         type: 'CheckSuite',
       });
@@ -286,7 +286,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('skipped check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run skipped for main branch',
         type: 'CheckSuite',
       });
@@ -303,7 +303,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('successful check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run succeeded for main branch',
         type: 'CheckSuite',
       });
@@ -320,7 +320,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('unknown check suite state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'Demo workflow run unknown-status for main branch',
         type: 'CheckSuite',
       });
@@ -337,7 +337,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
     });
 
     it('unhandled check suite title', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'A title that is not in the structure we expect',
         type: 'CheckSuite',
       });

--- a/src/renderer/utils/notifications/handlers/commit.test.ts
+++ b/src/renderer/utils/notifications/handlers/commit.test.ts
@@ -1,16 +1,16 @@
 import axios from 'axios';
 import nock from 'nock';
 
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../../__mocks__/state-mocks';
-import { createPartialMockUser } from '../../../__mocks__/user-mocks';
 import type { GitifyNotification, Link } from '../../../types';
+import { mockRawUser } from '../../api/__mocks__/response-mocks';
 import { commitHandler } from './commit';
 
 describe('renderer/utils/notifications/handlers/commit.ts', () => {
   describe('enrich', () => {
-    const mockAuthor = createPartialMockUser('some-author');
-    const mockCommenter = createPartialMockUser('some-commenter');
+    const mockAuthor = mockRawUser('some-author');
+    const mockCommenter = mockRawUser('some-commenter');
 
     beforeEach(() => {
       // axios will default to using the XHR adapter which can't be intercepted
@@ -19,7 +19,7 @@ describe('renderer/utils/notifications/handlers/commit.ts', () => {
     });
 
     it('get commit commenter', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'This is a commit with comments',
         type: 'Commit',
         url: 'https://api.github.com/repos/gitify-app/notifications-test/commits/d2a86d80e3d24ea9510d5de6c147e53c30f313a8' as Link,
@@ -51,7 +51,7 @@ describe('renderer/utils/notifications/handlers/commit.ts', () => {
     });
 
     it('get commit without commenter', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'This is a commit with comments',
         type: 'Commit',
         url: 'https://api.github.com/repos/gitify-app/notifications-test/commits/d2a86d80e3d24ea9510d5de6c147e53c30f313a8' as Link,
@@ -78,7 +78,7 @@ describe('renderer/utils/notifications/handlers/commit.ts', () => {
     });
 
     it('return early if commit state filtered', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'This is a commit with comments',
         type: 'Commit',
         url: 'https://api.github.com/repos/gitify-app/notifications-test/commits/d2a86d80e3d24ea9510d5de6c147e53c30f313a8' as Link,
@@ -96,7 +96,7 @@ describe('renderer/utils/notifications/handlers/commit.ts', () => {
   });
 
   it('iconType', () => {
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       type: 'Commit',
     });
 

--- a/src/renderer/utils/notifications/handlers/default.test.ts
+++ b/src/renderer/utils/notifications/handlers/default.test.ts
@@ -1,4 +1,4 @@
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../../__mocks__/state-mocks';
 import type { GitifyNotification } from '../../../types';
 import {
@@ -17,7 +17,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
 
   describe('enrich', () => {
     it('unhandled subject details', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title:
           'There is no special subject handling for this notification type',
         type: 'RepositoryInvitation',
@@ -34,7 +34,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
   });
 
   it('iconType', () => {
-    const mockNotification = createPartialMockNotification({});
+    const mockNotification = mockPartialGitifyNotification({});
 
     expect(defaultHandler.iconType(mockNotification).displayName).toBe(
       'QuestionIcon',
@@ -50,7 +50,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
       ];
 
       states.forEach((state) => {
-        const mockNotification = createPartialMockNotification({
+        const mockNotification = mockPartialGitifyNotification({
           state: state,
         });
 
@@ -61,7 +61,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
 
   describe('formattedNotificationType', () => {
     it('formats state and type with proper casing and spacing', () => {
-      const notification = createPartialMockNotification({
+      const notification = mockPartialGitifyNotification({
         title: 'Sample',
         type: 'PullRequest',
         state: 'OPEN',
@@ -73,7 +73,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
     });
 
     it('handles missing state (null) gracefully', () => {
-      const notification = createPartialMockNotification({
+      const notification = mockPartialGitifyNotification({
         title: 'Sample',
         type: 'Issue',
         state: null,
@@ -87,7 +87,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
 
   describe('formattedNotificationNumber', () => {
     it('returns formatted number when present', () => {
-      const notification = createPartialMockNotification({
+      const notification = mockPartialGitifyNotification({
         title: 'Sample',
         type: 'Issue',
         state: 'OPEN',
@@ -99,7 +99,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
     });
 
     it('returns empty string when number absent', () => {
-      const notification = createPartialMockNotification({
+      const notification = mockPartialGitifyNotification({
         title: 'Sample',
         type: 'Issue',
         state: 'OPEN',
@@ -110,7 +110,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
 
   describe('formattedNotificationTitle', () => {
     it('appends number in brackets when present', () => {
-      const notification = createPartialMockNotification({
+      const notification = mockPartialGitifyNotification({
         title: 'Fix bug',
         type: 'Issue',
         state: 'OPEN',
@@ -122,7 +122,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
     });
 
     it('returns title unchanged when number missing', () => {
-      const notification = createPartialMockNotification({
+      const notification = mockPartialGitifyNotification({
         title: 'Improve docs',
         type: 'Issue',
         state: 'OPEN',

--- a/src/renderer/utils/notifications/handlers/discussion.test.ts
+++ b/src/renderer/utils/notifications/handlers/discussion.test.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import nock from 'nock';
 
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../../__mocks__/state-mocks';
-import { createMockGraphQLAuthor } from '../../../__mocks__/user-mocks';
 import type { GitifyNotification } from '../../../types';
 import {
   type GitifyDiscussionState,
@@ -11,15 +10,13 @@ import {
   IconColor,
   type Link,
 } from '../../../types';
-import type {
-  DiscussionDetailsFragment,
-  DiscussionStateReason,
-} from '../../api/graphql/generated/graphql';
+import {
+  mockAuthor,
+  mockCommenter,
+  mockDiscussionResponseNode,
+  mockReplier,
+} from '../../api/__mocks__/response-mocks';
 import { discussionHandler } from './discussion';
-
-const mockAuthor = createMockGraphQLAuthor('discussion-author');
-const mockCommenter = createMockGraphQLAuthor('discussion-commenter');
-const mockReplier = createMockGraphQLAuthor('discussion-replier');
 
 describe('renderer/utils/notifications/handlers/discussion.ts', () => {
   describe('supportsMergedQueryEnrichment', () => {
@@ -29,7 +26,7 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
   });
 
   describe('enrich', () => {
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       title: 'This is a mock discussion',
       type: 'Discussion',
       url: 'https://api.github.com/repos/gitify-app/notifications-test/discussions/123' as Link,
@@ -305,7 +302,7 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
     it.each(
       Object.entries(cases) as Array<[GitifyDiscussionState, IconColor]>,
     )('iconType for discussion with state %s', (discussionState, discussionIconType) => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         type: 'Discussion',
         state: discussionState,
       });
@@ -329,7 +326,7 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
     it.each(
       Object.entries(cases) as Array<[GitifyDiscussionState, IconColor]>,
     )('iconColor for discussion with state %s', (discussionState, discussionIconColor) => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         type: 'Discussion',
         state: discussionState,
       });
@@ -353,23 +350,3 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
     ).toEqual(`${mockHtmlUrl}/discussions`);
   });
 });
-
-function mockDiscussionResponseNode(mocks: {
-  stateReason?: DiscussionStateReason;
-  isAnswered: boolean;
-}): DiscussionDetailsFragment {
-  return {
-    __typename: 'Discussion',
-    number: 123,
-    title: 'This is a mock discussion',
-    url: 'https://github.com/gitify-app/notifications-test/discussions/123' as Link,
-    stateReason: mocks.stateReason,
-    isAnswered: mocks.isAnswered,
-    author: mockAuthor,
-    comments: {
-      nodes: [],
-      totalCount: 0,
-    },
-    labels: null,
-  };
-}

--- a/src/renderer/utils/notifications/handlers/index.test.ts
+++ b/src/renderer/utils/notifications/handlers/index.test.ts
@@ -1,4 +1,4 @@
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import type { SubjectType } from '../../../types';
 import { checkSuiteHandler } from './checkSuite';
 import { commitHandler } from './commit';
@@ -32,13 +32,13 @@ describe('renderer/utils/notifications/handlers/index.ts', () => {
     it.each(
       Object.entries(cases) as Array<[SubjectType, NotificationTypeHandler]>,
     )('returns expected handler instance for %s', (type, expected) => {
-      const notification = createPartialMockNotification({ type });
+      const notification = mockPartialGitifyNotification({ type });
       const handler = createNotificationHandler(notification);
       expect(handler).toBe(expected);
     });
 
     it('falls back to default handler for unknown type', () => {
-      const notification = createPartialMockNotification({
+      const notification = mockPartialGitifyNotification({
         type: 'SomeFutureType' as SubjectType,
       });
       const handler = createNotificationHandler(notification);

--- a/src/renderer/utils/notifications/handlers/issue.test.ts
+++ b/src/renderer/utils/notifications/handlers/issue.test.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import nock from 'nock';
 
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../../__mocks__/state-mocks';
-import { createMockGraphQLAuthor } from '../../../__mocks__/user-mocks';
 import type { GitifyNotification } from '../../../types';
 import {
   type GitifyIssueState,
@@ -11,15 +10,12 @@ import {
   IconColor,
   type Link,
 } from '../../../types';
-import type {
-  IssueDetailsFragment,
-  IssueState,
-  IssueStateReason,
-} from '../../api/graphql/generated/graphql';
+import {
+  mockAuthor,
+  mockCommenter,
+  mockIssueResponseNode,
+} from '../../api/__mocks__/response-mocks';
 import { issueHandler } from './issue';
-
-const mockAuthor = createMockGraphQLAuthor('issue-author');
-const mockCommenter = createMockGraphQLAuthor('issue-commenter');
 
 describe('renderer/utils/notifications/handlers/issue.ts', () => {
   describe('supportsMergedQueryEnrichment', () => {
@@ -32,7 +28,7 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
     let mockNotification: GitifyNotification;
 
     beforeEach(() => {
-      mockNotification = createPartialMockNotification({
+      mockNotification = mockPartialGitifyNotification({
         title: 'This is a mock issue',
         type: 'Issue',
         url: 'https://api.github.com/repos/gitify-app/notifications-test/issues/1' as Link,
@@ -101,7 +97,7 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
         state: 'COMPLETED',
         user: {
           login: mockAuthor.login,
-          avatarUrl: mockCommenter.avatarUrl,
+          avatarUrl: mockAuthor.avatarUrl,
           htmlUrl: mockAuthor.htmlUrl,
           type: mockAuthor.type,
         },
@@ -245,7 +241,7 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
     it.each(
       Object.entries(cases) as Array<[GitifyIssueState, IconColor]>,
     )('iconType for issue with state %s', (issueState, issueIconType) => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         type: 'Issue',
         state: issueState,
       });
@@ -269,7 +265,7 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
     it.each(
       Object.entries(cases) as Array<[GitifyIssueState, IconColor]>,
     )('iconColor for issue with state %s', (issueState, issueIconColor) => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         type: 'Issue',
         state: issueState,
       });
@@ -291,21 +287,3 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
     ).toEqual(`${mockHtmlUrl}/issues`);
   });
 });
-
-function mockIssueResponseNode(mocks: {
-  state: IssueState;
-  stateReason?: IssueStateReason;
-}): IssueDetailsFragment {
-  return {
-    __typename: 'Issue',
-    number: 123,
-    title: 'PR Title',
-    state: mocks.state,
-    stateReason: mocks.stateReason,
-    url: 'https://github.com/gitify-app/notifications-test/issues/123',
-    author: mockAuthor,
-    labels: { nodes: [] },
-    comments: { totalCount: 0, nodes: [] },
-    milestone: null,
-  };
-}

--- a/src/renderer/utils/notifications/handlers/pullRequest.test.ts
+++ b/src/renderer/utils/notifications/handlers/pullRequest.test.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import nock from 'nock';
 
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../../__mocks__/state-mocks';
-import { createMockGraphQLAuthor } from '../../../__mocks__/user-mocks';
 import type { GitifyNotification } from '../../../types';
 import {
   type GitifyPullRequestState,
@@ -11,21 +10,19 @@ import {
   IconColor,
   type Link,
 } from '../../../types';
-import type {
-  PullRequestDetailsFragment,
-  PullRequestReviewState,
-  PullRequestState,
-} from '../../api/graphql/generated/graphql';
+import {
+  mockAuthor,
+  mockCommenter,
+  mockPullRequestResponseNode,
+} from '../../api/__mocks__/response-mocks';
+import type { PullRequestReviewState } from '../../api/graphql/generated/graphql';
 import { getLatestReviewForReviewers, pullRequestHandler } from './pullRequest';
-
-const mockAuthor = createMockGraphQLAuthor('some-author');
-const mockCommenter = createMockGraphQLAuthor('some-commenter');
 
 describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
   let mockNotification: GitifyNotification;
 
   beforeEach(() => {
-    mockNotification = createPartialMockNotification({
+    mockNotification = mockPartialGitifyNotification({
       title: 'This is a mock pull request',
       type: 'PullRequest',
       url: 'https://api.github.com/repos/gitify-app/notifications-test/pulls/1' as Link,
@@ -398,7 +395,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
     it.each(
       Object.entries(cases) as Array<[GitifyPullRequestState, IconColor]>,
     )('iconType for pull request with state %s', (pullRequestState, pullRequestIconType) => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         type: 'PullRequest',
         state: pullRequestState,
       });
@@ -421,7 +418,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
     it.each(
       Object.entries(cases) as Array<[GitifyPullRequestState, IconColor]>,
     )('iconType for pull request with state %s', (pullRequestState, pullRequestIconColor) => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         type: 'PullRequest',
         state: pullRequestState,
       });
@@ -489,35 +486,3 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
     });
   });
 });
-
-function mockPullRequestResponseNode(mocks: {
-  state: PullRequestState;
-  isDraft?: boolean;
-  merged?: boolean;
-  isInMergeQueue?: boolean;
-}): PullRequestDetailsFragment {
-  return {
-    __typename: 'PullRequest',
-    number: 123,
-    title: 'Test PR',
-    state: mocks.state,
-    isDraft: mocks.isDraft ?? false,
-    merged: mocks.merged ?? false,
-    isInMergeQueue: mocks.isInMergeQueue ?? false,
-    url: 'https://github.com/gitify-app/notifications-test/pulls/123',
-    author: mockAuthor,
-    labels: { nodes: [] },
-    comments: {
-      totalCount: 0,
-      nodes: [],
-    },
-    reviews: {
-      totalCount: 0,
-      nodes: [],
-    },
-    milestone: null,
-    closingIssuesReferences: {
-      nodes: [],
-    },
-  };
-}

--- a/src/renderer/utils/notifications/handlers/release.test.ts
+++ b/src/renderer/utils/notifications/handlers/release.test.ts
@@ -1,15 +1,15 @@
 import axios from 'axios';
 import nock from 'nock';
 
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../../__mocks__/state-mocks';
-import { createPartialMockUser } from '../../../__mocks__/user-mocks';
 import type { GitifyNotification, Link } from '../../../types';
+import { mockRawUser } from '../../api/__mocks__/response-mocks';
 import { releaseHandler } from './release';
 
 describe('renderer/utils/notifications/handlers/release.ts', () => {
   describe('enrich', () => {
-    const mockAuthor = createPartialMockUser('some-author');
+    const mockAuthor = mockRawUser('some-author');
 
     beforeEach(() => {
       // axios will default to using the XHR adapter which can't be intercepted
@@ -18,7 +18,7 @@ describe('renderer/utils/notifications/handlers/release.ts', () => {
     });
 
     it('release notification', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'This is a mock release',
         type: 'Release',
         url: 'https://api.github.com/repos/gitify-app/notifications-test/releases/1' as Link,
@@ -47,7 +47,7 @@ describe('renderer/utils/notifications/handlers/release.ts', () => {
     });
 
     it('return early if release state filtered', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'This is a mock release',
         type: 'Release',
         url: 'https://api.github.com/repos/gitify-app/notifications-test/releases/1' as Link,
@@ -66,7 +66,7 @@ describe('renderer/utils/notifications/handlers/release.ts', () => {
   });
 
   it('iconType', () => {
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       type: 'Release',
     });
 

--- a/src/renderer/utils/notifications/handlers/repositoryDependabotAlertsThread.test.ts
+++ b/src/renderer/utils/notifications/handlers/repositoryDependabotAlertsThread.test.ts
@@ -1,10 +1,10 @@
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import type { GitifyNotification, Link } from '../../../types';
 import { repositoryDependabotAlertsThreadHandler } from './repositoryDependabotAlertsThread';
 
 describe('renderer/utils/notifications/handlers/repositoryDependabotAlertsThread.ts', () => {
   it('iconType', () => {
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       type: 'RepositoryDependabotAlertsThread',
     });
 

--- a/src/renderer/utils/notifications/handlers/repositoryInvitation.test.ts
+++ b/src/renderer/utils/notifications/handlers/repositoryInvitation.test.ts
@@ -1,10 +1,10 @@
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import type { GitifyNotification, Link } from '../../../types';
 import { repositoryInvitationHandler } from './repositoryInvitation';
 
 describe('renderer/utils/notifications/handlers/repositoryInvitation.ts', () => {
   it('iconType', () => {
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       type: 'RepositoryInvitation',
     });
 

--- a/src/renderer/utils/notifications/handlers/repositoryVulnerabilityAlert.test.ts
+++ b/src/renderer/utils/notifications/handlers/repositoryVulnerabilityAlert.test.ts
@@ -1,10 +1,10 @@
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import type { GitifyNotification, Link } from '../../../types';
 import { repositoryVulnerabilityAlertHandler } from './repositoryVulnerabilityAlert';
 
 describe('renderer/utils/notifications/handlers/repositoryVulnerabilityAlert.ts', () => {
   it('iconType', () => {
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       type: 'RepositoryVulnerabilityAlert',
     });
 

--- a/src/renderer/utils/notifications/handlers/utils.test.ts
+++ b/src/renderer/utils/notifications/handlers/utils.test.ts
@@ -1,10 +1,8 @@
-import { createMockGraphQLAuthor } from '../../../__mocks__/user-mocks';
+import { mockAuthor } from '../../api/__mocks__/response-mocks';
 import { formatForDisplay, getNotificationAuthor } from './utils';
 
 describe('renderer/utils/notifications/handlers/utils.ts', () => {
   describe('getNotificationAuthor', () => {
-    const mockAuthor = createMockGraphQLAuthor('some-author');
-
     it('returns null when all users are null', () => {
       const result = getNotificationAuthor([null, null]);
 

--- a/src/renderer/utils/notifications/handlers/workflowRun.test.ts
+++ b/src/renderer/utils/notifications/handlers/workflowRun.test.ts
@@ -1,4 +1,4 @@
-import { createPartialMockNotification } from '../../../__mocks__/notifications-mocks';
+import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../../__mocks__/state-mocks';
 import type { GitifyNotification, Link } from '../../../types';
 import { getWorkflowRunAttributes, workflowRunHandler } from './workflowRun';
@@ -6,7 +6,7 @@ import { getWorkflowRunAttributes, workflowRunHandler } from './workflowRun';
 describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
   describe('enrich', () => {
     it('deploy review workflow run state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'some-user requested your review to deploy to an environment',
         type: 'WorkflowRun',
       });
@@ -25,7 +25,7 @@ describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
     });
 
     it('unknown workflow run state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title:
           'some-user requested your unknown-state to deploy to an environment',
         type: 'WorkflowRun',
@@ -41,7 +41,7 @@ describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
     });
 
     it('unhandled workflow run title', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'unhandled workflow run structure',
         type: 'WorkflowRun',
       });
@@ -57,7 +57,7 @@ describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
   });
 
   it('iconType', () => {
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       type: 'WorkflowRun',
     });
 
@@ -84,7 +84,7 @@ describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
 
   describe('getWorkflowRunAttributes', () => {
     it('deploy review workflow run state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'some-user requested your review to deploy to an environment',
         type: 'WorkflowRun',
       });
@@ -99,7 +99,7 @@ describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
     });
 
     it('unknown workflow run state', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title:
           'some-user requested your unknown-state to deploy to an environment',
         type: 'WorkflowRun',
@@ -115,7 +115,7 @@ describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
     });
 
     it('unhandled workflow run title', async () => {
-      const mockNotification = createPartialMockNotification({
+      const mockNotification = mockPartialGitifyNotification({
         title: 'unhandled workflow run structure',
         type: 'WorkflowRun',
       });

--- a/src/renderer/utils/notifications/native.test.ts
+++ b/src/renderer/utils/notifications/native.test.ts
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/react';
 
 import {
-  mockAccountNotifications,
+  mockMultipleAccountNotifications,
   mockSingleAccountNotifications,
 } from '../../__mocks__/notifications-mocks';
 import * as helpers from '../helpers';
@@ -42,7 +42,9 @@ describe('renderer/utils/notifications/native.ts', () => {
   });
 
   it('should raise a native notification for multiple new notifications', async () => {
-    native.raiseNativeNotification(mockAccountNotifications[0].notifications);
+    native.raiseNativeNotification(
+      mockMultipleAccountNotifications[0].notifications,
+    );
 
     await waitFor(() =>
       expect(window.gitify.raiseNativeNotification).toHaveBeenCalledTimes(1),

--- a/src/renderer/utils/notifications/notifications.test.ts
+++ b/src/renderer/utils/notifications/notifications.test.ts
@@ -6,8 +6,8 @@ import {
   mockGitHubEnterpriseServerAccount,
 } from '../../__mocks__/account-mocks';
 import {
-  createMockNotificationForRepoName,
-  createPartialMockNotification,
+  mockGitifyNotificationForRepoName,
+  mockPartialGitifyNotification,
   mockSingleAccountNotifications,
 } from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
@@ -60,7 +60,7 @@ describe('renderer/utils/notifications/notifications.ts', () => {
       .mockImplementation();
 
     const mockError = new Error('Test error');
-    const mockNotification = createPartialMockNotification({
+    const mockNotification = mockPartialGitifyNotification({
       title: 'This issue will throw an error',
       type: 'Issue',
       url: 'https://api.github.com/repos/gitify-app/notifications-test/issues/1' as Link,
@@ -71,7 +71,8 @@ describe('renderer/utils/notifications/notifications.ts', () => {
       htmlUrl: 'https://github.com/gitify-app/notifications-test' as Link,
       owner: {
         login: 'gitify-app',
-        avatarUrl: 'https://avatars.githubusercontent.com/u/1' as Link,
+        avatarUrl:
+          'https://avatars.githubusercontent.com/u/133795385?s=200&v=4' as Link,
         type: 'Organization',
       },
     };
@@ -98,9 +99,9 @@ describe('renderer/utils/notifications/notifications.ts', () => {
     const acc1: AccountNotifications = {
       account: mockGitHubCloudAccount,
       notifications: [
-        createMockNotificationForRepoName('a1', 'owner/repo-1'),
-        createMockNotificationForRepoName('a2', 'owner/repo-2'),
-        createMockNotificationForRepoName('a3', 'owner/repo-1'),
+        mockGitifyNotificationForRepoName('a1', 'owner/repo-1'),
+        mockGitifyNotificationForRepoName('a2', 'owner/repo-2'),
+        mockGitifyNotificationForRepoName('a3', 'owner/repo-1'),
       ],
       error: null,
     };
@@ -108,9 +109,9 @@ describe('renderer/utils/notifications/notifications.ts', () => {
     const acc2: AccountNotifications = {
       account: mockGitHubEnterpriseServerAccount,
       notifications: [
-        createMockNotificationForRepoName('b1', 'owner/repo-3'),
-        createMockNotificationForRepoName('b2', 'owner/repo-4'),
-        createMockNotificationForRepoName('b3', 'owner/repo-3'),
+        mockGitifyNotificationForRepoName('b1', 'owner/repo-3'),
+        mockGitifyNotificationForRepoName('b2', 'owner/repo-4'),
+        mockGitifyNotificationForRepoName('b3', 'owner/repo-3'),
       ],
       error: null,
     };
@@ -146,7 +147,7 @@ describe('renderer/utils/notifications/notifications.ts', () => {
 
   describe('enrichNotifications', () => {
     it('should skip enrichment when detailedNotifications is false', async () => {
-      const notification = createPartialMockNotification({
+      const notification = mockPartialGitifyNotification({
         title: 'Issue #1',
         type: 'Issue',
         url: 'https://api.github.com/repos/gitify-app/notifications-test/issues/1' as Link,
@@ -163,7 +164,7 @@ describe('renderer/utils/notifications/notifications.ts', () => {
 
     it('should return notifications when all types do not support merge query', async () => {
       // CheckSuite types don't support merge query and have no URL
-      const notification = createPartialMockNotification({
+      const notification = mockPartialGitifyNotification({
         title: 'CI workflow run',
         type: 'CheckSuite',
         url: null,

--- a/src/renderer/utils/notifications/remove.test.ts
+++ b/src/renderer/utils/notifications/remove.test.ts
@@ -1,7 +1,9 @@
 import { mockGitHubEnterpriseServerAccount } from '../../__mocks__/account-mocks';
-import { mockSingleAccountNotifications } from '../../__mocks__/notifications-mocks';
+import {
+  mockGitifyNotification,
+  mockSingleAccountNotifications,
+} from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
-import { mockSingleNotification } from '../api/__mocks__/response-mocks';
 import { removeNotificationsForAccount } from './remove';
 
 describe('renderer/utils/remove.ts', () => {
@@ -11,7 +13,7 @@ describe('renderer/utils/remove.ts', () => {
     const result = removeNotificationsForAccount(
       mockSingleAccountNotifications[0].account,
       { ...mockSettings, delayNotificationState: false },
-      [mockSingleNotification],
+      [mockGitifyNotification],
       mockSingleAccountNotifications,
     );
 
@@ -24,7 +26,7 @@ describe('renderer/utils/remove.ts', () => {
     const result = removeNotificationsForAccount(
       mockSingleAccountNotifications[0].account,
       { ...mockSettings, delayNotificationState: true },
-      [mockSingleNotification],
+      [mockGitifyNotification],
       mockSingleAccountNotifications,
     );
 
@@ -40,7 +42,7 @@ describe('renderer/utils/remove.ts', () => {
       { ...mockSettings, delayNotificationState: true },
       [
         {
-          ...mockSingleNotification,
+          ...mockGitifyNotification,
           id: 'non-existent-id',
         },
       ],
@@ -71,7 +73,7 @@ describe('renderer/utils/remove.ts', () => {
     const result = removeNotificationsForAccount(
       mockGitHubEnterpriseServerAccount, // Different account
       { ...mockSettings, delayNotificationState: false },
-      [mockSingleNotification],
+      [mockGitifyNotification],
       mockSingleAccountNotifications,
     );
 

--- a/src/renderer/utils/notifications/utils.test.ts
+++ b/src/renderer/utils/notifications/utils.test.ts
@@ -2,7 +2,7 @@ import {
   mockGitHubCloudAccount,
   mockGitHubEnterpriseServerAccount,
 } from '../../__mocks__/account-mocks';
-import { createMockNotificationForRepoName } from '../../__mocks__/notifications-mocks';
+import { mockGitifyNotificationForRepoName } from '../../__mocks__/notifications-mocks';
 import type { AccountNotifications } from '../../types';
 import { getNewNotifications } from './utils';
 
@@ -13,9 +13,9 @@ describe('renderer/utils/notifications/utils.ts', () => {
         {
           account: mockGitHubCloudAccount,
           notifications: [
-            createMockNotificationForRepoName('1', 'some/repo'),
-            createMockNotificationForRepoName('2', 'some/repo'),
-            createMockNotificationForRepoName('3', 'some/repo'),
+            mockGitifyNotificationForRepoName('1', 'some/repo'),
+            mockGitifyNotificationForRepoName('2', 'some/repo'),
+            mockGitifyNotificationForRepoName('3', 'some/repo'),
           ],
           error: null,
         },
@@ -31,7 +31,7 @@ describe('renderer/utils/notifications/utils.ts', () => {
       const previousAccountNotifications: AccountNotifications[] = [
         {
           account: mockGitHubCloudAccount,
-          notifications: [createMockNotificationForRepoName('1', 'some/repo')],
+          notifications: [mockGitifyNotificationForRepoName('1', 'some/repo')],
           error: null,
         },
       ];
@@ -52,8 +52,8 @@ describe('renderer/utils/notifications/utils.ts', () => {
         {
           account: mockGitHubCloudAccount,
           notifications: [
-            createMockNotificationForRepoName('1', 'some/repo'),
-            createMockNotificationForRepoName('2', 'some/repo'),
+            mockGitifyNotificationForRepoName('1', 'some/repo'),
+            mockGitifyNotificationForRepoName('2', 'some/repo'),
           ],
           error: null,
         },
@@ -63,9 +63,9 @@ describe('renderer/utils/notifications/utils.ts', () => {
         {
           account: mockGitHubCloudAccount,
           notifications: [
-            createMockNotificationForRepoName('2', 'some/repo'),
-            createMockNotificationForRepoName('3', 'some/repo'),
-            createMockNotificationForRepoName('4', 'some/repo'),
+            mockGitifyNotificationForRepoName('2', 'some/repo'),
+            mockGitifyNotificationForRepoName('3', 'some/repo'),
+            mockGitifyNotificationForRepoName('4', 'some/repo'),
           ],
           error: null,
         },
@@ -85,9 +85,9 @@ describe('renderer/utils/notifications/utils.ts', () => {
         {
           account: mockGitHubCloudAccount,
           notifications: [
-            createMockNotificationForRepoName('1', 'some/repo'),
-            createMockNotificationForRepoName('2', 'some/repo'),
-            createMockNotificationForRepoName('3', 'some/repo'),
+            mockGitifyNotificationForRepoName('1', 'some/repo'),
+            mockGitifyNotificationForRepoName('2', 'some/repo'),
+            mockGitifyNotificationForRepoName('3', 'some/repo'),
           ],
           error: null,
         },
@@ -97,9 +97,9 @@ describe('renderer/utils/notifications/utils.ts', () => {
         {
           account: mockGitHubCloudAccount,
           notifications: [
-            createMockNotificationForRepoName('1', 'some/repo'),
-            createMockNotificationForRepoName('2', 'some/repo'),
-            createMockNotificationForRepoName('3', 'some/repo'),
+            mockGitifyNotificationForRepoName('1', 'some/repo'),
+            mockGitifyNotificationForRepoName('2', 'some/repo'),
+            mockGitifyNotificationForRepoName('3', 'some/repo'),
           ],
           error: null,
         },
@@ -117,12 +117,12 @@ describe('renderer/utils/notifications/utils.ts', () => {
       const previousAccountNotifications: AccountNotifications[] = [
         {
           account: mockGitHubCloudAccount,
-          notifications: [createMockNotificationForRepoName('1', 'some/repo')],
+          notifications: [mockGitifyNotificationForRepoName('1', 'some/repo')],
           error: null,
         },
         {
           account: mockGitHubEnterpriseServerAccount,
-          notifications: [createMockNotificationForRepoName('10', 'some/repo')],
+          notifications: [mockGitifyNotificationForRepoName('10', 'some/repo')],
           error: null,
         },
       ];
@@ -131,16 +131,16 @@ describe('renderer/utils/notifications/utils.ts', () => {
         {
           account: mockGitHubCloudAccount,
           notifications: [
-            createMockNotificationForRepoName('1', 'some/repo'),
-            createMockNotificationForRepoName('2', 'some/repo'),
+            mockGitifyNotificationForRepoName('1', 'some/repo'),
+            mockGitifyNotificationForRepoName('2', 'some/repo'),
           ],
           error: null,
         },
         {
           account: mockGitHubEnterpriseServerAccount,
           notifications: [
-            createMockNotificationForRepoName('10', 'some/repo'),
-            createMockNotificationForRepoName('11', 'some/repo'),
+            mockGitifyNotificationForRepoName('10', 'some/repo'),
+            mockGitifyNotificationForRepoName('11', 'some/repo'),
           ],
           error: null,
         },
@@ -159,7 +159,7 @@ describe('renderer/utils/notifications/utils.ts', () => {
       const previousAccountNotifications: AccountNotifications[] = [
         {
           account: mockGitHubCloudAccount,
-          notifications: [createMockNotificationForRepoName('1', 'some/repo')],
+          notifications: [mockGitifyNotificationForRepoName('1', 'some/repo')],
           error: null,
         },
       ];
@@ -167,14 +167,14 @@ describe('renderer/utils/notifications/utils.ts', () => {
       const newAccountNotifications: AccountNotifications[] = [
         {
           account: mockGitHubCloudAccount,
-          notifications: [createMockNotificationForRepoName('1', 'some/repo')],
+          notifications: [mockGitifyNotificationForRepoName('1', 'some/repo')],
           error: null,
         },
         {
           account: mockGitHubEnterpriseServerAccount,
           notifications: [
-            createMockNotificationForRepoName('10', 'some/repo'),
-            createMockNotificationForRepoName('11', 'some/repo'),
+            mockGitifyNotificationForRepoName('10', 'some/repo'),
+            mockGitifyNotificationForRepoName('11', 'some/repo'),
           ],
           error: null,
         },
@@ -193,7 +193,7 @@ describe('renderer/utils/notifications/utils.ts', () => {
       const previousAccountNotifications: AccountNotifications[] = [
         {
           account: mockGitHubCloudAccount,
-          notifications: [createMockNotificationForRepoName('1', 'some/repo')],
+          notifications: [mockGitifyNotificationForRepoName('1', 'some/repo')],
           error: null,
         },
       ];
@@ -218,7 +218,7 @@ describe('renderer/utils/notifications/utils.ts', () => {
       const previousAccountNotifications: AccountNotifications[] = [
         {
           account: mockGitHubCloudAccount,
-          notifications: [createMockNotificationForRepoName('1', 'some/repo')],
+          notifications: [mockGitifyNotificationForRepoName('1', 'some/repo')],
           error: null,
         },
       ];
@@ -227,9 +227,9 @@ describe('renderer/utils/notifications/utils.ts', () => {
         {
           account: mockGitHubCloudAccount,
           notifications: [
-            createMockNotificationForRepoName('5', 'some/repo'),
-            createMockNotificationForRepoName('3', 'some/repo'),
-            createMockNotificationForRepoName('4', 'some/repo'),
+            mockGitifyNotificationForRepoName('5', 'some/repo'),
+            mockGitifyNotificationForRepoName('3', 'some/repo'),
+            mockGitifyNotificationForRepoName('4', 'some/repo'),
           ],
           error: null,
         },
@@ -248,12 +248,12 @@ describe('renderer/utils/notifications/utils.ts', () => {
       const previousAccountNotifications: AccountNotifications[] = [
         {
           account: mockGitHubCloudAccount,
-          notifications: [createMockNotificationForRepoName('1', 'some/repo')],
+          notifications: [mockGitifyNotificationForRepoName('1', 'some/repo')],
           error: null,
         },
         {
           account: mockGitHubEnterpriseServerAccount,
-          notifications: [createMockNotificationForRepoName('10', 'some/repo')],
+          notifications: [mockGitifyNotificationForRepoName('10', 'some/repo')],
           error: null,
         },
       ];
@@ -262,8 +262,8 @@ describe('renderer/utils/notifications/utils.ts', () => {
         {
           account: mockGitHubCloudAccount,
           notifications: [
-            createMockNotificationForRepoName('1', 'some/repo'),
-            createMockNotificationForRepoName('2', 'some/repo'),
+            mockGitifyNotificationForRepoName('1', 'some/repo'),
+            mockGitifyNotificationForRepoName('2', 'some/repo'),
           ],
           error: null,
         },
@@ -286,16 +286,16 @@ describe('renderer/utils/notifications/utils.ts', () => {
         {
           account: mockGitHubCloudAccount,
           notifications: [
-            createMockNotificationForRepoName('1', 'some/repo'),
-            createMockNotificationForRepoName('2', 'some/repo'),
+            mockGitifyNotificationForRepoName('1', 'some/repo'),
+            mockGitifyNotificationForRepoName('2', 'some/repo'),
           ],
           error: null,
         },
         {
           account: mockGitHubEnterpriseServerAccount,
           notifications: [
-            createMockNotificationForRepoName('10', 'some/repo'),
-            createMockNotificationForRepoName('11', 'some/repo'),
+            mockGitifyNotificationForRepoName('10', 'some/repo'),
+            mockGitifyNotificationForRepoName('11', 'some/repo'),
           ],
           error: null,
         },


### PR DESCRIPTION
Rearrange our mock utilities so there is clear separation between
- response mocks (REST or GraphQL response shapes)
- notification mocks (now that we have an transformed GitifyNotification type)
- account mocks
- state mocks

Some of this was comingled post the introduction of GitifyNotification type

In addition, I took the opportunity to clarify the names of mocks / mock functions