### PR TITLE
fix: resolve react-is version mismatch and .gitattributes syntax error

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,4 @@
 *.snap linguist-generated=true
 
 # GraphQL Codegen outputs
-+ src/renderer/utils/api/graphql/generated/**/*.ts linguist-generated=true
+src/renderer/utils/api/graphql/generated/**/*.ts linguist-generated=true

--- a/package.json
+++ b/package.json
@@ -137,7 +137,10 @@
       "electron",
       "esbuild",
       "unrs-resolver"
-    ]
+    ],
+    "overrides": {
+      "react-is": "19.2.4"
+    }
   },
   "lint-staged": {
     "*": "biome check --no-errors-on-unmatched",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  react-is: 19.2.4
+
 importers:
 
   .:
@@ -1240,7 +1243,7 @@ packages:
       '@types/react-is': 18.x || 19.x
       react: 18.x || 19.x
       react-dom: 18.x || 19.x
-      react-is: 18.x || 19.x
+      react-is: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3412,9 +3415,6 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
-
-  react-is@17.0.2:
-    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@19.2.4:
     resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
@@ -7584,7 +7584,7 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
-      react-is: 17.0.2
+      react-is: 19.2.4
 
   proc-log@5.0.0: {}
 
@@ -7630,8 +7630,6 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
-
-  react-is@17.0.2: {}
 
   react-is@19.2.4: {}
 


### PR DESCRIPTION
Override `react-is` to v19.2.4 via pnpm overrides to fix `CounterLabel` crash:

```
chunk-ZTL4OTR6.js?v=90b5cbd1:3741 Uncaught Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: <CounterLabel />. Did you accidentally export a JSX literal instead of a component?

Check the render method of ForwardRef.
at createFiberFromTypeAndProps (chunk-ZTL4OTR6.js?v=90b5cbd1:3741:30)
at createFiberFromElement (chunk-ZTL4OTR6.js?v=90b5cbd1:3754:16)
at reconcileChildFibersImpl (chunk-ZTL4OTR6.js?v=90b5cbd1:5120:248)
at chunk-ZTL4OTR6.js?v=90b5cbd1:5237:35
at reconcileChildren (chunk-ZTL4OTR6.js?v=90b5cbd1:7182:53)
at beginWork (chunk-ZTL4OTR6.js?v=90b5cbd1:8701:104)
at runWithFiberInDEV (chunk-ZTL4OTR6.js?v=90b5cbd1:997:72)
at performUnitOfWork (chunk-ZTL4OTR6.js?v=90b5cbd1:12561:98)
at workLoopSync (chunk-ZTL4OTR6.js?v=90b5cbd1:12424:43)
at renderRootSync (chunk-ZTL4OTR6.js?v=90b5cbd1:12408:13)
```

 `react-is@18.3.1` checks for `Symbol(react.element)` but React 19 uses `Symbol(react.transitional.element)`, causing `isElement()` to return false in `@primer/react`'s `ButtonBase` and blow up at runtime.

Also fix .gitattributes syntax error from stray merge conflict marker:

<img width="558" height="94" alt="Screenshot 2026-03-02 at 11 10 57 AM" src="https://github.com/user-attachments/assets/dcb9d066-10b9-455a-b320-cc4e40434322" />


<details><summary>Before</summary>
<p>

<img width="568" height="468" alt="Screenshot 2026-03-02 at 10 53 58 AM" src="https://github.com/user-attachments/assets/0cc7cb01-e9e9-4373-bfac-e40944439b5e" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="612" height="512" alt="Screenshot 2026-03-02 at 11 05 54 AM" src="https://github.com/user-attachments/assets/ce42c053-8578-4326-8cde-35a07b906cde" />

</p>
</details> 