### PR TITLE
fix(ci): skip @primer/primitives postinstall script

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 allowBuilds:
   '@parcel/watcher': true
+  '@primer/primitives': false
   electron: true
   electron-winstaller: true


### PR DESCRIPTION
## Summary

CI on `main` started failing after the lock file maintenance pulled in `@primer/primitives@11.8.0`, which has a `postinstall` that runs `cd docs/storybook && npm ci` — a path that doesn't exist in the published tarball. Under pnpm 11 this surfaces as `ERR_PNPM_IGNORED_BUILDS` and fails `pnpm install --frozen-lockfile`.

Marking it `false` in `pnpm-workspace.yaml > allowBuilds` explicitly skips the script (it would be a no-op or error anyway, since only `dist/` and tokens ship in the package).