### PR TITLE
fix(settings): volume icon size

### DIFF
--- a/src/renderer/components/icons/VolumeDownIcon.tsx
+++ b/src/renderer/components/icons/VolumeDownIcon.tsx
@@ -4,7 +4,7 @@ export const VolumeDownIcon: FC = () => (
   <svg
     aria-hidden="true"
     aria-label="Volume Down Icon"
-    className="size-2"
+    className="size-4"
     fill="currentColor"
     height="24"
     viewBox="0 0 24 24"

--- a/src/renderer/components/icons/VolumeUpIcon.tsx
+++ b/src/renderer/components/icons/VolumeUpIcon.tsx
@@ -4,7 +4,7 @@ export const VolumeUpIcon: FC = () => (
   <svg
     aria-hidden="true"
     aria-label="Volume Up Icon"
-    className="size-2"
+    className="size-4"
     fill="currentColor"
     height="24"
     viewBox="0 0 24 24"

--- a/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
@@ -1779,7 +1779,7 @@ exports[`renderer/routes/Settings.tsx should render itself & its children 1`] = 
                   <svg
                     aria-hidden="true"
                     aria-label="Volume Down Icon"
-                    class="size-2"
+                    class="size-4"
                     fill="currentColor"
                     height="24"
                     viewBox="0 0 24 24"
@@ -1840,7 +1840,7 @@ exports[`renderer/routes/Settings.tsx should render itself & its children 1`] = 
                   <svg
                     aria-hidden="true"
                     aria-label="Volume Up Icon"
-                    class="size-2"
+                    class="size-4"
                     fill="currentColor"
                     height="24"
                     viewBox="0 0 24 24"


### PR DESCRIPTION
Somewhere along the lines the tailwind/primer updates decreased the size of all components.  Doubling this size restores it.