### PR TITLE
feat: allow window to be resizable

### DIFF
--- a/src/main/config.test.ts
+++ b/src/main/config.test.ts
@@ -30,7 +30,7 @@ describe('main/config.ts', () => {
     expect(WindowConfig.height).toBe(400);
     expect(WindowConfig.minWidth).toBe(500);
     expect(WindowConfig.minHeight).toBe(400);
-    expect(WindowConfig.resizable).toBe(false);
+    expect(WindowConfig.resizable).toBe(true);
     expect(WindowConfig.skipTaskbar).toBe(true);
     expect(WindowConfig.webPreferences).toBeDefined();
     expect(WindowConfig.webPreferences.contextIsolation).toBe(true);

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -44,7 +44,7 @@ export const WindowConfig: BrowserWindowConstructorOptions = {
   height: 400,
   minWidth: 500,
   minHeight: 400,
-  resizable: false,
+  resizable: true,
   /** Hide the app from the Windows taskbar */
   skipTaskbar: true,
   webPreferences: {

--- a/src/main/lifecycle/window.ts
+++ b/src/main/lifecycle/window.ts
@@ -34,11 +34,11 @@ export function configureWindowEvents(mb: Menubar): void {
 
   /**
    * When DevTools is closed, restore the window to its original size and position it centered on the tray icon.
+   * Keep the window resizable to allow users to adjust the size at any time.
    */
   mb.window.webContents.on('devtools-closed', () => {
     const trayBounds = mb.tray.getBounds();
     mb.window.setSize(WindowConfig.width, WindowConfig.height);
     mb.positioner.move('trayCenter', trayBounds);
-    mb.window.resizable = false;
   });
 }


### PR DESCRIPTION
Fixes #2441

This PR allows the Gitify window to be resizable:
- Set WindowConfig.resizable to true
- Remove resizable = false in DevTools closed event
- Update test to expect resizable = true

This improves user experience by allowing users to resize the window according to their needs.