### PR TITLE
feat: milestone closed color

### DIFF
--- a/src/renderer/components/metrics/MetricGroup.tsx
+++ b/src/renderer/components/metrics/MetricGroup.tsx
@@ -96,7 +96,9 @@ export const MetricGroup: FC<MetricGroupProps> = ({
 
         {milestone && (
           <MetricPill
-            color={milestone.state === 'OPEN' ? IconColor.GREEN : IconColor.RED}
+            color={
+              milestone.state === 'OPEN' ? IconColor.GREEN : IconColor.PURPLE
+            }
             icon={MilestoneIcon}
             title={milestone.title}
           />

--- a/src/renderer/components/metrics/__snapshots__/MetricGroup.test.tsx.snap
+++ b/src/renderer/components/metrics/__snapshots__/MetricGroup.test.tsx.snap
@@ -3232,7 +3232,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
                 >
                   <svg
                     aria-hidden="true"
-                    class="octicon octicon-milestone text-gitify-icon-closed"
+                    class="octicon octicon-milestone text-gitify-icon-done"
                     display="inline-block"
                     fill="currentColor"
                     focusable="false"
@@ -3566,7 +3566,7 @@ exports[`renderer/components/metrics/MetricGroup.tsx milestone pills should rend
               >
                 <svg
                   aria-hidden="true"
-                  class="octicon octicon-milestone text-gitify-icon-closed"
+                  class="octicon octicon-milestone text-gitify-icon-done"
                   display="inline-block"
                   fill="currentColor"
                   focusable="false"


### PR DESCRIPTION
Update closed milestone icon color from `RED` to `PURPLE` to be consistent with Issue / Pull Request state colors.  

A closed milestones should be celebrated, not feared! 🎉  