### PR TITLE
chore: use pnpm dlx instead of deprecated pnpx in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpx lint-staged
+pnpm dlx lint-staged


### PR DESCRIPTION
## Summary
- Replace `pnpx lint-staged` with `pnpm dlx lint-staged` in `.husky/pre-commit`. `pnpx` is deprecated upstream in favor of `pnpm dlx`.