### PR TITLE
fix(filters): pin filter sort to a stable locale

### DIFF
--- a/src/renderer/components/filters/FilterSection.tsx
+++ b/src/renderer/components/filters/FilterSection.tsx
@@ -74,9 +74,10 @@ const FilterSectionComponent = <K extends keyof FiltersState>({
           .sort((a, b) =>
             filter
               .getTypeDetails(a)
-              .title.toLocaleLowerCase()
+              .title.toLowerCase()
               .localeCompare(
-                filter.getTypeDetails(b).title.toLocaleLowerCase(),
+                filter.getTypeDetails(b).title.toLowerCase(),
+                'en',
               ),
           )
           .map((type) => {


### PR DESCRIPTION
## Summary

- Filter checkbox order in `FilterSection` is sorted via `localeCompare()` + `toLocaleLowerCase()`, both of which fall back to the host locale. This makes the resulting order machine-dependent.
- Under `cs_CZ.UTF-8` (Czech), for example, `"Check Suite"` sorts after `"Co..."` and `"De..."` entries because Czech treats `"ch"` as a digraph that collates after `"h"`. This causes the `SubjectTypeFilter` and `Filters` snapshot tests to fail locally for non-English contributors while CI (which runs in English) keeps passing — the snapshot was effectively captured against a host-locale-specific order.
- Pin the comparator to `'en'` and switch `toLocaleLowerCase()` → `toLowerCase()` so the order is stable across machines. Filter type labels are hardcoded English strings (no i18n in this app), so sorting them in English is also semantically correct.

## Test plan

- [ ] `pnpm test` passes locally under a non-English locale (e.g. `LANG=cs_CZ.UTF-8 pnpm test`) — previously fails on `SubjectTypeFilter.test.tsx` and `Filters.test.tsx` snapshots.
- [ ] CI still passes (English locale — sort order is unchanged from before).
- [ ] Visual check: filter checkbox order in the UI is unchanged on an English system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)