### PR TITLE
test(mocks): pin electron mock shapes via satisfies Pick

### DIFF
--- a/src/main/config.test.ts
+++ b/src/main/config.test.ts
@@ -7,7 +7,7 @@ vi.mock('./utils', () => ({
 vi.mock('electron', () => ({
   app: {
     isPackaged: true,
-  },
+  } satisfies Pick<Electron.App, 'isPackaged'>,
 }));
 
 describe('main/config.ts', () => {

--- a/src/main/events.test.ts
+++ b/src/main/events.test.ts
@@ -7,7 +7,7 @@ vi.mock('electron', () => ({
   ipcMain: {
     on: (...args: unknown[]) => onMock(...args),
     handle: (...args: unknown[]) => handleMock(...args),
-  },
+  } satisfies Pick<Electron.IpcMain, 'on' | 'handle'>,
 }));
 
 import type { Menubar } from 'menubar';

--- a/src/main/handlers/app.test.ts
+++ b/src/main/handlers/app.test.ts
@@ -11,10 +11,10 @@ vi.mock('electron', () => ({
   ipcMain: {
     handle: (...args: unknown[]) => handleMock(...args),
     on: (...args: unknown[]) => onMock(...args),
-  },
+  } satisfies Pick<Electron.IpcMain, 'handle' | 'on'>,
   app: {
     getVersion: vi.fn(() => '1.0.0'),
-  },
+  } satisfies Pick<Electron.App, 'getVersion'>,
 }));
 
 vi.mock('../config', () => ({

--- a/src/main/handlers/system.test.ts
+++ b/src/main/handlers/system.test.ts
@@ -12,17 +12,17 @@ vi.mock('electron', () => ({
   ipcMain: {
     on: (...args: unknown[]) => onMock(...args),
     handle: (...args: unknown[]) => handleMock(...args),
-  },
+  } satisfies Pick<Electron.IpcMain, 'on' | 'handle'>,
   globalShortcut: {
     register: vi.fn(),
     unregister: vi.fn(),
-  },
+  } satisfies Pick<Electron.GlobalShortcut, 'register' | 'unregister'>,
   app: {
     setLoginItemSettings: vi.fn(),
-  },
+  } satisfies Pick<Electron.App, 'setLoginItemSettings'>,
   shell: {
     openExternal: vi.fn(),
-  },
+  } satisfies Pick<Electron.Shell, 'openExternal'>,
 }));
 
 describe('main/handlers/system.ts', () => {

--- a/src/main/handlers/tray.test.ts
+++ b/src/main/handlers/tray.test.ts
@@ -10,10 +10,10 @@ const onMock = vi.fn();
 vi.mock('electron', () => ({
   ipcMain: {
     on: (...args: unknown[]) => onMock(...args),
-  },
+  } satisfies Pick<Electron.IpcMain, 'on'>,
   net: {
     isOnline: vi.fn().mockReturnValue(true),
-  },
+  } satisfies Pick<Electron.Net, 'isOnline'>,
 }));
 
 describe('main/handlers/tray.ts', () => {

--- a/src/main/lifecycle/first-run.test.ts
+++ b/src/main/lifecycle/first-run.test.ts
@@ -20,15 +20,23 @@ const moveToApplicationsFolderMock = vi.fn();
 const isInApplicationsFolderMock = vi.fn(() => false);
 const getPathMock = vi.fn(() => '/User/Data');
 
-const showMessageBoxMock = vi.fn(async () => ({ response: 0 }));
+const showMessageBoxMock = vi.fn(async () => ({
+  response: 0,
+  checkboxChecked: false,
+}));
 
 vi.mock('electron', () => ({
   app: {
     getPath: () => getPathMock(),
     isInApplicationsFolder: () => isInApplicationsFolderMock(),
     moveToApplicationsFolder: () => moveToApplicationsFolderMock(),
-  },
-  dialog: { showMessageBox: () => showMessageBoxMock() },
+  } satisfies Pick<
+    Electron.App,
+    'getPath' | 'isInApplicationsFolder' | 'moveToApplicationsFolder'
+  >,
+  dialog: {
+    showMessageBox: () => showMessageBoxMock(),
+  } satisfies Pick<Electron.Dialog, 'showMessageBox'>,
 }));
 
 // Ensure the module under test thinks we're not in dev mode
@@ -97,7 +105,10 @@ describe('main/lifecycle/first-run', () => {
   it('prompts and moves app on macOS when user accepts', async () => {
     existsSyncMock.mockReturnValueOnce(false); // marker
     existsSyncMock.mockReturnValueOnce(false); // folder
-    showMessageBoxMock.mockResolvedValueOnce({ response: 0 });
+    showMessageBoxMock.mockResolvedValueOnce({
+      response: 0,
+      checkboxChecked: false,
+    });
 
     await onFirstRunMaybe();
 
@@ -107,7 +118,10 @@ describe('main/lifecycle/first-run', () => {
   it('does not move when user declines', async () => {
     existsSyncMock.mockReturnValueOnce(false);
     existsSyncMock.mockReturnValueOnce(false);
-    showMessageBoxMock.mockResolvedValueOnce({ response: 1 });
+    showMessageBoxMock.mockResolvedValueOnce({
+      response: 1,
+      checkboxChecked: false,
+    });
 
     await onFirstRunMaybe();
 

--- a/src/main/lifecycle/reset.test.ts
+++ b/src/main/lifecycle/reset.test.ts
@@ -1,7 +1,9 @@
 import type { Menubar } from 'menubar';
 
 vi.mock('electron', () => ({
-  dialog: { showMessageBoxSync: vi.fn(() => 0) },
+  dialog: {
+    showMessageBoxSync: vi.fn(() => 0),
+  } satisfies Pick<Electron.Dialog, 'showMessageBoxSync'>,
 }));
 
 const sendRendererEventMock = vi.fn();

--- a/src/main/lifecycle/startup.test.ts
+++ b/src/main/lifecycle/startup.test.ts
@@ -13,7 +13,7 @@ vi.mock('electron', () => ({
     requestSingleInstanceLock: () => requestSingleInstanceLockMock(),
     on: (...a: unknown[]) => appOnMock(...a),
     quit: () => appQuitMock(),
-  },
+  } satisfies Pick<Electron.App, 'requestSingleInstanceLock' | 'on' | 'quit'>,
 }));
 
 const sendRendererEventMock = vi.fn();

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -29,9 +29,11 @@ vi.mock('electron', () => {
   return {
     Menu: {
       buildFromTemplate: vi.fn(),
-    },
+    } satisfies Pick<typeof Electron.Menu, 'buildFromTemplate'>,
     MenuItem: MockMenuItem,
-    shell: { openExternal: vi.fn() },
+    shell: {
+      openExternal: vi.fn(),
+    } satisfies Pick<Electron.Shell, 'openExternal'>,
   };
 });
 

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -45,10 +45,16 @@ vi.mock('electron', () => {
     }
   }
   return {
-    dialog: { showMessageBox: vi.fn() },
+    dialog: {
+      showMessageBox: vi.fn(),
+    } satisfies Pick<Electron.Dialog, 'showMessageBox'>,
     MenuItem,
-    Menu: { buildFromTemplate: vi.fn() },
-    shell: { openExternal: vi.fn() },
+    Menu: {
+      buildFromTemplate: vi.fn(),
+    } satisfies Pick<typeof Electron.Menu, 'buildFromTemplate'>,
+    shell: {
+      openExternal: vi.fn(),
+    } satisfies Pick<Electron.Shell, 'openExternal'>,
   };
 });
 

--- a/src/main/utils.test.ts
+++ b/src/main/utils.test.ts
@@ -19,9 +19,13 @@ vi.mock('node:os', () => ({
 vi.mock('electron', () => ({
   app: {
     isPackaged: true,
-  },
-  shell: { openPath: vi.fn(() => Promise.resolve('')) },
-  dialog: { showMessageBoxSync: vi.fn(() => 0) },
+  } satisfies Pick<Electron.App, 'isPackaged'>,
+  shell: {
+    openPath: vi.fn(() => Promise.resolve('')),
+  } satisfies Pick<Electron.Shell, 'openPath'>,
+  dialog: {
+    showMessageBoxSync: vi.fn(() => 0),
+  } satisfies Pick<Electron.Dialog, 'showMessageBoxSync'>,
 }));
 
 const fileGetFileMock = vi.fn(() => ({ path: '/var/log/app/app.log' }));

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -36,11 +36,11 @@ vi.mock('electron', () => ({
   contextBridge: {
     exposeInMainWorld: (key: string, value: unknown) =>
       exposeInMainWorldMock(key, value),
-  },
+  } satisfies Pick<Electron.ContextBridge, 'exposeInMainWorld'>,
   webFrame: {
     getZoomLevel: () => getZoomLevelMock(),
     setZoomLevel: (level: number) => setZoomLevelMock(level),
-  },
+  } satisfies Pick<Electron.WebFrame, 'getZoomLevel' | 'setZoomLevel'>,
 }));
 
 // Simple Notification stub

--- a/src/preload/utils.test.ts
+++ b/src/preload/utils.test.ts
@@ -3,22 +3,30 @@ import { EVENTS } from '../shared/events';
 import { invokeMainEvent, onRendererEvent, sendMainEvent } from './utils';
 
 vi.mock('electron', () => {
-  type Listener = (event: unknown, ...args: unknown[]) => void;
+  type Listener = Parameters<Electron.IpcRenderer['on']>[1];
   const listeners: Record<string, Listener[]> = {};
+  const ipcRendererStub = {
+    send: vi.fn(),
+    invoke: vi.fn().mockResolvedValue('response'),
+    on: vi.fn(function (
+      this: Electron.IpcRenderer,
+      channel: string,
+      listener: Listener,
+    ) {
+      if (!listeners[channel]) {
+        listeners[channel] = [];
+      }
+      listeners[channel].push(listener);
+      return this;
+    }),
+  } satisfies Pick<Electron.IpcRenderer, 'send' | 'invoke' | 'on'>;
   return {
     ipcRenderer: {
-      send: vi.fn(),
-      invoke: vi.fn().mockResolvedValue('response'),
-      on: vi.fn((channel: string, listener: Listener) => {
-        if (!listeners[channel]) {
-          listeners[channel] = [];
-        }
-        listeners[channel].push(listener);
-      }),
+      ...ipcRendererStub,
       __emit: (channel: string, ...args: unknown[]) => {
         const list = listeners[channel] || [];
         for (const l of list) {
-          l({}, ...args);
+          l({} as Electron.IpcRendererEvent, ...args);
         }
       },
       __listeners: listeners,


### PR DESCRIPTION
## Summary

Generalises the [PR #2839](https://github.com/gitify-app/gitify/pull/2839) safety pattern (`satisfies Pick<SafeStorage, …>` on `storage.test.ts`) to every other `vi.mock('electron', …)` factory in the test suite. Any future drift between a mocked Electron API and its real signature now fails `tsc`.

Already paid off: the new constraint surfaced two real, pre-existing mock drifts that this PR fixes:

- `dialog.showMessageBox` mock returned `{response}` instead of `{response, checkboxChecked}`.
- `ipcRenderer.on` mock returned `void` instead of `IpcRenderer` (chainable).

## Verified

- `pnpm tsc --noEmit` — clean.
- `pnpm test` — 938/938 (renderer route timeouts are a preexisting flake; pass on retry).
- Drift verification: temporarily changed `globalShortcut.register` to return a string — `tsc` errors with `Type 'Mock<() => string>' is not assignable to type '(accelerator: string, callback: () => void) => boolean'`.