### PR TITLE
fix: animate exit on unsubscribe

### DIFF
--- a/src/renderer/components/notifications/NotificationRow.tsx
+++ b/src/renderer/components/notifications/NotificationRow.tsx
@@ -62,6 +62,7 @@ export const NotificationRow: FC<NotificationRowProps> = ({
   };
 
   const actionUnsubscribeFromThread = () => {
+    setShouldAnimateNotificationExit(shouldAnimateExit);
     unsubscribeNotification(notification);
   };
 


### PR DESCRIPTION
Noticed today that for `Unsubscribe` actions that we weren't animating the notification row exit transition.  Now this is consistent with other action events