### PR TITLE
refactor(api): reduce octokit retry plugin amount

### DIFF
--- a/src/renderer/utils/api/octokit.ts
+++ b/src/renderer/utils/api/octokit.ts
@@ -83,8 +83,7 @@ export async function createOctokitClientUncached(
     baseUrl: baseUrl,
     userAgent: userAgent,
     retry: {
-      doNotRetry: ['400', '401', '403', '404', '422'],
-      retries: 3,
+      retries: 1,
     },
   });
 }


### PR DESCRIPTION
Using default `doNotRetry` logic and reducing from 3 to 1 retries