### PR TITLE
chore(events): remove dead UPDATE_THEME event and onSystemThemeUpdate API

### DIFF
--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -66,7 +66,6 @@ interface TestApi {
   tray: { updateColor: (n?: number) => void };
   openExternalLink: (u: string, f: boolean) => void;
   app: { version: () => Promise<string>; show?: () => void; hide?: () => void };
-  onSystemThemeUpdate: (cb: (t: string) => void) => void;
   raiseNativeNotification: (t: string, b: string, u?: string) => unknown;
 }
 
@@ -132,24 +131,6 @@ describe('preload/index', () => {
 
     await expect(api.app.version()).resolves.toBe('v1.2.3');
     process.env.NODE_ENV = originalEnv;
-  });
-
-  it('onSystemThemeUpdate registers listener', async () => {
-    const api = getExposedApi();
-    const callback = vi.fn();
-    api.onSystemThemeUpdate(callback);
-
-    expect(onRendererEventMock).toHaveBeenCalledWith(
-      EVENTS.UPDATE_THEME,
-      expect.any(Function),
-    );
-
-    // Simulate event
-    const listener = onRendererEventMock.mock.calls[0][1];
-
-    listener({}, 'dark');
-
-    expect(callback).toHaveBeenCalledWith('dark');
   });
 
   it('raiseNativeNotification without url calls app.show', async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -193,15 +193,6 @@ export const api = {
   },
 
   /**
-   * Register a callback invoked when the OS system theme changes.
-   *
-   * @param callback - Called with the new theme string (`"light"` or `"dark"`).
-   */
-  onSystemThemeUpdate: (callback: (theme: string) => void) => {
-    onRendererEvent(EVENTS.UPDATE_THEME, (_, theme) => callback(theme));
-  },
-
-  /**
    * Display a native OS notification.
    *
    * Clicking the notification opens `url` in the browser (hiding the app window),

--- a/src/renderer/__helpers__/vitest.setup.ts
+++ b/src/renderer/__helpers__/vitest.setup.ts
@@ -59,7 +59,6 @@ window.gitify = {
   notificationSoundPath: vi.fn(),
   onAuthCallback: vi.fn(),
   onResetApp: vi.fn(),
-  onSystemThemeUpdate: vi.fn(),
   setAutoLaunch: vi.fn(),
   applyKeyboardShortcut: vi.fn().mockResolvedValue({ success: true }),
   raiseNativeNotification: vi.fn(),

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -21,7 +21,6 @@ export const EVENTS = {
   NOTIFICATION_SOUND_PATH: `${P}notification-sound-path`,
   OPEN_EXTERNAL: `${P}open-external`,
   RESET_APP: `${P}reset-app`,
-  UPDATE_THEME: `${P}update-theme`,
   TWEMOJI_DIRECTORY: `${P}twemoji-directory`,
 } as const;
 
@@ -87,7 +86,6 @@ export type EventContracts = AssertEventCoverage<{
   [EVENTS.NOTIFICATION_SOUND_PATH]: { request: undefined; response: string };
   [EVENTS.OPEN_EXTERNAL]: { request: IOpenExternal; response: undefined };
   [EVENTS.RESET_APP]: { request: undefined; response: undefined };
-  [EVENTS.UPDATE_THEME]: { request: string; response: undefined };
   [EVENTS.TWEMOJI_DIRECTORY]: { request: undefined; response: string };
 }>;
 


### PR DESCRIPTION
## Summary

`EVENTS.UPDATE_THEME` and the `window.gitify.onSystemThemeUpdate` registration shim are dead code:

- No code in `src/main/` ever calls `sendRendererEvent(mb, EVENTS.UPDATE_THEME, …)` — there is no producer.
- No code in `src/renderer/` ever calls `window.gitify.onSystemThemeUpdate(…)` — there is no consumer.
- Only the registration plumbing and its test exist, plus a `vi.fn()` stub in the renderer test setup.

Theme handling currently happens entirely on the renderer side via `@primer/react`'s `useTheme` and the OS-level `prefers-color-scheme` media query. The IPC channel was never wired up.

## Removed

- `EVENTS.UPDATE_THEME` and its `EventContracts` entry.
- `window.gitify.onSystemThemeUpdate` from `src/preload/index.ts`.
- The corresponding test in `src/preload/index.test.ts`.
- The `onSystemThemeUpdate` mock from the renderer test setup.

## Verified

`pnpm tsc --noEmit` clean, `pnpm test` 937/937, `pnpm lint:check` 0 errors.

If OS theme tracking is wanted in future, the right shape is `nativeTheme.on('updated', …)` on the main side, not this listener-without-a-producer.