### PR TITLE
feat(login): broaden gitea tagline to name forgejo and codeberg

### DIFF
--- a/src/renderer/components/filters/AccountFilter.tsx
+++ b/src/renderer/components/filters/AccountFilter.tsx
@@ -9,8 +9,6 @@ import { useFiltersStore } from '../../stores';
 import { Checkbox } from '../fields/Checkbox';
 import { Title } from '../primitives/Title';
 
-import type { AccountUUID } from '../../types';
-
 import { getAccountUUID } from '../../utils/auth/utils';
 
 export const AccountFilter: FC = () => {

--- a/src/renderer/utils/forges/gitea/adapter.ts
+++ b/src/renderer/utils/forges/gitea/adapter.ts
@@ -74,7 +74,7 @@ function getDisplayHelpers(
 export const giteaAdapter: ForgeAdapter = {
   id: 'gitea',
   displayName: 'Gitea',
-  tagline: 'Self-hosted Git service',
+  tagline: 'Gitea, Forgejo & Codeberg',
   icon: ServerIcon,
   capabilities,
 


### PR DESCRIPTION
## Summary

Updates the Gitea forge tagline on the login screen from `Self-hosted Git service` to `Gitea, Forgejo & Codeberg`.

The `gitea` adapter is API-compatible with Forgejo (a Gitea fork) and Codeberg (which runs Forgejo), so users of those forges already authenticate through this path successfully. Naming them in the tagline gives Forgejo/Codeberg users confidence they're in the right place instead of bouncing off a tab labelled "Gitea".

Also includes a tiny drive-by: removes an unused `AccountUUID` type import in `AccountFilter.tsx` that was tripping the local pre-commit `tsc --noEmit` hook.

## Test plan

- [ ] `pnpm vitest run src/renderer/utils/forges/gitea` — 32/32 passing locally.
- [ ] `pnpm tsc --noEmit` — clean (the drive-by fix unblocks this).
- [ ] Visually confirm in the running app: Gitea tab tagline reads "Gitea, Forgejo & Codeberg".