### PR TITLE
refactor(renovate): remove unused package rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,11 +17,6 @@
       "rangeStrategy": "auto"
     },
     {
-      "description": "Remove word `dependency` from commit messages and PR titles",
-      "matchDatasources": ["npm"],
-      "commitMessageTopic": "{{depName}}"
-    },
-    {
       "description": "Fetch changelog details for twemoji packages",
       "matchPackageNames": ["@discordapp/twemoji"],
       "changelogUrl": "https://github.com/jdjdecked/twemoji"


### PR DESCRIPTION
Based on some analysis, I don't believe this rule is required any more.