### PR TITLE
feat(settings): make close-to-tray the default and remove the option

### DIFF
--- a/src/main/handlers/app.ts
+++ b/src/main/handlers/app.ts
@@ -5,7 +5,6 @@ import { EVENTS } from '../../shared/events';
 
 import { Paths } from '../config';
 import { handleMainEvent, onMainEvent } from '../events';
-import { setKeepRunningInTray } from '../lifecycle/window';
 
 /**
  * Register IPC handlers for general application queries and window/app control.
@@ -20,10 +19,6 @@ export function registerAppHandlers(mb: Menubar): void {
   onMainEvent(EVENTS.WINDOW_HIDE, () => mb.hideWindow());
 
   onMainEvent(EVENTS.QUIT, () => mb.app.quit());
-
-  onMainEvent(EVENTS.UPDATE_KEEP_RUNNING_IN_TRAY, (_, value: boolean) => {
-    setKeepRunningInTray(value);
-  });
 
   // Path handlers for renderer queries about resource locations
   handleMainEvent(EVENTS.NOTIFICATION_SOUND_PATH, () => {

--- a/src/main/lifecycle/window.test.ts
+++ b/src/main/lifecycle/window.test.ts
@@ -3,7 +3,6 @@ import type { Menubar } from 'menubar';
 import {
   __resetWindowLifecycleForTests,
   configureWindowEvents,
-  setKeepRunningInTray,
 } from './window';
 
 const appOnMock = vi.fn();
@@ -57,7 +56,6 @@ describe('main/lifecycle/window.ts', () => {
     appOnMock.mockClear();
     appQuitMock.mockClear();
     __resetWindowLifecycleForTests();
-    setKeepRunningInTray(false);
     setPlatform('linux');
 
     menubar = {
@@ -128,9 +126,8 @@ describe('main/lifecycle/window.ts', () => {
   });
 
   describe('window close handler', () => {
-    it('hides the window and restores menubar reference when keepRunningInTray is enabled', async () => {
+    it('hides the window and restores menubar reference on a WM close', async () => {
       configureWindowEvents(menubar);
-      setKeepRunningInTray(true);
 
       const closeHandler = findWindowHandler(menubar, 'close');
       const event = { preventDefault: vi.fn() };
@@ -153,7 +150,6 @@ describe('main/lifecycle/window.ts', () => {
 
     it('skips the deferred hide when the captured window is destroyed', async () => {
       configureWindowEvents(menubar);
-      setKeepRunningInTray(true);
 
       const captured = menubar.window;
       const closeHandler = findWindowHandler(menubar, 'close');
@@ -166,22 +162,8 @@ describe('main/lifecycle/window.ts', () => {
       expect(captured?.hide).not.toHaveBeenCalled();
     });
 
-    it('lets the window close normally when keepRunningInTray is disabled', async () => {
+    it('lets the window close during quit', async () => {
       configureWindowEvents(menubar);
-
-      const closeHandler = findWindowHandler(menubar, 'close');
-      const event = { preventDefault: vi.fn() };
-      closeHandler?.(event);
-
-      await flushDeferred();
-
-      expect(event.preventDefault).not.toHaveBeenCalled();
-      expect(menubar.window?.hide).not.toHaveBeenCalled();
-    });
-
-    it('lets the window close during quit even when keepRunningInTray is enabled', async () => {
-      configureWindowEvents(menubar);
-      setKeepRunningInTray(true);
 
       findAppHandler('before-quit')?.();
 
@@ -197,26 +179,16 @@ describe('main/lifecycle/window.ts', () => {
   });
 
   describe('window-all-closed handler', () => {
-    it('keeps the app alive when keepRunningInTray is enabled', () => {
+    it('keeps the app alive when not quitting', () => {
       configureWindowEvents(menubar);
-      setKeepRunningInTray(true);
 
       findAppHandler('window-all-closed')?.();
 
       expect(appQuitMock).not.toHaveBeenCalled();
     });
 
-    it('quits when keepRunningInTray is disabled (linux)', () => {
+    it('quits on linux when the user is quitting', () => {
       configureWindowEvents(menubar);
-
-      findAppHandler('window-all-closed')?.();
-
-      expect(appQuitMock).toHaveBeenCalled();
-    });
-
-    it('quits when the user is quitting even if keepRunningInTray is enabled', () => {
-      configureWindowEvents(menubar);
-      setKeepRunningInTray(true);
 
       findAppHandler('before-quit')?.();
       findAppHandler('window-all-closed')?.();
@@ -224,10 +196,11 @@ describe('main/lifecycle/window.ts', () => {
       expect(appQuitMock).toHaveBeenCalled();
     });
 
-    it('does not quit on macOS when keepRunningInTray is disabled', () => {
+    it('does not quit on macOS', () => {
       setPlatform('darwin');
       configureWindowEvents(menubar);
 
+      findAppHandler('before-quit')?.();
       findAppHandler('window-all-closed')?.();
 
       expect(appQuitMock).not.toHaveBeenCalled();

--- a/src/main/lifecycle/window.ts
+++ b/src/main/lifecycle/window.ts
@@ -6,18 +6,7 @@ import { isMacOS } from '../../shared/platform';
 
 import { WindowConfig } from '../config';
 
-let keepRunningInTray = false;
 let isQuitting = false;
-
-/**
- * Update the "keep running in tray" preference. When `true`, an OS / window
- * manager close request hides the window instead of quitting the app.
- *
- * @param value - `true` to hide on window close, `false` to quit.
- */
-export function setKeepRunningInTray(value: boolean): void {
-  keepRunningInTray = value;
-}
 
 /**
  * Reset module-level lifecycle flags. Module-level state is unavoidable
@@ -27,7 +16,6 @@ export function setKeepRunningInTray(value: boolean): void {
  * @internal
  */
 export function __resetWindowLifecycleForTests(): void {
-  keepRunningInTray = false;
   isQuitting = false;
 }
 
@@ -94,7 +82,7 @@ export function configureWindowEvents(mb: Menubar): void {
    *      first.
    */
   win.on('close', (event) => {
-    if (!keepRunningInTray || isQuitting) {
+    if (isQuitting) {
       return;
     }
 
@@ -117,7 +105,7 @@ export function configureWindowEvents(mb: Menubar): void {
    * the next tray click.
    */
   app.on('window-all-closed', () => {
-    if (keepRunningInTray && !isQuitting) {
+    if (!isQuitting) {
       return;
     }
     if (!isMacOS()) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -56,15 +56,6 @@ export const api = {
     }),
 
   /**
-   * Enable or disable hiding the application window to the tray when the
-   * window receives a close request (e.g. from the OS / window manager).
-   *
-   * @param value - `true` to hide on close, `false` to quit on close.
-   */
-  setKeepRunningInTray: (value: boolean) =>
-    sendMainEvent(EVENTS.UPDATE_KEEP_RUNNING_IN_TRAY, value),
-
-  /**
    * Apply the global keyboard shortcut for toggling the app window visibility.
    *
    * @param payload - Whether the shortcut is enabled and the Electron accelerator string.

--- a/src/renderer/__helpers__/vitest.setup.ts
+++ b/src/renderer/__helpers__/vitest.setup.ts
@@ -60,7 +60,6 @@ window.gitify = {
   onAuthCallback: vi.fn(),
   onResetApp: vi.fn(),
   setAutoLaunch: vi.fn(),
-  setKeepRunningInTray: vi.fn(),
   applyKeyboardShortcut: vi.fn().mockResolvedValue({ success: true }),
   raiseNativeNotification: vi.fn(),
 };

--- a/src/renderer/__mocks__/state-mocks.ts
+++ b/src/renderer/__mocks__/state-mocks.ts
@@ -65,7 +65,6 @@ const mockSystemSettings: SystemSettingsState = {
   playSound: true,
   notificationVolume: 20 as Percentage,
   openAtStartup: false,
-  keepRunningInTray: false,
 };
 
 export const mockSettings: SettingsState = {

--- a/src/renderer/components/settings/SystemSettings.tsx
+++ b/src/renderer/components/settings/SystemSettings.tsx
@@ -372,28 +372,6 @@ export const SystemSettings: FC = () => {
           }
           visible={!window.gitify.platform.isLinux()}
         />
-
-        <Checkbox
-          checked={settings.keepRunningInTray}
-          label="Close to tray"
-          name="keepRunningInTray"
-          onChange={() =>
-            updateSetting('keepRunningInTray', !settings.keepRunningInTray)
-          }
-          tooltip={
-            <Stack direction="vertical" gap="condensed">
-              <Text>
-                Hide {APPLICATION.NAME} to the system tray when the window is
-                closed by the operating system or window manager, instead of
-                quitting the application.
-              </Text>
-              <Text>
-                Use the tray menu or the Quit shortcut to fully exit{' '}
-                {APPLICATION.NAME}.
-              </Text>
-            </Stack>
-          }
-        />
       </Stack>
     </fieldset>
   );

--- a/src/renderer/context/App.tsx
+++ b/src/renderer/context/App.tsx
@@ -58,7 +58,6 @@ import {
   decryptValue,
   encryptValue,
   setAutoLaunch,
-  setKeepRunningInTray,
   setUseAlternateIdleIcon,
   setUseUnreadActiveIcon,
 } from '../utils/system/comms';
@@ -400,10 +399,6 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     setAutoLaunch(settings.openAtStartup);
   }, [settings.openAtStartup]);
-
-  useEffect(() => {
-    setKeepRunningInTray(settings.keepRunningInTray);
-  }, [settings.keepRunningInTray]);
 
   useEffect(() => {
     window.gitify.onResetApp(() => {

--- a/src/renderer/context/defaults.ts
+++ b/src/renderer/context/defaults.ts
@@ -56,7 +56,6 @@ const defaultSystemSettings: SystemSettingsState = {
   playSound: true,
   notificationVolume: 20 as Percentage,
   openAtStartup: false,
-  keepRunningInTray: false,
 };
 
 export const defaultSettings: SettingsState = {

--- a/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
@@ -2138,55 +2138,6 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
               </svg>
             </button>
           </div>
-          <div
-            class="text-sm prc-Stack-Stack-UQ9k6"
-            data-align="center"
-            data-direction="horizontal"
-            data-gap="condensed"
-            data-justify="start"
-            data-padding="none"
-            data-wrap="nowrap"
-          >
-            <input
-              class="size-4 rounded-sm cursor-pointer"
-              data-testid="checkbox-keepRunningInTray"
-              id="keepRunningInTray"
-              type="checkbox"
-            />
-            <label
-              class="font-medium text-gitify-font cursor-pointer"
-              for="keepRunningInTray"
-            >
-              Close to tray
-            </label>
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              aria-label="tooltip-keepRunningInTray"
-              data-testid="tooltip-icon-tooltip-keepRunningInTray"
-              id="tooltip-keepRunningInTray"
-              tabindex="0"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="octicon octicon-question text-gitify-tooltip-icon"
-                data-component="Octicon"
-                display="inline-block"
-                fill="currentColor"
-                focusable="false"
-                height="16"
-                overflow="visible"
-                style="vertical-align: text-bottom;"
-                viewBox="0 0 16 16"
-                width="16"
-              >
-                <path
-                  d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.92 6.085h.001a.749.749 0 1 1-1.342-.67c.169-.339.436-.701.849-.977C6.845 4.16 7.369 4 8 4a2.756 2.756 0 0 1 1.637.525c.503.377.863.965.863 1.725 0 .448-.115.83-.329 1.15-.205.307-.47.513-.692.662-.109.072-.22.138-.313.195l-.006.004a6.24 6.24 0 0 0-.26.16.952.952 0 0 0-.276.245.75.75 0 0 1-1.248-.832c.184-.264.42-.489.692-.661.103-.067.207-.132.313-.195l.007-.004c.1-.061.182-.11.258-.161a.969.969 0 0 0 .277-.245C8.96 6.514 9 6.427 9 6.25a.612.612 0 0 0-.262-.525A1.27 1.27 0 0 0 8 5.5c-.369 0-.595.09-.74.187a1.01 1.01 0 0 0-.34.398ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
-                />
-              </svg>
-            </button>
-          </div>
         </div>
       </fieldset>
       <div
@@ -2243,7 +2194,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
         data-wrap="nowrap"
       >
         <button
-          aria-describedby="_r_1r_"
+          aria-describedby="_r_1p_"
           class="prc-Button-ButtonBase-9n-Xk"
           data-component="Button"
           data-loading="false"
@@ -2273,7 +2224,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           class="prc-TooltipV2-Tooltip-tLeuB"
           data-component="Tooltip"
           data-direction="ne"
-          id="_r_1r_"
+          id="_r_1p_"
           popover="auto"
           role="tooltip"
         >
@@ -2290,7 +2241,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
         data-wrap="nowrap"
       >
         <button
-          aria-describedby="_r_1t_"
+          aria-describedby="_r_1r_"
           aria-label="Accounts"
           class="prc-Button-ButtonBase-9n-Xk prc-Button-IconButton-fyge7"
           data-component="IconButton"
@@ -2328,7 +2279,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           role="tooltip"
         >
           <span
-            id="_r_1t_"
+            id="_r_1r_"
           >
             Accounts
             <span
@@ -2368,7 +2319,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           </span>
         </span>
         <button
-          aria-describedby="_r_1v_"
+          aria-describedby="_r_1t_"
           aria-label="Quit Gitify"
           class="prc-Button-ButtonBase-9n-Xk prc-Button-IconButton-fyge7"
           data-component="IconButton"
@@ -2406,7 +2357,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           role="tooltip"
         >
           <span
-            id="_r_1v_"
+            id="_r_1t_"
           >
             Quit Gitify
             <span

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -146,7 +146,6 @@ export interface SystemSettingsState {
   playSound: boolean;
   notificationVolume: Percentage;
   openAtStartup: boolean;
-  keepRunningInTray: boolean;
 }
 
 export interface AuthState {

--- a/src/renderer/utils/system/comms.ts
+++ b/src/renderer/utils/system/comms.ts
@@ -94,16 +94,6 @@ export function setAutoLaunch(value: boolean): void {
 }
 
 /**
- * Enable or disable hiding the application window to the tray when the
- * window receives a close request (e.g. from the OS / window manager).
- *
- * @param value - `true` to hide on close, `false` to quit on close.
- */
-export function setKeepRunningInTray(value: boolean): void {
-  window.gitify.setKeepRunningInTray(value);
-}
-
-/**
  * Switch the tray icon to an alternate idle icon variant.
  *
  * @param value - `true` to use the alternate idle icon, `false` for the default.

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -16,7 +16,6 @@ export const EVENTS = {
   USE_UNREAD_ACTIVE_ICON: `${P}use-unread-active-icon`,
   UPDATE_KEYBOARD_SHORTCUT: `${P}update-keyboard-shortcut`,
   UPDATE_AUTO_LAUNCH: `${P}update-auto-launch`,
-  UPDATE_KEEP_RUNNING_IN_TRAY: `${P}update-keep-running-in-tray`,
   SAFE_STORAGE_ENCRYPT: `${P}safe-storage-encrypt`,
   SAFE_STORAGE_DECRYPT: `${P}safe-storage-decrypt`,
   NOTIFICATION_SOUND_PATH: `${P}notification-sound-path`,
@@ -95,10 +94,6 @@ export type EventContracts = AssertEventCoverage<{
     response: IKeyboardShortcutResult;
   };
   [EVENTS.UPDATE_AUTO_LAUNCH]: { request: IAutoLaunch; response: undefined };
-  [EVENTS.UPDATE_KEEP_RUNNING_IN_TRAY]: {
-    request: boolean;
-    response: undefined;
-  };
   [EVENTS.SAFE_STORAGE_ENCRYPT]: { request: string; response: string };
   [EVENTS.SAFE_STORAGE_DECRYPT]: {
     request: string;


### PR DESCRIPTION
## Summary

Removes the "Close to tray" checkbox added in #2845 and makes the hide-on-close behavior the default on every platform. Window-manager close requests (Cmd+W, Alt+F4, Super+Q) now always hide Gitify to the tray instead of quitting; explicit quits via the tray menu, Cmd/Ctrl+Q, or `before-quit` still tear the app down. Drops the related IPC event, preload API, comms wrapper, settings state, and renderer wiring (-148 net lines).

## Test plan

- [x] WM close shortcut hides the popup; tray icon stays; clicking the tray reopens the same window with state intact
- [x] Tray right-click → "Quit Gitify" exits the app
- [x] `Ctrl/Cmd+Q` exits the app
- [x] `Esc` still hides the popup
- [x] `pnpm test` passes (window.test.ts trimmed; Settings snapshot regenerated)