### PR TITLE
fix: revert "fix: errors in build/package logs"

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "homepage": "https://gitify.io/",
   "dependencies": {
     "electron-log": "5.4.3",
-    "electron-updater": "6.8.1",
+    "electron-updater": "6.7.3",
     "menubar": "9.5.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",
@@ -118,7 +118,7 @@
     "date-fns": "4.1.0",
     "dotenv": "17.2.3",
     "electron": "40.0.0",
-    "electron-builder": "26.5.0",
+    "electron-builder": "26.4.0",
     "final-form": "5.0.0",
     "graphql": "16.12.0",
     "html-webpack-plugin": "5.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 5.4.3
         version: 5.4.3
       electron-updater:
-        specifier: 6.8.1
-        version: 6.8.1
+        specifier: 6.7.3
+        version: 6.7.3
       menubar:
         specifier: 9.5.2
         version: 9.5.2(electron@40.0.0)
@@ -142,8 +142,8 @@ importers:
         specifier: 40.0.0
         version: 40.0.0
       electron-builder:
-        specifier: 26.5.0
-        version: 26.5.0(electron-builder-squirrel-windows@24.13.3)
+        specifier: 26.4.0
+        version: 26.4.0(electron-builder-squirrel-windows@24.13.3)
       final-form:
         specifier: 5.0.0
         version: 5.0.0
@@ -2447,12 +2447,12 @@ packages:
       dmg-builder: 24.13.3
       electron-builder-squirrel-windows: 24.13.3
 
-  app-builder-lib@26.5.0:
-    resolution: {integrity: sha512-iRRiJhM0uFMauDeIuv8ESHZSn+LESbdDEuHi7rKdeETjrvBObecXnWJx1f3vs3KtoGcd3hCk1zURKypyvZOtFQ==}
+  app-builder-lib@26.4.0:
+    resolution: {integrity: sha512-Uas6hNe99KzP3xPWxh5LGlH8kWIVjZixzmMJHNB9+6hPyDpjc7NQMkVgi16rQDdpCFy22ZU5sp8ow7tvjeMgYQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      dmg-builder: 26.5.0
-      electron-builder-squirrel-windows: 26.5.0
+      dmg-builder: 26.4.0
+      electron-builder-squirrel-windows: 26.4.0
 
   archiver-utils@2.1.0:
     resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
@@ -2629,8 +2629,8 @@ packages:
   builder-util@24.13.1:
     resolution: {integrity: sha512-NhbCSIntruNDTOVI9fdXz0dihaqX2YuE1D6zZMrwiErzH4ELZHE6mdiB40wEgZNprDia+FghRFgKoAqMZRRjSA==}
 
-  builder-util@26.4.1:
-    resolution: {integrity: sha512-FlgH43XZ50w3UtS1RVGDWOz8v9qMXPC7upMtKMtBEnYdt1OVoS61NYhKm/4x+cIaWqJTXua0+VVPI+fSPGXNIw==}
+  builder-util@26.3.4:
+    resolution: {integrity: sha512-aRn88mYMktHxzdqDMF6Ayj0rKoX+ZogJ75Ck7RrIqbY/ad0HBvnS2xA4uHfzrGr5D2aLL3vU6OBEH4p0KMV2XQ==}
 
   cacache@19.0.1:
     resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
@@ -3123,8 +3123,8 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  dmg-builder@26.5.0:
-    resolution: {integrity: sha512-AyOCzpS1TCxDkSWxAzpfw5l7jBX4C8jKCucmT/6y6/24H5VKSHpjcVJD0W8o5BrFi+skC7Z7+F4aNyHmvn4AAw==}
+  dmg-builder@26.4.0:
+    resolution: {integrity: sha512-ce4Ogns4VMeisIuCSK0C62umG0lFy012jd8LMZ6w/veHUeX4fqfDrGe+HTWALAEwK6JwKP+dhPvizhArSOsFbg==}
 
   dmg-license@1.0.11:
     resolution: {integrity: sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==}
@@ -3205,8 +3205,8 @@ packages:
   electron-builder-squirrel-windows@24.13.3:
     resolution: {integrity: sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==}
 
-  electron-builder@26.5.0:
-    resolution: {integrity: sha512-DHvMBUmDscyvI/JvcJ1ZjrPqikzANbnX83MxUX5Daaeu2I8c2SxFM8LyKEepEZr1uomV1sw7yrLtKhKAT82OdA==}
+  electron-builder@26.4.0:
+    resolution: {integrity: sha512-FCUqvdq2AULL+Db2SUGgjOYTbrgkPxZtCjqIZGnjH9p29pTWyesQqBIfvQBKa6ewqde87aWl49n/WyI/NyUBog==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -3220,14 +3220,14 @@ packages:
   electron-publish@24.13.1:
     resolution: {integrity: sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==}
 
-  electron-publish@26.4.1:
-    resolution: {integrity: sha512-nByal9K5Ar3BNJUfCSglXltpKUhJqpwivNpKVHnkwxTET9LKl+NxoojpGF1dSXVFcoBKVm+OhsVa28ZsoshEPA==}
+  electron-publish@26.3.4:
+    resolution: {integrity: sha512-5/ouDPb73SkKuay2EXisPG60LTFTMNHWo2WLrK5GDphnWK9UC+yzYrzVeydj078Yk4WUXi0+TaaZsNd6Zt5k/A==}
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
-  electron-updater@6.8.1:
-    resolution: {integrity: sha512-6DvJ5xkIickdXI8llEiwsN47ea11/9ycwZmpSpNKBovAKfQPGblHRyI6JexifmHWxer/DY34Aa/OgTRqXQ3iMg==}
+  electron-updater@6.7.3:
+    resolution: {integrity: sha512-EgkT8Z9noqXKbwc3u5FkJA+r48jwZ5DTUiOkJMOTEEH//n5Am6wfQGz7nvSFEA2oIAMv9jRzn5JKTyWeSKOPgg==}
 
   electron@40.0.0:
     resolution: {integrity: sha512-UyBy5yJ0/wm4gNugCtNPjvddjAknMTuXR2aCHioXicH7aKRKGDBPp4xqTEi/doVcB3R+MN3wfU9o8d/9pwgK2A==}
@@ -5510,8 +5510,8 @@ packages:
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
-  tar@7.5.3:
-    resolution: {integrity: sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==}
+  tar@7.5.2:
+    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
@@ -8748,7 +8748,7 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@24.13.3(dmg-builder@26.5.0)(electron-builder-squirrel-windows@24.13.3):
+  app-builder-lib@24.13.3(dmg-builder@26.4.0)(electron-builder-squirrel-windows@24.13.3):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.2.1
@@ -8762,9 +8762,9 @@ snapshots:
       builder-util-runtime: 9.2.4
       chromium-pickle-js: 0.2.0
       debug: 4.4.3
-      dmg-builder: 26.5.0(electron-builder-squirrel-windows@24.13.3)
+      dmg-builder: 26.4.0(electron-builder-squirrel-windows@24.13.3)
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 24.13.3(dmg-builder@26.5.0)
+      electron-builder-squirrel-windows: 24.13.3(dmg-builder@26.4.0)
       electron-publish: 24.13.1
       form-data: 4.0.4
       fs-extra: 10.1.0
@@ -8782,7 +8782,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  app-builder-lib@26.5.0(dmg-builder@26.5.0)(electron-builder-squirrel-windows@24.13.3):
+  app-builder-lib@26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@24.13.3):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.4.1
@@ -8794,17 +8794,17 @@ snapshots:
       '@malept/flatpak-bundler': 0.4.0
       '@types/fs-extra': 9.0.13
       async-exit-hook: 2.0.1
-      builder-util: 26.4.1
+      builder-util: 26.3.4
       builder-util-runtime: 9.5.1
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
       debug: 4.4.3
-      dmg-builder: 26.5.0(electron-builder-squirrel-windows@24.13.3)
+      dmg-builder: 26.4.0(electron-builder-squirrel-windows@24.13.3)
       dotenv: 16.4.5
       dotenv-expand: 11.0.6
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 24.13.3(dmg-builder@26.5.0)
-      electron-publish: 26.4.1
+      electron-builder-squirrel-windows: 24.13.3(dmg-builder@26.4.0)
+      electron-publish: 26.3.4
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.2
@@ -8816,7 +8816,7 @@ snapshots:
       plist: 3.1.0
       resedit: 1.7.1
       semver: 7.7.3
-      tar: 7.5.3
+      tar: 6.2.1
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       which: 5.0.0
@@ -9069,7 +9069,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  builder-util@26.4.1:
+  builder-util@26.3.4:
     dependencies:
       7zip-bin: 5.2.0
       '@types/debug': 4.1.12
@@ -9102,7 +9102,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       p-map: 7.0.4
       ssri: 12.0.0
-      tar: 7.5.3
+      tar: 7.5.2
       unique-filename: 4.0.0
 
   cacheable-lookup@5.0.4: {}
@@ -9587,10 +9587,10 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dmg-builder@26.5.0(electron-builder-squirrel-windows@24.13.3):
+  dmg-builder@26.4.0(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 26.5.0(dmg-builder@26.5.0)(electron-builder-squirrel-windows@24.13.3)
-      builder-util: 26.4.1
+      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@24.13.3)
+      builder-util: 26.3.4
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
       js-yaml: 4.1.0
@@ -9685,9 +9685,9 @@ snapshots:
     dependencies:
       jake: 10.8.7
 
-  electron-builder-squirrel-windows@24.13.3(dmg-builder@26.5.0):
+  electron-builder-squirrel-windows@24.13.3(dmg-builder@26.4.0):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@26.5.0)(electron-builder-squirrel-windows@24.13.3)
+      app-builder-lib: 24.13.3(dmg-builder@26.4.0)(electron-builder-squirrel-windows@24.13.3)
       archiver: 5.3.2
       builder-util: 24.13.1
       fs-extra: 10.1.0
@@ -9695,14 +9695,14 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.5.0(electron-builder-squirrel-windows@24.13.3):
+  electron-builder@26.4.0(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 26.5.0(dmg-builder@26.5.0)(electron-builder-squirrel-windows@24.13.3)
-      builder-util: 26.4.1
+      app-builder-lib: 26.4.0(dmg-builder@26.4.0)(electron-builder-squirrel-windows@24.13.3)
+      builder-util: 26.3.4
       builder-util-runtime: 9.5.1
       chalk: 4.1.2
-      ci-info: 4.3.1
-      dmg-builder: 26.5.0(electron-builder-squirrel-windows@24.13.3)
+      ci-info: 4.2.0
+      dmg-builder: 26.4.0(electron-builder-squirrel-windows@24.13.3)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0
@@ -9727,10 +9727,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-publish@26.4.1:
+  electron-publish@26.3.4:
     dependencies:
       '@types/fs-extra': 9.0.13
-      builder-util: 26.4.1
+      builder-util: 26.3.4
       builder-util-runtime: 9.5.1
       chalk: 4.1.2
       form-data: 4.0.4
@@ -9742,7 +9742,7 @@ snapshots:
 
   electron-to-chromium@1.5.267: {}
 
-  electron-updater@6.8.1:
+  electron-updater@6.7.3:
     dependencies:
       builder-util-runtime: 9.5.1
       fs-extra: 10.1.0
@@ -10550,7 +10550,7 @@ snapshots:
       '@jest/types': 30.2.0
       babel-jest: 30.2.0(@babel/core@7.28.6)
       chalk: 4.1.2
-      ci-info: 4.3.1
+      ci-info: 4.2.0
       deepmerge: 4.3.1
       glob: 10.4.5
       graceful-fs: 4.2.11
@@ -10803,7 +10803,7 @@ snapshots:
       '@jest/types': 30.0.0
       '@types/node': 24.10.9
       chalk: 4.1.2
-      ci-info: 4.3.1
+      ci-info: 4.2.0
       graceful-fs: 4.2.11
       picomatch: 4.0.3
 
@@ -11295,7 +11295,7 @@ snapshots:
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.7.3
-      tar: 7.5.3
+      tar: 7.5.2
       tinyglobby: 0.2.12
       which: 5.0.0
     transitivePeerDependencies:
@@ -12219,7 +12219,7 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tar@7.5.3:
+  tar@7.5.2:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
Reverts gitify-app/gitify#2577

Reverting as I found via Atlassify releases that this breaks Windows auto-update process.  Reported as bug to electron-builder team