### PR TITLE
fix: add fetch lock

### DIFF
--- a/src/renderer/hooks/useNotifications.ts
+++ b/src/renderer/hooks/useNotifications.ts
@@ -136,8 +136,9 @@ export const useNotifications = (): NotificationsState => {
             raiseNativeNotification(diffNotifications);
           }
         }
-      } finally {
+
         setStatus('success');
+      } finally {
         isFetchingRef.current = false;
       }
     },


### PR DESCRIPTION
I've noticed that the new notification sound on occasion will play more than once in quick succession. 

Adding a simple fetch lock to ensure that the fetch notifications callback runs at most once