### PR TITLE
fix: Improve password store detection on Linux tiling WMs

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,36 @@
+import { execFileSync } from 'node:child_process';
+
 import { app } from 'electron';
 import log from 'electron-log';
 import { menubar } from 'menubar';
+
+// On Linux tiling WMs (Hyprland, Sway, i3, etc.), Electron fails to detect the
+// correct password storage backend because XDG_CURRENT_DESKTOP doesn't match a
+// known DE. Query D-Bus for an active Secret Service provider and, if found, tell
+// Electron to use gnome-libsecret so safeStorage works correctly.
+if (
+  process.platform === 'linux' &&
+  !app.commandLine.hasSwitch('password-store')
+) {
+  try {
+    execFileSync(
+      'dbus-send',
+      [
+        '--session',
+        '--dest=org.freedesktop.DBus',
+        '--type=method_call',
+        '--print-reply',
+        '/org/freedesktop/DBus',
+        'org.freedesktop.DBus.GetNameOwner',
+        'string:org.freedesktop.secrets',
+      ],
+      { timeout: 2000, stdio: 'ignore' },
+    );
+    app.commandLine.appendSwitch('password-store', 'gnome-libsecret');
+  } catch {
+    // D-Bus not available or no Secret Service provider — let Electron fall back
+  }
+}
 
 import { Paths, WindowConfig } from './config';
 import {


### PR DESCRIPTION
## Summary

On Linux tiling WMs (Hyprland, Sway, i3, etc.), Electron's `safeStorage` API fails to detect the correct password storage backend, even when a keyring like `gnome-keyring` is installed and running. This causes login to fail with `Encryption is not available`.

The root cause is that Electron selects the backend based on the `XDG_CURRENT_DESKTOP` environment variable. When it doesn't match a known desktop environment, it falls back to `basic_text` and reports `isEncryptionAvailable: false` -- despite `org.freedesktop.secrets` being available on D-Bus.

This PR adds a startup check that queries D-Bus for an active Secret Service provider. If one is found and the user hasn't explicitly passed `--password-store`, it sets `--password-store=gnome-libsecret` so Electron uses the correct backend.

## Details

- Only runs on Linux, before the app ready event (where command line switches must be set)
- Uses `execFileSync` to call `dbus-send` -- no shell spawned, no new dependencies
- Wrapped in try/catch with a 2s timeout -- if D-Bus is unavailable, it's a no-op
- Respects any explicit `--password-store=...` flag the user passes

## Related

- #1981 -- "Encryption is not available" on Arch Linux
- #2309 -- "Fail to authenticate in hyprland/wayland"

## Tested on

- Gentoo Linux x86_64 (kernel 6.18.12)
- Hyprland
- gnome-keyring-daemon