### PR TITLE
fix: notification number wrap / truncation

### DIFF
--- a/src/renderer/components/notifications/NotificationRow.tsx
+++ b/src/renderer/components/notifications/NotificationRow.tsx
@@ -92,7 +92,10 @@ export const NotificationRow: FC<NotificationRowProps> = ({
         </Tooltip>
 
         <Stack
-          className="cursor-pointer text-sm w-full"
+          className={cn(
+            'cursor-pointer text-sm w-full',
+            !settings.wrapNotificationTitle && 'truncate',
+          )}
           direction="vertical"
           gap="none"
           onClick={actionNotificationInteraction}
@@ -101,7 +104,10 @@ export const NotificationRow: FC<NotificationRowProps> = ({
 
           <Stack
             align="start"
-            className="mb-0.5"
+            className={cn(
+              'mb-0.5',
+              !settings.wrapNotificationTitle && 'truncate',
+            )}
             data-testid="notification-row"
             direction="horizontal"
             gap="condensed"

--- a/src/renderer/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
+++ b/src/renderer/components/notifications/__snapshots__/AccountNotifications.test.tsx.snap
@@ -1329,7 +1329,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx should rende
                 Open Issue
               </span>
               <div
-                class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+                class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
                 data-align="stretch"
                 data-direction="vertical"
                 data-gap="none"
@@ -1392,7 +1392,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx should rende
                   </div>
                 </div>
                 <div
-                  class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                  class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                   data-align="start"
                   data-direction="horizontal"
                   data-gap="condensed"
@@ -1733,7 +1733,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx should rende
                 Issue
               </span>
               <div
-                class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+                class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
                 data-align="stretch"
                 data-direction="vertical"
                 data-gap="none"
@@ -1796,7 +1796,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx should rende
                   </div>
                 </div>
                 <div
-                  class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                  class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                   data-align="start"
                   data-direction="horizontal"
                   data-gap="condensed"
@@ -2225,7 +2225,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx should rende
               Open Issue
             </span>
             <div
-              class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+              class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
               data-align="stretch"
               data-direction="vertical"
               data-gap="none"
@@ -2288,7 +2288,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx should rende
                 </div>
               </div>
               <div
-                class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                 data-align="start"
                 data-direction="horizontal"
                 data-gap="condensed"
@@ -2629,7 +2629,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx should rende
               Issue
             </span>
             <div
-              class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+              class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
               data-align="stretch"
               data-direction="vertical"
               data-gap="none"
@@ -2692,7 +2692,7 @@ exports[`renderer/components/notifications/AccountNotifications.tsx should rende
                 </div>
               </div>
               <div
-                class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                 data-align="start"
                 data-direction="horizontal"
                 data-gap="condensed"

--- a/src/renderer/components/notifications/__snapshots__/NotificationRow.test.tsx.snap
+++ b/src/renderer/components/notifications/__snapshots__/NotificationRow.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
                 Open Issue
               </span>
               <div
-                class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+                class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
                 data-align="stretch"
                 data-direction="vertical"
                 data-gap="none"
@@ -126,7 +126,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
                   </div>
                 </div>
                 <div
-                  class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                  class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                   data-align="start"
                   data-direction="horizontal"
                   data-gap="condensed"
@@ -481,7 +481,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
               Open Issue
             </span>
             <div
-              class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+              class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
               data-align="stretch"
               data-direction="vertical"
               data-gap="none"
@@ -544,7 +544,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
                 </div>
               </div>
               <div
-                class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                 data-align="start"
                 data-direction="horizontal"
                 data-gap="condensed"
@@ -956,7 +956,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
                 Open Issue
               </span>
               <div
-                class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+                class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
                 data-align="stretch"
                 data-direction="vertical"
                 data-gap="none"
@@ -965,7 +965,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
                 data-wrap="nowrap"
               >
                 <div
-                  class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                  class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                   data-align="start"
                   data-direction="horizontal"
                   data-gap="condensed"
@@ -1320,7 +1320,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
               Open Issue
             </span>
             <div
-              class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+              class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
               data-align="stretch"
               data-direction="vertical"
               data-gap="none"
@@ -1329,7 +1329,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
               data-wrap="nowrap"
             >
               <div
-                class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                 data-align="start"
                 data-direction="horizontal"
                 data-gap="condensed"
@@ -1741,7 +1741,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
                 Open Issue
               </span>
               <div
-                class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+                class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
                 data-align="stretch"
                 data-direction="vertical"
                 data-gap="none"
@@ -1750,7 +1750,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
                 data-wrap="nowrap"
               >
                 <div
-                  class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                  class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                   data-align="start"
                   data-direction="horizontal"
                   data-gap="condensed"
@@ -2105,7 +2105,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
               Open Issue
             </span>
             <div
-              class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+              class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
               data-align="stretch"
               data-direction="vertical"
               data-gap="none"
@@ -2114,7 +2114,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
               data-wrap="nowrap"
             >
               <div
-                class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                 data-align="start"
                 data-direction="horizontal"
                 data-gap="condensed"
@@ -2526,7 +2526,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
                 Open Issue
               </span>
               <div
-                class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+                class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
                 data-align="stretch"
                 data-direction="vertical"
                 data-gap="none"
@@ -2535,7 +2535,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
                 data-wrap="nowrap"
               >
                 <div
-                  class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                  class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                   data-align="start"
                   data-direction="horizontal"
                   data-gap="condensed"
@@ -2832,7 +2832,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
               Open Issue
             </span>
             <div
-              class="cursor-pointer text-sm w-full prc-Stack-Stack-UQ9k6"
+              class="cursor-pointer text-sm w-full truncate prc-Stack-Stack-UQ9k6"
               data-align="stretch"
               data-direction="vertical"
               data-gap="none"
@@ -2841,7 +2841,7 @@ exports[`renderer/components/notifications/NotificationRow.tsx should render its
               data-wrap="nowrap"
             >
               <div
-                class="mb-0.5 prc-Stack-Stack-UQ9k6"
+                class="mb-0.5 truncate prc-Stack-Stack-UQ9k6"
                 data-align="start"
                 data-direction="horizontal"
                 data-gap="condensed"


### PR DESCRIPTION
Found some notifications today where notification numbers weren't truncating correctly. 