### PR TITLE
fix(accounts): hide view-scopes affordance for forges without OAuth scopes

### DIFF
--- a/src/renderer/routes/Accounts.tsx
+++ b/src/renderer/routes/Accounts.tsx
@@ -39,6 +39,7 @@ import { getAccountUUID, refreshAccount } from '../utils/auth/utils';
 import { Errors } from '../utils/core/errors';
 import { toError } from '../utils/core/logger';
 import { saveState } from '../utils/core/storage';
+import { getAdapter } from '../utils/forges/registry';
 import {
   openAccountProfile,
   openDeveloperSettings,
@@ -259,35 +260,36 @@ export const AccountsRoute: FC = () => {
                       variant={i === 0 ? 'primary' : 'default'}
                     />
 
-                    {!hasBadCredentials && (
-                      <IconButton
-                        aria-label={`View scopes for ${account.user?.login}`}
-                        data-testid="account-view-scopes"
-                        icon={() => (
-                          <ShieldCheckIcon
-                            className={
-                              hasRecommendedScopes(account)
-                                ? IconColor.GREEN
-                                : hasAlternateScopes(account)
-                                  ? 'text-gitify-warning'
-                                  : ''
-                            }
-                          />
-                        )}
-                        onClick={() =>
-                          navigate('/account-scopes', {
-                            state: { account },
-                          })
-                        }
-                        size="small"
-                        variant={
-                          !hasRecommendedScopes(account) &&
-                          !hasAlternateScopes(account)
-                            ? 'danger'
-                            : 'default'
-                        }
-                      />
-                    )}
+                    {!hasBadCredentials &&
+                      getAdapter(account).supportsOAuthScopes && (
+                        <IconButton
+                          aria-label={`View scopes for ${account.user?.login}`}
+                          data-testid="account-view-scopes"
+                          icon={() => (
+                            <ShieldCheckIcon
+                              className={
+                                hasRecommendedScopes(account)
+                                  ? IconColor.GREEN
+                                  : hasAlternateScopes(account)
+                                    ? 'text-gitify-warning'
+                                    : ''
+                              }
+                            />
+                          )}
+                          onClick={() =>
+                            navigate('/account-scopes', {
+                              state: { account },
+                            })
+                          }
+                          size="small"
+                          variant={
+                            !hasRecommendedScopes(account) &&
+                            !hasAlternateScopes(account)
+                              ? 'danger'
+                              : 'default'
+                          }
+                        />
+                      )}
 
                     {hasBadCredentials && (
                       <IconButton

--- a/src/renderer/utils/forges/gitea/adapter.ts
+++ b/src/renderer/utils/forges/gitea/adapter.ts
@@ -109,6 +109,8 @@ export const giteaAdapter: ForgeAdapter = {
     `https://${account.hostname}/user/settings/applications` as Link,
   documentationUrl: GITEA_DOCS_URL,
 
+  supportsOAuthScopes: false,
+
   loginMethods: [
     {
       testId: 'login-gitea-pat',

--- a/src/renderer/utils/forges/github/adapter.ts
+++ b/src/renderer/utils/forges/github/adapter.ts
@@ -116,6 +116,8 @@ export const githubAdapter: ForgeAdapter = {
   getDeveloperSettingsUrl: getDeveloperSettingsURL,
   documentationUrl: Constants.GITHUB_DOCS.PAT_URL as Link,
 
+  supportsOAuthScopes: true,
+
   loginMethods: [
     {
       testId: 'login-github',

--- a/src/renderer/utils/forges/types.ts
+++ b/src/renderer/utils/forges/types.ts
@@ -175,6 +175,13 @@ export interface ForgeAdapter {
   // Forges without an OAuth scope concept (e.g. Gitea) report `true` for
   // every check, signalling "nothing to verify".
 
+  /**
+   * Whether this forge has an OAuth scope concept at all. Drives whether the
+   * UI surfaces a scopes affordance (account view scopes, scope health icon).
+   * Forges that return `false` here should have callers skip rendering any
+   * scopes UI rather than showing a meaningless "all granted" or empty state.
+   */
+  readonly supportsOAuthScopes: boolean;
   /** Whether the account holds the minimum scopes Gitify needs to function. */
   hasRequiredScopes(account: Account): boolean;
   /** Whether the account holds the full recommended scope set. */


### PR DESCRIPTION
## Summary

- Adds a `supportsOAuthScopes: boolean` flag to the `ForgeAdapter` contract; GitHub sets `true`, Gitea sets `false`.
- Gates the `account-view-scopes` IconButton in `Accounts.tsx` on the active account's adapter, so Gitea accounts no longer surface a scopes UI that has no meaning for that forge.

## Why

Reported visually for Gitea accounts: the shield button rendered green (Gitea's adapter stubs `hasRecommendedScopes() => true`), but clicking it landed on `/account-scopes` with the GitHub-shaped scope list (`notifications`, `read:user`, `repo`, `public_repo`) all marked denied — because Gitea's `fetchAuthenticatedUser` never populates `account.scopes`, and the route's hard-coded GitHub vocabulary has no meaning for Gitea regardless. Refresh wouldn't help.

The minimal fix is to declare scope-awareness as adapter metadata and let callers skip the affordance entirely for forges that have no scope concept. Renders accurately, removes the misleading affordance, and stays narrow — no changes to the `AccountScopes` route itself or the existing `hasRequired/Recommended/AlternateScopes` capability methods.

## Test plan

- [ ] Typecheck (`pnpm tsc --noEmit`) — passing.
- [ ] `pnpm vitest run src/renderer/routes/Accounts.test.tsx src/renderer/utils/forges` — 275/275 passing locally.
- [ ] Visually confirm in the running app: Gitea account no longer shows the shield IconButton; GitHub account behaviour unchanged.