### PR TITLE
refactor: tidy up the forge adapter interface

### DIFF
--- a/src/renderer/context/App.test.tsx
+++ b/src/renderer/context/App.test.tsx
@@ -13,9 +13,9 @@ import { useNotifications } from '../hooks/useNotifications';
 import type { AuthState, ClientID, ClientSecret, SettingsState, Token } from '../types';
 import type { DeviceFlowSession } from '../utils/auth/types';
 
-import * as authFlows from '../utils/auth/flows';
 import * as authUtils from '../utils/auth/utils';
 import * as storage from '../utils/core/storage';
+import { getAdapter } from '../utils/forges/registry';
 import * as notifications from '../utils/notifications/notifications';
 import * as comms from '../utils/system/comms';
 import * as tray from '../utils/system/tray';
@@ -212,39 +212,41 @@ describe('renderer/context/App.tsx', () => {
       } as unknown as AuthState);
     const removeAccountSpy = vi.spyOn(authUtils, 'removeAccount');
 
-    it('loginWithDeviceFlowStart calls startGitHubDeviceFlow', async () => {
-      const startGitHubDeviceFlowSpy = vi
-        .spyOn(authFlows, 'startGitHubDeviceFlow')
-        .mockImplementation(vi.fn());
+    it('loginWithDeviceFlowStart delegates to the forge adapter', async () => {
+      const adapter = getAdapter('github');
+      const startSpy = vi.spyOn(adapter, 'startDeviceFlow').mockImplementation(vi.fn());
 
       const getContext = renderWithContext();
 
       await act(async () => {
-        getContext().loginWithDeviceFlowStart();
+        getContext().loginWithDeviceFlowStart('github');
       });
 
-      expect(startGitHubDeviceFlowSpy).toHaveBeenCalled();
+      expect(startSpy).toHaveBeenCalled();
     });
 
-    it('loginWithDeviceFlowPoll calls pollGitHubDeviceFlow', async () => {
-      const pollGitHubDeviceFlowSpy = vi
-        .spyOn(authFlows, 'pollGitHubDeviceFlow')
-        .mockImplementation(vi.fn());
+    it('loginWithDeviceFlowPoll delegates to the forge adapter', async () => {
+      const adapter = getAdapter('github');
+      const pollSpy = vi.spyOn(adapter, 'pollDeviceFlow').mockImplementation(vi.fn());
 
       const getContext = renderWithContext();
 
       await act(async () => {
-        getContext().loginWithDeviceFlowPoll('session' as unknown as DeviceFlowSession);
+        getContext().loginWithDeviceFlowPoll('github', 'session' as unknown as DeviceFlowSession);
       });
 
-      expect(pollGitHubDeviceFlowSpy).toHaveBeenCalledWith('session');
+      expect(pollSpy).toHaveBeenCalledWith('session');
     });
 
     it('loginWithDeviceFlowComplete calls addAccount', async () => {
       const getContext = renderWithContext();
 
       await act(async () => {
-        await getContext().loginWithDeviceFlowComplete('token' as Token, Constants.GITHUB_HOSTNAME);
+        await getContext().loginWithDeviceFlowComplete(
+          'github',
+          'token' as Token,
+          Constants.GITHUB_HOSTNAME,
+        );
       });
 
       expect(addAccountSpy).toHaveBeenCalledWith(
@@ -256,20 +258,61 @@ describe('renderer/context/App.tsx', () => {
       );
     });
 
-    it('loginWithOAuthApp calls performGitHubWebOAuth', async () => {
-      const performGitHubWebOAuthSpy = vi.spyOn(authFlows, 'performGitHubWebOAuth');
+    it('loginWithOAuthApp delegates to the forge adapter', async () => {
+      const adapter = getAdapter('github');
+      const oauthSpy = vi.spyOn(adapter, 'performWebOAuth');
 
       const getContext = renderWithContext();
 
       await act(async () => {
-        getContext().loginWithOAuthApp({
+        getContext().loginWithOAuthApp('github', {
           clientId: 'id' as ClientID,
           clientSecret: 'secret' as ClientSecret,
           hostname: Constants.GITHUB_HOSTNAME,
         });
       });
 
-      expect(performGitHubWebOAuthSpy).toHaveBeenCalled();
+      expect(oauthSpy).toHaveBeenCalled();
+    });
+
+    it('loginWithDeviceFlowStart throws when the forge does not support device flow', async () => {
+      const getContext = renderWithContext();
+
+      await expect(getContext().loginWithDeviceFlowStart('gitea')).rejects.toThrow(
+        /Device flow is not supported for forge "gitea"/,
+      );
+    });
+
+    it('loginWithDeviceFlowPoll throws when the forge does not support device flow', async () => {
+      const getContext = renderWithContext();
+
+      await expect(
+        getContext().loginWithDeviceFlowPoll('gitea', {} as DeviceFlowSession),
+      ).rejects.toThrow(/Device flow is not supported for forge "gitea"/);
+    });
+
+    it('loginWithDeviceFlowComplete throws when the forge declares no auth method', async () => {
+      const getContext = renderWithContext();
+
+      await expect(
+        getContext().loginWithDeviceFlowComplete(
+          'gitea',
+          'token' as Token,
+          Constants.GITHUB_HOSTNAME,
+        ),
+      ).rejects.toThrow(/did not declare a device-flow auth method/);
+    });
+
+    it('loginWithOAuthApp throws when the forge does not support OAuth app login', async () => {
+      const getContext = renderWithContext();
+
+      await expect(
+        getContext().loginWithOAuthApp('gitea', {
+          clientId: 'id' as ClientID,
+          clientSecret: 'secret' as ClientSecret,
+          hostname: Constants.GITHUB_HOSTNAME,
+        }),
+      ).rejects.toThrow(/OAuth app login is not supported for forge "gitea"/);
     });
 
     it('logoutFromAccount calls removeAccountNotifications, removeAccount', async () => {

--- a/src/renderer/context/App.tsx
+++ b/src/renderer/context/App.tsx
@@ -38,12 +38,6 @@ import type {
 } from '../utils/auth/types';
 
 import {
-  exchangeAuthCodeForAccessToken,
-  performGitHubWebOAuth,
-  pollGitHubDeviceFlow,
-  startGitHubDeviceFlow,
-} from '../utils/auth/flows';
-import {
   addAccount,
   getAccountUUID,
   hasAccounts,
@@ -105,10 +99,14 @@ function migrateLegacyAuthState(auth: AuthState): AuthState {
 export interface AppContextState {
   auth: AuthState;
   isLoggedIn: boolean;
-  loginWithDeviceFlowStart: (hostname?: Hostname, scopes?: string[]) => Promise<DeviceFlowSession>;
-  loginWithDeviceFlowPoll: (session: DeviceFlowSession) => Promise<Token | null>;
-  loginWithDeviceFlowComplete: (token: Token, hostname: Hostname) => Promise<void>;
-  loginWithOAuthApp: (data: LoginOAuthWebOptions) => Promise<void>;
+  loginWithDeviceFlowStart: (
+    forge: Forge,
+    hostname?: Hostname,
+    scopes?: string[],
+  ) => Promise<DeviceFlowSession>;
+  loginWithDeviceFlowPoll: (forge: Forge, session: DeviceFlowSession) => Promise<Token | null>;
+  loginWithDeviceFlowComplete: (forge: Forge, token: Token, hostname: Hostname) => Promise<void>;
+  loginWithOAuthApp: (forge: Forge, data: LoginOAuthWebOptions) => Promise<void>;
   loginWithPersonalAccessToken: (data: LoginPersonalAccessTokenOptions) => Promise<void>;
   logoutFromAccount: (account: Account) => Promise<void>;
 
@@ -439,40 +437,49 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   }, [auth]);
 
   /**
-   * Login to GitHub Gitify OAuth App.
-   *
-   * Initiate device flow session.
+   * Initiate an OAuth device-flow session for the given forge.
    */
   const loginWithDeviceFlowStart = useCallback(
-    async (hostname?: Hostname, scopes?: string[]) => await startGitHubDeviceFlow(hostname, scopes),
+    async (forge: Forge, hostname?: Hostname, scopes?: string[]) => {
+      const adapter = getAdapter(forge);
+      if (!adapter.startDeviceFlow) {
+        throw new Error(`Device flow is not supported for forge "${forge}".`);
+      }
+      return await adapter.startDeviceFlow(hostname, scopes);
+    },
     [],
   );
 
   /**
-   * Login to GitHub Gitify OAuth App.
-   *
-   * Poll for device flow session.
+   * Poll for completion of an OAuth device-flow session.
    */
-  const loginWithDeviceFlowPoll = useCallback(
-    async (session: DeviceFlowSession) => await pollGitHubDeviceFlow(session),
-    [],
-  );
+  const loginWithDeviceFlowPoll = useCallback(async (forge: Forge, session: DeviceFlowSession) => {
+    const adapter = getAdapter(forge);
+    if (!adapter.pollDeviceFlow) {
+      throw new Error(`Device flow is not supported for forge "${forge}".`);
+    }
+    return await adapter.pollDeviceFlow(session);
+  }, []);
 
   /**
-   * Login to GitHub Gitify OAuth App.
-   *
-   * Finalize device flow session.
+   * Finalise an OAuth device-flow session by recording the account.
    */
   const loginWithDeviceFlowComplete = useCallback(
-    async (token: Token, hostname: Hostname) => {
+    async (forge: Forge, token: Token, hostname: Hostname) => {
+      const adapter = getAdapter(forge);
+      const method = adapter.deviceFlowAuthMethod;
+      if (!method) {
+        throw new Error(`Forge "${forge}" did not declare a device-flow auth method.`);
+      }
+
       const existingAccount = auth.accounts.find(
-        (a) => a.hostname === hostname && a.method === 'GitHub App',
+        (a) => a.hostname === hostname && a.method === method,
       );
       if (existingAccount) {
         await removeAccountNotifications(existingAccount);
       }
 
-      const updatedAuth = await addAccount(auth, 'GitHub App', token, hostname, 'github');
+      const updatedAuth = await addAccount(auth, method, token, hostname, forge);
 
       persistAuth(updatedAuth);
       await fetchNotifications({ auth: updatedAuth, settings });
@@ -481,12 +488,17 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   );
 
   /**
-   * Login with custom GitHub OAuth App.
+   * Login with a custom OAuth app on the given forge.
    */
   const loginWithOAuthApp = useCallback(
-    async (data: LoginOAuthWebOptions) => {
-      const { authOptions, authCode } = await performGitHubWebOAuth(data);
-      const token = await exchangeAuthCodeForAccessToken(authCode, authOptions);
+    async (forge: Forge, data: LoginOAuthWebOptions) => {
+      const adapter = getAdapter(forge);
+      if (!adapter.performWebOAuth || !adapter.exchangeAuthCodeForToken) {
+        throw new Error(`OAuth app login is not supported for forge "${forge}".`);
+      }
+
+      const { authOptions, authCode } = await adapter.performWebOAuth(data);
+      const token = await adapter.exchangeAuthCodeForToken(authCode, authOptions);
 
       const existingAccount = auth.accounts.find(
         (a) => a.hostname === authOptions.hostname && a.method === 'OAuth App',
@@ -495,13 +507,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         await removeAccountNotifications(existingAccount);
       }
 
-      const updatedAuth = await addAccount(
-        auth,
-        'OAuth App',
-        token,
-        authOptions.hostname,
-        'github',
-      );
+      const updatedAuth = await addAccount(auth, 'OAuth App', token, authOptions.hostname, forge);
 
       persistAuth(updatedAuth);
       await fetchNotifications({ auth: updatedAuth, settings });

--- a/src/renderer/routes/AccountScopes.test.tsx
+++ b/src/renderer/routes/AccountScopes.test.tsx
@@ -151,9 +151,9 @@ describe('renderer/routes/AccountScopes.tsx', () => {
     expect(screen.getByTestId('account-scopes-no-scopes')).toBeInTheDocument();
   });
 
-  it('should open developer settings when manage link is clicked', async () => {
-    const openDeveloperSettingsSpy = vi
-      .spyOn(links, 'openDeveloperSettings')
+  it('should open account settings when manage link is clicked', async () => {
+    const openAccountSettingsSpy = vi
+      .spyOn(links, 'openAccountSettings')
       .mockImplementation(vi.fn());
 
     await act(async () => {
@@ -162,7 +162,7 @@ describe('renderer/routes/AccountScopes.tsx', () => {
 
     await userEvent.click(screen.getByTestId('account-scopes-manage-link'));
 
-    expect(openDeveloperSettingsSpy).toHaveBeenCalledTimes(1);
+    expect(openAccountSettingsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should go back when pressing the back icon', async () => {

--- a/src/renderer/routes/AccountScopes.tsx
+++ b/src/renderer/routes/AccountScopes.tsx
@@ -20,7 +20,7 @@ import {
   getRequiredScopeNames,
   hasRequiredScopes,
 } from '../utils/auth/scopes';
-import { openDeveloperSettings } from '../utils/system/links';
+import { openAccountSettings } from '../utils/system/links';
 
 interface LocationState {
   account: Account;
@@ -186,7 +186,7 @@ export const AccountScopesRoute: FC = () => {
         <Button
           data-testid="account-scopes-manage-link"
           leadingVisual={LinkExternalIcon}
-          onClick={() => openDeveloperSettings(account)}
+          onClick={() => openAccountSettings(account)}
         >
           Developer settings
         </Button>

--- a/src/renderer/routes/Accounts.test.tsx
+++ b/src/renderer/routes/Accounts.test.tsx
@@ -213,6 +213,7 @@ describe('renderer/routes/Accounts.tsx', () => {
       expect(navigateMock).toHaveBeenCalledTimes(1);
       expect(navigateMock).toHaveBeenCalledWith('/login-device-flow', {
         replace: true,
+        state: { forge: 'github' },
       });
     });
 
@@ -245,6 +246,7 @@ describe('renderer/routes/Accounts.tsx', () => {
       expect(navigateMock).toHaveBeenCalledTimes(1);
       expect(navigateMock).toHaveBeenCalledWith('/login-oauth-app', {
         replace: true,
+        state: { forge: 'github' },
       });
     });
 

--- a/src/renderer/routes/Accounts.tsx
+++ b/src/renderer/routes/Accounts.tsx
@@ -33,7 +33,7 @@ import { Errors } from '../utils/core/errors';
 import { toError } from '../utils/core/logger';
 import { saveState } from '../utils/core/storage';
 import { getAdapter } from '../utils/forges/registry';
-import { openAccountProfile, openDeveloperSettings, openHost } from '../utils/system/links';
+import { openAccountProfile, openAccountSettings, openHost } from '../utils/system/links';
 import { getAuthMethodIcon, getPlatformIcon } from '../utils/ui/icons';
 
 export const AccountsRoute: FC = () => {
@@ -92,7 +92,10 @@ export const AccountsRoute: FC = () => {
   };
 
   const loginWithGitHub = async () => {
-    return navigate('/login-device-flow', { replace: true });
+    return navigate('/login-device-flow', {
+      replace: true,
+      state: { forge: 'github' as const },
+    });
   };
 
   const loginWithPersonalAccessToken = () => {
@@ -107,7 +110,10 @@ export const AccountsRoute: FC = () => {
   };
 
   const loginWithOAuthApp = () => {
-    return navigate('/login-oauth-app', { replace: true });
+    return navigate('/login-oauth-app', {
+      replace: true,
+      state: { forge: 'github' as const },
+    });
   };
 
   const getAccountError = (account: Account) => {
@@ -203,7 +209,7 @@ export const AccountsRoute: FC = () => {
                         data-testid="account-developer-settings"
                         direction="horizontal"
                         gap="condensed"
-                        onClick={() => openDeveloperSettings(account)}
+                        onClick={() => openAccountSettings(account)}
                         title="Open developer settings ↗"
                       >
                         {AuthMethodIcon && <AuthMethodIcon />}
@@ -217,7 +223,7 @@ export const AccountsRoute: FC = () => {
                           data-testid="account-bad-credentials"
                           direction="horizontal"
                           gap="condensed"
-                          onClick={() => openDeveloperSettings(account)}
+                          onClick={() => openAccountSettings(account)}
                           title="Open developer settings ↗"
                         >
                           <AlertFillIcon />

--- a/src/renderer/routes/Login.test.tsx
+++ b/src/renderer/routes/Login.test.tsx
@@ -35,7 +35,9 @@ describe('renderer/routes/Login.tsx', () => {
     await userEvent.click(screen.getByTestId('login-github'));
 
     expect(navigateMock).toHaveBeenCalledTimes(1);
-    expect(navigateMock).toHaveBeenCalledWith('/login-device-flow');
+    expect(navigateMock).toHaveBeenCalledWith('/login-device-flow', {
+      state: { forge: 'github' },
+    });
   });
 
   it('should navigate to login with personal access token', async () => {
@@ -53,7 +55,9 @@ describe('renderer/routes/Login.tsx', () => {
     await userEvent.click(screen.getByTestId('login-oauth-app'));
 
     expect(navigateMock).toHaveBeenCalledTimes(1);
-    expect(navigateMock).toHaveBeenCalledWith('/login-oauth-app');
+    expect(navigateMock).toHaveBeenCalledWith('/login-oauth-app', {
+      state: { forge: 'github' },
+    });
   });
 
   it('should navigate to login with Gitea personal access token', async () => {

--- a/src/renderer/routes/LoginWithDeviceFlow.test.tsx
+++ b/src/renderer/routes/LoginWithDeviceFlow.test.tsx
@@ -50,7 +50,7 @@ describe('renderer/routes/LoginWithDeviceFlow.tsx', () => {
 
     await userEvent.click(screen.getByTestId('device-scope-public'));
 
-    expect(loginWithDeviceFlowStartMock).toHaveBeenCalledWith(undefined, [
+    expect(loginWithDeviceFlowStartMock).toHaveBeenCalledWith('github', undefined, [
       'notifications',
       'read:user',
       'public_repo',
@@ -81,7 +81,7 @@ describe('renderer/routes/LoginWithDeviceFlow.tsx', () => {
 
     await userEvent.click(screen.getByTestId('device-scope-full'));
 
-    expect(loginWithDeviceFlowStartMock).toHaveBeenCalledWith(undefined, [
+    expect(loginWithDeviceFlowStartMock).toHaveBeenCalledWith('github', undefined, [
       'notifications',
       'read:user',
       'repo',

--- a/src/renderer/routes/LoginWithDeviceFlow.tsx
+++ b/src/renderer/routes/LoginWithDeviceFlow.tsx
@@ -13,16 +13,17 @@ import { Page } from '../components/layout/Page';
 import { Footer } from '../components/primitives/Footer';
 import { Header } from '../components/primitives/Header';
 
-import type { Account, Link } from '../types';
+import type { Account, Forge, Link } from '../types';
 import type { DeviceFlowSession } from '../utils/auth/types';
 
 import { getAlternateScopeNames, getRecommendedScopeNames } from '../utils/auth/scopes';
 import { rendererLogError, toError } from '../utils/core/logger';
 import { copyToClipboard, openExternalLink } from '../utils/system/comms';
-import { openDeveloperSettings } from '../utils/system/links';
+import { openAccountSettings } from '../utils/system/links';
 
 interface LocationState {
   account?: Account;
+  forge?: Forge;
 }
 
 type ScopeChoice = 'public' | 'full';
@@ -30,7 +31,12 @@ type ScopeChoice = 'public' | 'full';
 export const LoginWithDeviceFlowRoute: FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { account: reAuthAccount } = (location.state ?? {}) as LocationState;
+  const { account: reAuthAccount, forge: routeForge } = (location.state ?? {}) as LocationState;
+  // Forge is supplied either by the login-method descriptor's state (new
+  // login) or via the re-authenticating account (re-auth). Either path lands
+  // here through a registered adapter, so a missing forge would indicate a
+  // mis-registered route — fall back to 'github' to preserve existing UX.
+  const forge: Forge = routeForge ?? reAuthAccount?.forge ?? 'github';
 
   const { loginWithDeviceFlowStart, loginWithDeviceFlowPoll, loginWithDeviceFlowComplete } =
     useAppContext();
@@ -47,7 +53,7 @@ export const LoginWithDeviceFlowRoute: FC = () => {
         const scopes =
           scopeChoice === 'public' ? getAlternateScopeNames() : getRecommendedScopeNames();
 
-        const newSession = await loginWithDeviceFlowStart(reAuthAccount?.hostname, scopes);
+        const newSession = await loginWithDeviceFlowStart(forge, reAuthAccount?.hostname, scopes);
         setSession(newSession);
 
         // Auto-copy the user code to clipboard
@@ -64,7 +70,7 @@ export const LoginWithDeviceFlowRoute: FC = () => {
     if (scopeChoice) {
       initializeDeviceFlow();
     }
-  }, [loginWithDeviceFlowStart, reAuthAccount, scopeChoice]);
+  }, [loginWithDeviceFlowStart, reAuthAccount, scopeChoice, forge]);
 
   // Poll for device flow completion
   useEffect(() => {
@@ -81,10 +87,10 @@ export const LoginWithDeviceFlowRoute: FC = () => {
 
       try {
         while (isActive && Date.now() < session.expiresAt) {
-          const token = await loginWithDeviceFlowPoll(session);
+          const token = await loginWithDeviceFlowPoll(forge, session);
 
           if (token && isActive) {
-            await loginWithDeviceFlowComplete(token, session.hostname);
+            await loginWithDeviceFlowComplete(forge, token, session.hostname);
             navigate('/');
             return;
           }
@@ -118,7 +124,7 @@ export const LoginWithDeviceFlowRoute: FC = () => {
       }
     };
     // oxlint-disable-next-line react/exhaustive-deps -- navigate is stable
-  }, [session, loginWithDeviceFlowPoll, loginWithDeviceFlowComplete]);
+  }, [session, loginWithDeviceFlowPoll, loginWithDeviceFlowComplete, forge]);
 
   const handleCopyUserCode = useCallback(async () => {
     if (session?.userCode) {
@@ -229,7 +235,7 @@ export const LoginWithDeviceFlowRoute: FC = () => {
             <button
               className="text-gitify-link cursor-pointer"
               onClick={() =>
-                openDeveloperSettings({
+                openAccountSettings({
                   hostname: Constants.GITHUB_HOSTNAME,
                   method: 'GitHub App',
                 } as Account)

--- a/src/renderer/routes/LoginWithOAuthApp.tsx
+++ b/src/renderer/routes/LoginWithOAuthApp.tsx
@@ -13,27 +13,22 @@ import { Page } from '../components/layout/Page';
 import { Footer } from '../components/primitives/Footer';
 import { Header } from '../components/primitives/Header';
 
-import type { Account, ClientID, ClientSecret, Hostname, Token } from '../types';
+import type { Account, ClientID, ClientSecret, Forge, Token } from '../types';
 import type { LoginOAuthWebOptions } from '../utils/auth/types';
 
-import {
-  getNewOAuthAppURL,
-  isValidClientId,
-  isValidHostname,
-  isValidToken,
-} from '../utils/auth/utils';
+import { isValidHostname } from '../utils/auth/utils';
 import { rendererLogError, toError } from '../utils/core/logger';
+import { getNewOAuthAppURL, isValidClientId, isValidToken } from '../utils/forges/github/auth';
 import { openExternalLink } from '../utils/system/comms';
 
 interface LocationState {
   account?: Account;
+  forge?: Forge;
 }
 
-export interface IFormData {
-  hostname: Hostname;
-  clientId: ClientID;
-  clientSecret: ClientSecret;
-}
+// IFormData mirrors LoginOAuthWebOptions exactly — keep them aliased so the
+// form can be passed straight into the context callback without casting.
+export type IFormData = LoginOAuthWebOptions;
 
 interface IFormErrors {
   hostname?: string;
@@ -69,7 +64,8 @@ export const validateForm = (values: IFormData): IFormErrors => {
 export const LoginWithOAuthAppRoute: FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { account: reAuthAccount } = (location.state ?? {}) as LocationState;
+  const { account: reAuthAccount, forge: routeForge } = (location.state ?? {}) as LocationState;
+  const forge: Forge = routeForge ?? reAuthAccount?.forge ?? 'github';
 
   const { loginWithOAuthApp } = useAppContext();
 
@@ -108,7 +104,7 @@ export const LoginWithOAuthAppRoute: FC = () => {
   const verifyLoginCredentials = useCallback(
     async (data: IFormData) => {
       try {
-        await loginWithOAuthApp(data as LoginOAuthWebOptions);
+        await loginWithOAuthApp(forge, data);
         navigate('/');
       } catch (err) {
         rendererLogError('loginWithOAuthApp', 'Failed to login with OAuth App', toError(err));
@@ -118,7 +114,7 @@ export const LoginWithOAuthAppRoute: FC = () => {
       }
     },
     // oxlint-disable-next-line react/exhaustive-deps -- navigate is stable
-    [loginWithOAuthApp],
+    [loginWithOAuthApp, forge],
   );
 
   return (

--- a/src/renderer/utils/api/features.test.ts
+++ b/src/renderer/utils/api/features.test.ts
@@ -4,11 +4,7 @@ import {
   mockGitHubEnterpriseServerAccount,
 } from '../../__mocks__/account-mocks';
 
-import {
-  isAnsweredDiscussionFeatureSupported,
-  isMarkAsDoneFeatureSupported,
-  isUnsubscribeThreadSupported,
-} from './features';
+import { isMarkAsDoneFeatureSupported, isUnsubscribeThreadSupported } from './features';
 
 describe('renderer/utils/api/features.ts', () => {
   describe('isMarkAsDoneFeatureSupported', () => {
@@ -55,43 +51,6 @@ describe('renderer/utils/api/features.ts', () => {
 
     it('should return false for Gitea', () => {
       expect(isUnsubscribeThreadSupported(mockGiteaAccount)).toBe(false);
-    });
-  });
-
-  describe('isAnsweredDiscussionFeatureSupported', () => {
-    it('should return true for GitHub Cloud', () => {
-      expect(isAnsweredDiscussionFeatureSupported(mockGitHubCloudAccount)).toBe(true);
-    });
-
-    it('should return false for GitHub Enterprise Server < v3.12', () => {
-      const account = {
-        ...mockGitHubEnterpriseServerAccount,
-        version: '3.11.0',
-      };
-
-      expect(isAnsweredDiscussionFeatureSupported(account)).toBe(false);
-    });
-
-    it('should return true for GitHub Enterprise Server >= v3.12', () => {
-      const account = {
-        ...mockGitHubEnterpriseServerAccount,
-        version: '3.12.0',
-      };
-
-      expect(isAnsweredDiscussionFeatureSupported(account)).toBe(true);
-    });
-
-    it('should return false for GitHub Enterprise Server when no version available', () => {
-      const account = {
-        ...mockGitHubEnterpriseServerAccount,
-        version: undefined,
-      };
-
-      expect(isAnsweredDiscussionFeatureSupported(account)).toBe(false);
-    });
-
-    it('should return false for Gitea', () => {
-      expect(isAnsweredDiscussionFeatureSupported(mockGiteaAccount)).toBe(false);
     });
   });
 });

--- a/src/renderer/utils/api/features.ts
+++ b/src/renderer/utils/api/features.ts
@@ -14,14 +14,6 @@ export function isMarkAsDoneFeatureSupported(account: Account): boolean {
 }
 
 /**
- * Whether the account's forge surfaces an "answered" discussion state during
- * notification enrichment.
- */
-export function isAnsweredDiscussionFeatureSupported(account: Account): boolean {
-  return getAdapter(account).capabilities.answeredDiscussion(account);
-}
-
-/**
  * Whether the account's forge supports ignoring a thread subscription.
  */
 export function isUnsubscribeThreadSupported(account: Account): boolean {

--- a/src/renderer/utils/auth/types.ts
+++ b/src/renderer/utils/auth/types.ts
@@ -24,12 +24,6 @@ export interface DeviceFlowSession {
   expiresAt: number;
 }
 
-export type DeviceFlowErrorResponse = {
-  error: string;
-  error_description: string;
-  error_uri: string;
-};
-
 export interface LoginPersonalAccessTokenOptions {
   hostname: Hostname;
   token: Token;

--- a/src/renderer/utils/auth/utils.test.ts
+++ b/src/renderer/utils/auth/utils.test.ts
@@ -4,23 +4,16 @@ import { mockRawUser } from '../forges/github/__mocks__/response-mocks';
 
 import { Constants } from '../../constants';
 
-import type { Account, AuthState, ClientID, Hostname, Link, Token } from '../../types';
+import type { Account, AuthState, Hostname, Link, Token } from '../../types';
 import type { GetAuthenticatedUserResponse } from '../forges/github/types';
-import type { AuthMethod } from './types';
 
 import * as logger from '../core/logger';
 import * as apiClient from '../forges/github/client';
 import { getRecommendedScopeNames } from './scopes';
 import * as authUtils from './utils';
-import { getGitHubAuthBaseUrl, getNewOAuthAppURL, getNewTokenURL } from './utils';
 
 describe('renderer/utils/auth/utils.ts', () => {
   vi.spyOn(logger, 'rendererLogInfo').mockImplementation(vi.fn());
-
-  beforeEach(() => {
-    // Mock OAUTH_DEVICE_FLOW_CLIENT_ID value
-    Constants.OAUTH_DEVICE_FLOW_CLIENT_ID = 'FAKE_CLIENT_ID_123' as ClientID;
-  });
 
   describe('addAccount', () => {
     let mockAuthState: AuthState;
@@ -193,111 +186,6 @@ describe('renderer/utils/auth/utils.ts', () => {
     });
   });
 
-  it('extractHostVersion', () => {
-    expect(authUtils.extractHostVersion(null)).toBe('latest');
-
-    expect(authUtils.extractHostVersion('foo')).toBeUndefined();
-
-    expect(authUtils.extractHostVersion('3')).toBe('3.0.0');
-
-    expect(authUtils.extractHostVersion('3.15')).toBe('3.15.0');
-
-    expect(authUtils.extractHostVersion('3.15.0')).toBe('3.15.0');
-
-    expect(authUtils.extractHostVersion('3.15.0-beta1')).toBe('3.15.0');
-
-    expect(authUtils.extractHostVersion('enterprise-server@3')).toBe('3.0.0');
-
-    expect(authUtils.extractHostVersion('enterprise-server@3.15')).toBe('3.15.0');
-
-    expect(authUtils.extractHostVersion('enterprise-server@3.15.0')).toBe('3.15.0');
-
-    expect(authUtils.extractHostVersion('enterprise-server@3.15.0-beta1')).toBe('3.15.0');
-  });
-
-  describe('getGitHubAuthBaseUrl', () => {
-    it('should generate a GitHub Auth url - non enterprise', () => {
-      const result = getGitHubAuthBaseUrl('github.com' as Hostname);
-      expect(result.toString()).toBe('https://github.com/');
-    });
-
-    it('should generate a GitHub Auth url - enterprise', () => {
-      const result = getGitHubAuthBaseUrl('github.gitify.io' as Hostname);
-      expect(result.toString()).toBe('https://github.gitify.io/api/v3/');
-    });
-
-    it('should generate a GitHub Auth url - data residency', () => {
-      const result = getGitHubAuthBaseUrl('gitify.ghe.com' as Hostname);
-      expect(result.toString()).toBe('https://api.gitify.ghe.com/');
-    });
-  });
-
-  it('getDeveloperSettingsURL', () => {
-    expect(
-      authUtils.getDeveloperSettingsURL({
-        hostname: 'github.com' as Hostname,
-        method: 'GitHub App',
-      } as Account),
-    ).toBe('https://github.com/settings/connections/applications/FAKE_CLIENT_ID_123');
-
-    expect(
-      authUtils.getDeveloperSettingsURL({
-        hostname: 'github.com' as Hostname,
-        method: 'OAuth App',
-      } as Account),
-    ).toBe('https://github.com/settings/developers');
-
-    expect(
-      authUtils.getDeveloperSettingsURL({
-        hostname: 'github.com' as Hostname,
-        method: 'Personal Access Token',
-      } as Account),
-    ).toBe('https://github.com/settings/tokens');
-
-    expect(
-      authUtils.getDeveloperSettingsURL({
-        hostname: 'github.com',
-        method: 'unknown' as AuthMethod,
-      } as Account),
-    ).toBe('https://github.com/settings');
-  });
-
-  describe('getNewTokenURL', () => {
-    it('should generate new PAT url - github cloud', () => {
-      expect(
-        getNewTokenURL('github.com' as Hostname).startsWith(
-          'https://github.com/settings/tokens/new',
-        ),
-      ).toBeTruthy();
-    });
-
-    it('should generate new PAT url - github server', () => {
-      expect(
-        getNewTokenURL('github.gitify.io' as Hostname).startsWith(
-          'https://github.gitify.io/settings/tokens/new',
-        ),
-      ).toBeTruthy();
-    });
-  });
-
-  describe('getNewOAuthAppURL', () => {
-    it('should generate new oauth app url - github cloud', () => {
-      expect(
-        getNewOAuthAppURL('github.com' as Hostname).startsWith(
-          'https://github.com/settings/applications/new',
-        ),
-      ).toBeTruthy();
-    });
-
-    it('should generate new oauth app url - github server', () => {
-      expect(
-        getNewOAuthAppURL('github.gitify.io' as Hostname).startsWith(
-          'https://github.gitify.io/settings/applications/new',
-        ),
-      ).toBeTruthy();
-    });
-  });
-
   describe('isValidHostname', () => {
     it('should validate hostname - github cloud', () => {
       expect(authUtils.isValidHostname('github.com' as Hostname)).toBeTruthy();
@@ -313,36 +201,6 @@ describe('renderer/utils/auth/utils.ts', () => {
 
     it('should invalidate hostname - invalid', () => {
       expect(authUtils.isValidHostname('github' as Hostname)).toBeFalsy();
-    });
-  });
-
-  describe('isValidClientId', () => {
-    it('should validate client id - valid', () => {
-      expect(authUtils.isValidClientId('1234567890_ASDFGHJKL' as ClientID)).toBeTruthy();
-    });
-
-    it('should validate client id - empty', () => {
-      expect(authUtils.isValidClientId('' as ClientID)).toBeFalsy();
-    });
-
-    it('should validate client id - invalid', () => {
-      expect(authUtils.isValidClientId('1234567890asdfg' as ClientID)).toBeFalsy();
-    });
-  });
-
-  describe('isValidToken', () => {
-    it('should validate token - valid', () => {
-      expect(
-        authUtils.isValidToken('1234567890_asdfghjklPOIUYTREWQ0987654321' as Token),
-      ).toBeTruthy();
-    });
-
-    it('should validate token - empty', () => {
-      expect(authUtils.isValidToken('' as Token)).toBeFalsy();
-    });
-
-    it('should validate token - invalid', () => {
-      expect(authUtils.isValidToken('1234567890asdfg' as Token)).toBeFalsy();
     });
   });
 

--- a/src/renderer/utils/auth/utils.ts
+++ b/src/renderer/utils/auth/utils.ts
@@ -1,27 +1,13 @@
-import { format } from 'date-fns/format';
-import semver from 'semver';
-
-import { APPLICATION } from '../../../shared/constants';
-
 import { Constants } from '../../constants';
 
-import type {
-  Account,
-  AccountUUID,
-  AuthState,
-  ClientID,
-  Forge,
-  Hostname,
-  Link,
-  Token,
-} from '../../types';
+import type { Account, AccountUUID, AuthState, Forge, Hostname, Link, Token } from '../../types';
 import type { AuthMethod } from './types';
 
 import { rendererLogError, rendererLogInfo, rendererLogWarn, toError } from '../core/logger';
 import { getAdapter } from '../forges/registry';
 import { encryptValue } from '../system/comms';
-import { getPlatformFromHostname, resolvePlatform } from './platform';
-import { getRecommendedScopeNames, hasRequiredScopes } from './scopes';
+import { resolvePlatform } from './platform';
+import { hasRequiredScopes } from './scopes';
 
 /**
  * Add or update an account in the auth state.
@@ -33,7 +19,7 @@ import { getRecommendedScopeNames, hasRequiredScopes } from './scopes';
  * @param auth - The current auth state.
  * @param method - The authentication method used.
  * @param token - The plaintext access token to store (will be encrypted).
- * @param hostname - The GitHub hostname for the account.
+ * @param hostname - The forge hostname for the account.
  * @returns The updated auth state.
  */
 export async function addAccount(
@@ -132,126 +118,6 @@ export async function refreshAccount(account: Account): Promise<Account> {
 }
 
 /**
- * Normalize a GitHub Enterprise Server version string to a semver string.
- *
- * Returns `"latest"` when `version` is null/empty (GitHub Cloud or unknown),
- * which is treated as "supports all features" by feature-flag checks.
- *
- * @param version - The raw version string from the `x-github-enterprise-version` header.
- * @returns A normalized semver string, or `"latest"` if unset.
- */
-export function extractHostVersion(version: string | null): string | undefined {
-  if (version) {
-    return semver.valid(semver.coerce(version)) ?? undefined;
-  }
-
-  return 'latest';
-}
-
-/**
- * Build the GitHub authentication base URL for the given hostname.
- *
- * The URL structure differs by platform:
- * - GitHub.com → `https://github.com/`
- * - GitHub Enterprise Server → `https://<hostname>/api/v3/`
- * - GitHub Enterprise Cloud with Data Residency → `https://api.<hostname>/`
- *
- * @param hostname - The GitHub hostname.
- * @returns The base URL to use for OAuth API requests.
- */
-export function getGitHubAuthBaseUrl(hostname: Hostname): URL {
-  const platform = getPlatformFromHostname(hostname);
-  const url = new URL(APPLICATION.GITHUB_BASE_URL);
-
-  switch (platform) {
-    case 'GitHub Enterprise Server':
-      url.hostname = hostname;
-      url.pathname = '/api/v3/';
-      break;
-    case 'GitHub Enterprise Cloud with Data Residency':
-      url.hostname = `api.${hostname}`;
-      url.pathname = '/';
-      break;
-    default:
-      url.pathname = '/';
-      break;
-  }
-
-  return url;
-}
-
-/**
- * Return the GitHub developer settings URL appropriate for the account's auth method.
- *
- * - GitHub App → application connections page
- * - OAuth App → developer settings page
- * - Personal Access Token → tokens settings page
- *
- * @param account - The account whose settings URL to build.
- * @returns The URL to the relevant GitHub developer settings page.
- */
-export function getDeveloperSettingsURL(account: Account): Link {
-  const settingsURL = new URL(`https://${account.hostname}`);
-
-  switch (account.method) {
-    case 'GitHub App':
-      settingsURL.pathname = `/settings/connections/applications/${Constants.OAUTH_DEVICE_FLOW_CLIENT_ID}`;
-      break;
-    case 'OAuth App':
-      settingsURL.pathname = '/settings/developers';
-      break;
-    case 'Personal Access Token':
-      settingsURL.pathname = '/settings/tokens';
-      break;
-    default:
-      settingsURL.pathname = '/settings';
-      break;
-  }
-  return settingsURL.toString() as Link;
-}
-
-/**
- * Build a pre-filled URL for creating a new Personal Access Token.
- *
- * Pre-populates the token description (with app name and current date),
- * the required OAuth scopes, and a 90-day expiry.
- *
- * @param hostname - The GitHub hostname to create the token on.
- * @returns The URL with pre-filled query parameters.
- */
-export function getNewTokenURL(hostname: Hostname): Link {
-  const date = format(new Date(), 'PP p');
-  const newTokenURL = new URL(`https://${hostname}/settings/tokens/new`);
-  newTokenURL.searchParams.append('description', `${APPLICATION.NAME} (Created on ${date})`);
-  newTokenURL.searchParams.append('scopes', getRecommendedScopeNames().join(','));
-  newTokenURL.searchParams.append('default_expires_at', '90'); // 90 days
-
-  return newTokenURL.toString() as Link;
-}
-
-/**
- * Build a pre-filled URL for registering a new OAuth App.
- *
- * Pre-populates the app name (with creation date), homepage URL, and
- * the `gitify://oauth` callback URL.
- *
- * @param hostname - The GitHub hostname to register the app on.
- * @returns The URL with pre-filled query parameters.
- */
-export function getNewOAuthAppURL(hostname: Hostname): Link {
-  const date = format(new Date(), 'PP p');
-  const newOAuthAppURL = new URL(`https://${hostname}/settings/applications/new`);
-  newOAuthAppURL.searchParams.append(
-    'oauth_application[name]',
-    `${APPLICATION.NAME} (Created on ${date})`,
-  );
-  newOAuthAppURL.searchParams.append('oauth_application[url]', 'https://gitify.io');
-  newOAuthAppURL.searchParams.append('oauth_application[callback_url]', 'gitify://oauth');
-
-  return newOAuthAppURL.toString() as Link;
-}
-
-/**
  * Return true if `hostname` is a valid DNS hostname (e.g. `github.com`).
  * Accepts hostnames with 2-6 character TLDs; rejects IP addresses and bare labels.
  *
@@ -260,28 +126,6 @@ export function getNewOAuthAppURL(hostname: Hostname): Link {
  */
 export function isValidHostname(hostname: Hostname) {
   return /^([A-Z0-9]([A-Z0-9-]{0,61}[A-Z0-9])?\.)+[A-Z]{2,6}$/i.test(hostname);
-}
-
-/**
- * Return true if `clientId` matches the expected GitHub OAuth App format
- * (20 alphanumeric/underscore characters).
- *
- * @param clientId - The client ID string to validate.
- * @returns `true` if valid.
- */
-export function isValidClientId(clientId: ClientID) {
-  return /^[A-Z0-9_]{20}$/i.test(clientId);
-}
-
-/**
- * Return true if `token` matches the expected Personal Access Token format
- * (40 alphanumeric/underscore characters).
- *
- * @param token - The token string to validate.
- * @returns `true` if valid.
- */
-export function isValidToken(token: Token) {
-  return /^[A-Z0-9_]{40}$/i.test(token);
 }
 
 /**

--- a/src/renderer/utils/forges/gitea/adapter.test.ts
+++ b/src/renderer/utils/forges/gitea/adapter.test.ts
@@ -15,7 +15,6 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
     it('reports unsupported capabilities', () => {
       expect(giteaAdapter.capabilities.markAsDone(mockGiteaAccount)).toBe(false);
       expect(giteaAdapter.capabilities.unsubscribeThread(mockGiteaAccount)).toBe(false);
-      expect(giteaAdapter.capabilities.answeredDiscussion(mockGiteaAccount)).toBe(false);
     });
 
     it('does not implement detailed enrichment', () => {
@@ -31,12 +30,12 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
       });
     });
 
-    it('builds PAT settings and developer settings URLs from the hostname', () => {
+    it('builds PAT settings and account settings URLs from the hostname', () => {
       expect(giteaAdapter.getPersonalAccessTokenSettingsUrl('gitea.example.com' as Hostname)).toBe(
         'https://gitea.example.com/user/settings/applications',
       );
 
-      expect(giteaAdapter.getDeveloperSettingsUrl(mockGiteaAccount)).toBe(
+      expect(giteaAdapter.getAccountSettingsUrl(mockGiteaAccount)).toBe(
         'https://gitea.example.com/user/settings/applications',
       );
     });

--- a/src/renderer/utils/forges/gitea/adapter.ts
+++ b/src/renderer/utils/forges/gitea/adapter.ts
@@ -29,7 +29,6 @@ const GITEA_DOCS_URL = 'https://docs.gitea.com/development/api-usage' as Link;
 const capabilities: ForgeCapabilities = {
   markAsDone: () => false,
   unsubscribeThread: () => false,
-  answeredDiscussion: () => false,
 };
 
 async function fetchAuthenticatedUser(account: Account): Promise<RefreshAccountData> {
@@ -101,7 +100,7 @@ export const giteaAdapter: ForgeAdapter = {
   validateToken: (token: Token) => /^[a-f0-9]{40}$/.test(token),
   getPersonalAccessTokenSettingsUrl: (hostname: Hostname) =>
     `https://${hostname}/user/settings/applications` as Link,
-  getDeveloperSettingsUrl: (account: Account) =>
+  getAccountSettingsUrl: (account: Account) =>
     `https://${account.hostname}/user/settings/applications` as Link,
   documentationUrl: GITEA_DOCS_URL,
 

--- a/src/renderer/utils/forges/github/adapter.test.ts
+++ b/src/renderer/utils/forges/github/adapter.test.ts
@@ -32,10 +32,18 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
       expect(url).toContain('https://github.com/settings/tokens/new');
     });
 
-    it('routes getDeveloperSettingsUrl through the auth-method helper', () => {
-      expect(githubAdapter.getDeveloperSettingsUrl(mockGitHubCloudAccount)).toBe(
+    it('routes getAccountSettingsUrl through the auth-method helper', () => {
+      expect(githubAdapter.getAccountSettingsUrl(mockGitHubCloudAccount)).toBe(
         'https://github.com/settings/tokens',
       );
+    });
+
+    it('wires the device-flow and OAuth-app methods so the context can dispatch via the adapter', () => {
+      expect(githubAdapter.deviceFlowAuthMethod).toBe('GitHub App');
+      expect(githubAdapter.startDeviceFlow).toBeDefined();
+      expect(githubAdapter.pollDeviceFlow).toBeDefined();
+      expect(githubAdapter.performWebOAuth).toBeDefined();
+      expect(githubAdapter.exchangeAuthCodeForToken).toBeDefined();
     });
   });
 

--- a/src/renderer/utils/forges/github/adapter.ts
+++ b/src/renderer/utils/forges/github/adapter.ts
@@ -5,12 +5,7 @@ import { Constants } from '../../../constants';
 import type { Account, Link, RawGitifyNotification, SettingsState } from '../../../types';
 import type { ForgeAdapter, NotificationDisplayHelpers, RefreshAccountData } from '../types';
 
-import {
-  extractHostVersion,
-  getDeveloperSettingsURL,
-  getNewTokenURL,
-  isValidToken,
-} from '../../auth/utils';
+import { extractHostVersion, getDeveloperSettingsURL, getNewTokenURL, isValidToken } from './auth';
 import { githubCapabilities } from './capabilities';
 import {
   fetchAuthenticatedUserDetails,
@@ -20,6 +15,12 @@ import {
   markNotificationThreadAsRead,
 } from './client';
 import { enrichGitHubNotifications } from './enrich';
+import {
+  exchangeAuthCodeForAccessToken,
+  performGitHubWebOAuth,
+  pollGitHubDeviceFlow,
+  startGitHubDeviceFlow,
+} from './flows';
 import { createNotificationHandler } from './handlers';
 import { clearOctokitClientCacheForAccount, createOctokitClient } from './octokit';
 import { transformNotifications } from './transform';
@@ -96,7 +97,7 @@ export const githubAdapter: ForgeAdapter = {
   defaultHostname: Constants.GITHUB_HOSTNAME,
   validateToken: isValidToken,
   getPersonalAccessTokenSettingsUrl: getNewTokenURL,
-  getDeveloperSettingsUrl: getDeveloperSettingsURL,
+  getAccountSettingsUrl: getDeveloperSettingsURL,
   documentationUrl: Constants.GITHUB_DOCS.PAT_URL as Link,
 
   supportsOAuthScopes: true,
@@ -108,6 +109,7 @@ export const githubAdapter: ForgeAdapter = {
       label: 'GitHub',
       variant: 'primary',
       route: '/login-device-flow',
+      state: { forge: 'github' },
     },
     {
       testId: 'login-pat',
@@ -120,8 +122,15 @@ export const githubAdapter: ForgeAdapter = {
       icon: PersonIcon,
       label: 'OAuth App',
       route: '/login-oauth-app',
+      state: { forge: 'github' },
     },
   ],
+
+  deviceFlowAuthMethod: 'GitHub App',
+  startDeviceFlow: startGitHubDeviceFlow,
+  pollDeviceFlow: pollGitHubDeviceFlow,
+  performWebOAuth: performGitHubWebOAuth,
+  exchangeAuthCodeForToken: exchangeAuthCodeForAccessToken,
 
   hasRequiredScopes: (account) => accountHasScopes(account, 'REQUIRED'),
   hasRecommendedScopes: (account) => accountHasScopes(account, 'RECOMMENDED'),

--- a/src/renderer/utils/forges/github/auth.test.ts
+++ b/src/renderer/utils/forges/github/auth.test.ts
@@ -1,0 +1,164 @@
+import { Constants } from '../../../constants';
+
+import type { Account, ClientID, Hostname, Token } from '../../../types';
+import type { AuthMethod } from '../../auth/types';
+
+import {
+  extractHostVersion,
+  getDeveloperSettingsURL,
+  getGitHubAuthBaseUrl,
+  getNewOAuthAppURL,
+  getNewTokenURL,
+  isValidClientId,
+  isValidToken,
+} from './auth';
+
+describe('renderer/utils/forges/github/auth.ts', () => {
+  beforeEach(() => {
+    Constants.OAUTH_DEVICE_FLOW_CLIENT_ID = 'FAKE_CLIENT_ID_123' as ClientID;
+  });
+
+  describe('extractHostVersion', () => {
+    it('returns "latest" for null/empty version', () => {
+      expect(extractHostVersion(null)).toBe('latest');
+    });
+
+    it('returns undefined for unparseable version strings', () => {
+      expect(extractHostVersion('foo')).toBeUndefined();
+    });
+
+    it('coerces partial versions to semver', () => {
+      expect(extractHostVersion('3')).toBe('3.0.0');
+      expect(extractHostVersion('3.15')).toBe('3.15.0');
+      expect(extractHostVersion('3.15.0')).toBe('3.15.0');
+      expect(extractHostVersion('3.15.0-beta1')).toBe('3.15.0');
+    });
+
+    it('strips the "enterprise-server@" prefix from GHES headers', () => {
+      expect(extractHostVersion('enterprise-server@3')).toBe('3.0.0');
+      expect(extractHostVersion('enterprise-server@3.15')).toBe('3.15.0');
+      expect(extractHostVersion('enterprise-server@3.15.0')).toBe('3.15.0');
+      expect(extractHostVersion('enterprise-server@3.15.0-beta1')).toBe('3.15.0');
+    });
+  });
+
+  describe('getGitHubAuthBaseUrl', () => {
+    it('returns the github.com URL for non-enterprise hosts', () => {
+      expect(getGitHubAuthBaseUrl('github.com' as Hostname).toString()).toBe('https://github.com/');
+    });
+
+    it('returns the api/v3 URL for enterprise server hosts', () => {
+      expect(getGitHubAuthBaseUrl('github.gitify.io' as Hostname).toString()).toBe(
+        'https://github.gitify.io/api/v3/',
+      );
+    });
+
+    it('returns the data-residency URL for ghe.com hosts', () => {
+      expect(getGitHubAuthBaseUrl('gitify.ghe.com' as Hostname).toString()).toBe(
+        'https://api.gitify.ghe.com/',
+      );
+    });
+  });
+
+  describe('getDeveloperSettingsURL', () => {
+    it('returns the GitHub App connections URL', () => {
+      expect(
+        getDeveloperSettingsURL({
+          hostname: 'github.com' as Hostname,
+          method: 'GitHub App',
+        } as Account),
+      ).toBe('https://github.com/settings/connections/applications/FAKE_CLIENT_ID_123');
+    });
+
+    it('returns the OAuth App developer URL', () => {
+      expect(
+        getDeveloperSettingsURL({
+          hostname: 'github.com' as Hostname,
+          method: 'OAuth App',
+        } as Account),
+      ).toBe('https://github.com/settings/developers');
+    });
+
+    it('returns the PAT settings URL', () => {
+      expect(
+        getDeveloperSettingsURL({
+          hostname: 'github.com' as Hostname,
+          method: 'Personal Access Token',
+        } as Account),
+      ).toBe('https://github.com/settings/tokens');
+    });
+
+    it('falls back to the generic settings page for unknown auth methods', () => {
+      expect(
+        getDeveloperSettingsURL({
+          hostname: 'github.com' as Hostname,
+          method: 'unknown' as AuthMethod,
+        } as Account),
+      ).toBe('https://github.com/settings');
+    });
+  });
+
+  describe('getNewTokenURL', () => {
+    it('builds a token-creation URL on github.com', () => {
+      expect(
+        getNewTokenURL('github.com' as Hostname).startsWith(
+          'https://github.com/settings/tokens/new',
+        ),
+      ).toBeTruthy();
+    });
+
+    it('builds a token-creation URL on enterprise hosts', () => {
+      expect(
+        getNewTokenURL('github.gitify.io' as Hostname).startsWith(
+          'https://github.gitify.io/settings/tokens/new',
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('getNewOAuthAppURL', () => {
+    it('builds an OAuth-App-creation URL on github.com', () => {
+      expect(
+        getNewOAuthAppURL('github.com' as Hostname).startsWith(
+          'https://github.com/settings/applications/new',
+        ),
+      ).toBeTruthy();
+    });
+
+    it('builds an OAuth-App-creation URL on enterprise hosts', () => {
+      expect(
+        getNewOAuthAppURL('github.gitify.io' as Hostname).startsWith(
+          'https://github.gitify.io/settings/applications/new',
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('isValidClientId', () => {
+    it('accepts a 20-char alphanumeric/underscore client id', () => {
+      expect(isValidClientId('1234567890_ASDFGHJKL' as ClientID)).toBeTruthy();
+    });
+
+    it('rejects an empty client id', () => {
+      expect(isValidClientId('' as ClientID)).toBeFalsy();
+    });
+
+    it('rejects a client id of the wrong length', () => {
+      expect(isValidClientId('1234567890asdfg' as ClientID)).toBeFalsy();
+    });
+  });
+
+  describe('isValidToken', () => {
+    it('accepts a 40-char alphanumeric/underscore token', () => {
+      expect(isValidToken('1234567890_asdfghjklPOIUYTREWQ0987654321' as Token)).toBeTruthy();
+    });
+
+    it('rejects an empty token', () => {
+      expect(isValidToken('' as Token)).toBeFalsy();
+    });
+
+    it('rejects a token of the wrong length', () => {
+      expect(isValidToken('1234567890asdfg' as Token)).toBeFalsy();
+    });
+  });
+});

--- a/src/renderer/utils/forges/github/auth.ts
+++ b/src/renderer/utils/forges/github/auth.ts
@@ -1,0 +1,147 @@
+import { format } from 'date-fns/format';
+import semver from 'semver';
+
+import { APPLICATION } from '../../../../shared/constants';
+
+import { Constants } from '../../../constants';
+
+import type { Account, ClientID, Hostname, Link, Token } from '../../../types';
+
+import { getPlatformFromHostname } from '../../auth/platform';
+import { getRecommendedScopeNames } from '../../auth/scopes';
+
+/**
+ * Normalize a GitHub Enterprise Server version string to a semver string.
+ *
+ * Returns `"latest"` when `version` is null/empty (GitHub Cloud or unknown),
+ * which is treated as "supports all features" by capability checks.
+ *
+ * @param version - The raw version string from the `x-github-enterprise-version` header.
+ * @returns A normalized semver string, or `"latest"` if unset.
+ */
+export function extractHostVersion(version: string | null): string | undefined {
+  if (version) {
+    return semver.valid(semver.coerce(version)) ?? undefined;
+  }
+
+  return 'latest';
+}
+
+/**
+ * Build the GitHub authentication base URL for the given hostname.
+ *
+ * The URL structure differs by platform:
+ * - GitHub.com → `https://github.com/`
+ * - GitHub Enterprise Server → `https://<hostname>/api/v3/`
+ * - GitHub Enterprise Cloud with Data Residency → `https://api.<hostname>/`
+ *
+ * @param hostname - The GitHub hostname.
+ * @returns The base URL to use for OAuth API requests.
+ */
+export function getGitHubAuthBaseUrl(hostname: Hostname): URL {
+  const platform = getPlatformFromHostname(hostname);
+  const url = new URL(APPLICATION.GITHUB_BASE_URL);
+
+  switch (platform) {
+    case 'GitHub Enterprise Server':
+      url.hostname = hostname;
+      url.pathname = '/api/v3/';
+      break;
+    case 'GitHub Enterprise Cloud with Data Residency':
+      url.hostname = `api.${hostname}`;
+      url.pathname = '/';
+      break;
+    default:
+      url.pathname = '/';
+      break;
+  }
+
+  return url;
+}
+
+/**
+ * Return the GitHub developer settings URL appropriate for the account's auth method.
+ *
+ * - GitHub App → application connections page
+ * - OAuth App → developer settings page
+ * - Personal Access Token → tokens settings page
+ *
+ * @param account - The account whose settings URL to build.
+ * @returns The URL to the relevant GitHub developer settings page.
+ */
+export function getDeveloperSettingsURL(account: Account): Link {
+  const settingsURL = new URL(`https://${account.hostname}`);
+
+  switch (account.method) {
+    case 'GitHub App':
+      settingsURL.pathname = `/settings/connections/applications/${Constants.OAUTH_DEVICE_FLOW_CLIENT_ID}`;
+      break;
+    case 'OAuth App':
+      settingsURL.pathname = '/settings/developers';
+      break;
+    case 'Personal Access Token':
+      settingsURL.pathname = '/settings/tokens';
+      break;
+    default:
+      settingsURL.pathname = '/settings';
+      break;
+  }
+  return settingsURL.toString() as Link;
+}
+
+/**
+ * Build a pre-filled URL for creating a new Personal Access Token.
+ *
+ * Pre-populates the token description (with app name and current date),
+ * the required OAuth scopes, and a 90-day expiry.
+ *
+ * @param hostname - The GitHub hostname to create the token on.
+ * @returns The URL with pre-filled query parameters.
+ */
+export function getNewTokenURL(hostname: Hostname): Link {
+  const date = format(new Date(), 'PP p');
+  const newTokenURL = new URL(`https://${hostname}/settings/tokens/new`);
+  newTokenURL.searchParams.append('description', `${APPLICATION.NAME} (Created on ${date})`);
+  newTokenURL.searchParams.append('scopes', getRecommendedScopeNames().join(','));
+  newTokenURL.searchParams.append('default_expires_at', '90'); // 90 days
+
+  return newTokenURL.toString() as Link;
+}
+
+/**
+ * Build a pre-filled URL for registering a new OAuth App.
+ *
+ * Pre-populates the app name (with creation date), homepage URL, and
+ * the `gitify://oauth` callback URL.
+ *
+ * @param hostname - The GitHub hostname to register the app on.
+ * @returns The URL with pre-filled query parameters.
+ */
+export function getNewOAuthAppURL(hostname: Hostname): Link {
+  const date = format(new Date(), 'PP p');
+  const newOAuthAppURL = new URL(`https://${hostname}/settings/applications/new`);
+  newOAuthAppURL.searchParams.append(
+    'oauth_application[name]',
+    `${APPLICATION.NAME} (Created on ${date})`,
+  );
+  newOAuthAppURL.searchParams.append('oauth_application[url]', 'https://gitify.io');
+  newOAuthAppURL.searchParams.append('oauth_application[callback_url]', 'gitify://oauth');
+
+  return newOAuthAppURL.toString() as Link;
+}
+
+/**
+ * Return true if `clientId` matches the expected GitHub OAuth App format
+ * (20 alphanumeric/underscore characters).
+ */
+export function isValidClientId(clientId: ClientID) {
+  return /^[A-Z0-9_]{20}$/i.test(clientId);
+}
+
+/**
+ * Return true if `token` matches the expected GitHub Personal Access Token
+ * format (40 alphanumeric/underscore characters).
+ */
+export function isValidToken(token: Token) {
+  return /^[A-Z0-9_]{40}$/i.test(token);
+}

--- a/src/renderer/utils/forges/github/capabilities.test.ts
+++ b/src/renderer/utils/forges/github/capabilities.test.ts
@@ -1,0 +1,74 @@
+import {
+  mockGitHubCloudAccount,
+  mockGitHubEnterpriseServerAccount,
+} from '../../../__mocks__/account-mocks';
+
+import { githubCapabilities, supportsAnsweredDiscussion } from './capabilities';
+
+describe('renderer/utils/forges/github/capabilities.ts', () => {
+  describe('markAsDone', () => {
+    it('returns true for GitHub Cloud', () => {
+      expect(githubCapabilities.markAsDone(mockGitHubCloudAccount)).toBe(true);
+    });
+
+    it('returns false for GitHub Enterprise Server < v3.13', () => {
+      expect(
+        githubCapabilities.markAsDone({
+          ...mockGitHubEnterpriseServerAccount,
+          version: '3.12.0',
+        }),
+      ).toBe(false);
+    });
+
+    it('returns true for GitHub Enterprise Server >= v3.13', () => {
+      expect(
+        githubCapabilities.markAsDone({
+          ...mockGitHubEnterpriseServerAccount,
+          version: '3.13.0',
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when the GHES version is unknown', () => {
+      expect(
+        githubCapabilities.markAsDone({
+          ...mockGitHubEnterpriseServerAccount,
+          version: undefined,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('supportsAnsweredDiscussion', () => {
+    it('returns true for GitHub Cloud', () => {
+      expect(supportsAnsweredDiscussion(mockGitHubCloudAccount)).toBe(true);
+    });
+
+    it('returns false for GitHub Enterprise Server < v3.12', () => {
+      expect(
+        supportsAnsweredDiscussion({
+          ...mockGitHubEnterpriseServerAccount,
+          version: '3.11.0',
+        }),
+      ).toBe(false);
+    });
+
+    it('returns true for GitHub Enterprise Server >= v3.12', () => {
+      expect(
+        supportsAnsweredDiscussion({
+          ...mockGitHubEnterpriseServerAccount,
+          version: '3.12.0',
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when the GHES version is unknown', () => {
+      expect(
+        supportsAnsweredDiscussion({
+          ...mockGitHubEnterpriseServerAccount,
+          version: undefined,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/renderer/utils/forges/github/capabilities.ts
+++ b/src/renderer/utils/forges/github/capabilities.ts
@@ -6,7 +6,7 @@ import type { ForgeCapabilities } from '../types';
 import { isEnterpriseServerHost } from '../../auth/platform';
 
 /**
- * GitHub feature capabilities.
+ * GitHub feature capabilities exposed through the forge adapter contract.
  *
  * GitHub Cloud and GitHub Enterprise Cloud with Data Residency support
  * everything; GitHub Enterprise Server gates certain features behind a
@@ -25,13 +25,22 @@ export const githubCapabilities: ForgeCapabilities = {
   unsubscribeThread(): boolean {
     return true;
   },
-  answeredDiscussion(account: Account): boolean {
-    if (!isEnterpriseServerHost(account.hostname)) {
-      return true;
-    }
-    if (account.version) {
-      return semver.gte(account.version, '3.12.0');
-    }
-    return false;
-  },
 };
+
+/**
+ * GitHub-only capability: whether the GraphQL discussion schema exposes the
+ * `isAnswered` field. Lives outside the shared `ForgeCapabilities` because no
+ * other forge has an "answered discussion" concept and the only consumer is
+ * the GitHub GraphQL query construction in `client.ts`.
+ *
+ * GHES exposed `isAnswered` from version 3.12 onwards.
+ */
+export function supportsAnsweredDiscussion(account: Account): boolean {
+  if (!isEnterpriseServerHost(account.hostname)) {
+    return true;
+  }
+  if (account.version) {
+    return semver.gte(account.version, '3.12.0');
+  }
+  return false;
+}

--- a/src/renderer/utils/forges/github/client.ts
+++ b/src/renderer/utils/forges/github/client.ts
@@ -12,7 +12,7 @@ import type {
   MarkNotificationThreadAsReadResponse,
 } from './types';
 
-import { githubCapabilities } from './capabilities';
+import { supportsAnsweredDiscussion } from './capabilities';
 import {
   FetchDiscussionByNumberDocument,
   type FetchDiscussionByNumberQuery,
@@ -204,7 +204,7 @@ export async function fetchDiscussionByNumber(
     firstLabels: Constants.GRAPHQL_ARGS.FIRST_LABELS,
     lastThreadedComments: Constants.GRAPHQL_ARGS.LAST_THREADED_COMMENTS,
     lastReplies: Constants.GRAPHQL_ARGS.LAST_REPLIES,
-    includeIsAnswered: githubCapabilities.answeredDiscussion(notification.account),
+    includeIsAnswered: supportsAnsweredDiscussion(notification.account),
   });
 }
 
@@ -287,7 +287,7 @@ export async function fetchNotificationDetailsForList(
   }
 
   builder.setSharedVariables({
-    includeIsAnswered: githubCapabilities.answeredDiscussion(notifications[0].account),
+    includeIsAnswered: supportsAnsweredDiscussion(notifications[0].account),
     firstClosingIssues: Constants.GRAPHQL_ARGS.FIRST_CLOSING_ISSUES,
     firstLabels: Constants.GRAPHQL_ARGS.FIRST_LABELS,
     lastComments: Constants.GRAPHQL_ARGS.LAST_COMMENTS,

--- a/src/renderer/utils/forges/github/flows.test.ts
+++ b/src/renderer/utils/forges/github/flows.test.ts
@@ -15,15 +15,15 @@ import { RequestError } from '@octokit/request-error';
 
 import type { MockedFunction } from 'vitest';
 
-import { Constants } from '../../constants';
+import { Constants } from '../../../constants';
 
-import type { AuthCode, ClientID, ClientSecret, Hostname } from '../../types';
-import type { DeviceFlowSession, LoginOAuthWebOptions } from './types';
+import type { AuthCode, ClientID, ClientSecret, Hostname } from '../../../types';
+import type { DeviceFlowSession, LoginOAuthWebOptions } from '../../auth/types';
 
-import * as comms from '../../utils/system/comms';
-import * as logger from '../core/logger';
-import * as authUtils from './flows';
-import { getRecommendedScopeNames } from './scopes';
+import { getRecommendedScopeNames } from '../../auth/scopes';
+import * as logger from '../../core/logger';
+import * as comms from '../../system/comms';
+import * as flows from './flows';
 
 const createDeviceCodeMock = createDeviceCode as unknown as MockedFunction<typeof createDeviceCode>;
 
@@ -35,7 +35,7 @@ const exchangeWebFlowCodeMock = exchangeWebFlowCode as unknown as MockedFunction
   typeof exchangeWebFlowCode
 >;
 
-describe('renderer/utils/auth/flows.ts', () => {
+describe('renderer/utils/forges/github/flows.ts', () => {
   vi.spyOn(logger, 'rendererLogInfo').mockImplementation(vi.fn());
   const openExternalLinkSpy = vi.spyOn(comms, 'openExternalLink').mockImplementation(vi.fn());
 
@@ -57,7 +57,7 @@ describe('renderer/utils/auth/flows.ts', () => {
           },
         } as unknown as Awaited<ReturnType<typeof createDeviceCode>>);
 
-        const session = await authUtils.startGitHubDeviceFlow();
+        const session = await flows.startGitHubDeviceFlow();
 
         expect(createDeviceCodeMock).toHaveBeenCalledWith({
           clientType: 'oauth-app',
@@ -90,7 +90,7 @@ describe('renderer/utils/auth/flows.ts', () => {
           authentication: { token: 'device-token-xyz' },
         } as unknown as Awaited<ReturnType<typeof exchangeDeviceCode>>);
 
-        const token = await authUtils.pollGitHubDeviceFlow(baseSession as DeviceFlowSession);
+        const token = await flows.pollGitHubDeviceFlow(baseSession as DeviceFlowSession);
 
         expect(exchangeDeviceCodeMock).toHaveBeenCalledWith({
           clientType: 'oauth-app',
@@ -108,7 +108,7 @@ describe('renderer/utils/auth/flows.ts', () => {
 
         exchangeDeviceCodeMock.mockRejectedValueOnce(pendingErr);
 
-        const token = await authUtils.pollGitHubDeviceFlow(baseSession as DeviceFlowSession);
+        const token = await flows.pollGitHubDeviceFlow(baseSession as DeviceFlowSession);
 
         expect(token).toBeNull();
       });
@@ -119,7 +119,7 @@ describe('renderer/utils/auth/flows.ts', () => {
         exchangeDeviceCodeMock.mockRejectedValueOnce(otherErr);
 
         await expect(
-          async () => await authUtils.pollGitHubDeviceFlow(baseSession as DeviceFlowSession),
+          async () => await flows.pollGitHubDeviceFlow(baseSession as DeviceFlowSession),
         ).rejects.toThrow('boom');
       });
     });
@@ -137,7 +137,7 @@ describe('renderer/utils/auth/flows.ts', () => {
         callback('gitify://oauth?code=123-456');
       });
 
-      const res = await authUtils.performGitHubWebOAuth({
+      const res = await flows.performGitHubWebOAuth({
         clientId: 'BYO_CLIENT_ID' as ClientID,
         clientSecret: 'BYO_CLIENT_SECRET' as ClientSecret,
         hostname: 'my.git.com' as Hostname,
@@ -164,9 +164,7 @@ describe('renderer/utils/auth/flows.ts', () => {
         );
       });
 
-      await expect(
-        async () => await authUtils.performGitHubWebOAuth(webAuthOptions),
-      ).rejects.toEqual(
+      await expect(async () => await flows.performGitHubWebOAuth(webAuthOptions)).rejects.toEqual(
         new Error(
           "Oops! Something went wrong and we couldn't log you in using GitHub. Please try again. Reason: The redirect_uri is missing or invalid. Docs: https://docs.github.com/en/developers/apps/troubleshooting-oauth-errors",
         ),
@@ -193,7 +191,7 @@ describe('renderer/utils/auth/flows.ts', () => {
           },
         } as unknown as Awaited<ReturnType<typeof exchangeWebFlowCode>>);
 
-        const res = await authUtils.exchangeAuthCodeForAccessToken(authCode, {
+        const res = await flows.exchangeAuthCodeForAccessToken(authCode, {
           ...webAuthOptions,
         });
 
@@ -210,7 +208,7 @@ describe('renderer/utils/auth/flows.ts', () => {
       it('should throw when client secret is missing', async () => {
         await expect(
           async () =>
-            await authUtils.exchangeAuthCodeForAccessToken(authCode, {
+            await flows.exchangeAuthCodeForAccessToken(authCode, {
               ...webAuthOptions,
               clientSecret: undefined as unknown as ClientSecret,
             }),

--- a/src/renderer/utils/forges/github/flows.ts
+++ b/src/renderer/utils/forges/github/flows.ts
@@ -7,20 +7,21 @@ import {
 import { request } from '@octokit/request';
 import { RequestError } from '@octokit/request-error';
 
-import { Constants } from '../../constants';
+import { Constants } from '../../../constants';
 
-import type { AuthCode, Hostname, Link, Token } from '../../types';
-import type {
-  AuthResponse,
-  DeviceFlowErrorResponse,
-  DeviceFlowSession,
-  LoginOAuthWebOptions,
-} from './types';
+import type { AuthCode, Hostname, Link, Token } from '../../../types';
+import type { AuthResponse, DeviceFlowSession, LoginOAuthWebOptions } from '../../auth/types';
 
-import { rendererLogError, rendererLogInfo, toError } from '../core/logger';
-import { openExternalLink } from '../system/comms';
-import { getRecommendedScopeNames } from './scopes';
-import { getGitHubAuthBaseUrl } from './utils';
+import { getRecommendedScopeNames } from '../../auth/scopes';
+import { rendererLogError, rendererLogInfo, toError } from '../../core/logger';
+import { openExternalLink } from '../../system/comms';
+import { getGitHubAuthBaseUrl } from './auth';
+
+type DeviceFlowErrorResponse = {
+  error: string;
+  error_description: string;
+  error_uri: string;
+};
 
 /**
  * Initiate a GitHub OAuth Web Flow (OAuth App) authentication.

--- a/src/renderer/utils/forges/types.ts
+++ b/src/renderer/utils/forges/types.ts
@@ -4,6 +4,7 @@ import type { OcticonProps } from '@primer/octicons-react';
 
 import type {
   Account,
+  AuthCode,
   Forge,
   Hostname,
   IconColor,
@@ -13,6 +14,12 @@ import type {
   Token,
   UserType,
 } from '../../types';
+import type {
+  AuthMethod,
+  AuthResponse,
+  DeviceFlowSession,
+  LoginOAuthWebOptions,
+} from '../auth/types';
 
 /**
  * Capability flags exposed by a forge adapter.
@@ -25,8 +32,6 @@ export interface ForgeCapabilities {
   markAsDone(account: Account): boolean;
   /** Whether the forge supports ignoring a thread's subscription (unsubscribe). */
   unsubscribeThread(account: Account): boolean;
-  /** Whether the forge surfaces an "answered" state for discussions. */
-  answeredDiscussion(account: Account): boolean;
 }
 
 /**
@@ -161,12 +166,36 @@ export interface ForgeAdapter {
   validateToken(token: Token): boolean;
   /** URL to manage/create a personal access token on the forge. */
   getPersonalAccessTokenSettingsUrl(hostname: Hostname): Link;
-  /** URL to the developer settings page for the account's auth method. */
-  getDeveloperSettingsUrl(account: Account): Link;
+  /**
+   * URL to the forge page where the user manages this account's auth method
+   * (e.g. tokens, OAuth apps, GitHub Apps). Forges may key this off the
+   * account's auth method.
+   */
+  getAccountSettingsUrl(account: Account): Link;
   /** Login entries rendered in the Login route. */
   loginMethods: ReadonlyArray<LoginMethodDescriptor>;
   /** External documentation link shown in the PAT login route. */
   documentationUrl: Link;
+
+  // --- Auth flows ---
+  // Optional because not every forge supports every flow. Gitea today is
+  // PAT-only and implements none of these. The orchestrator gates UI on the
+  // presence of these methods (and on `loginMethods` entries pointing at
+  // `/login-device-flow` or `/login-oauth-app`).
+
+  /**
+   * The `AuthMethod` string recorded on the account when a successful device
+   * flow login completes. Required when `startDeviceFlow` is provided.
+   */
+  deviceFlowAuthMethod?: AuthMethod;
+  /** Start an OAuth device-flow authorization session. */
+  startDeviceFlow?(hostname?: Hostname, scopes?: string[]): Promise<DeviceFlowSession>;
+  /** Poll for completion of a device-flow session; resolves to a token when granted. */
+  pollDeviceFlow?(session: DeviceFlowSession): Promise<Token | null>;
+  /** Initiate a custom-OAuth-app web flow. */
+  performWebOAuth?(options: LoginOAuthWebOptions): Promise<AuthResponse>;
+  /** Exchange an OAuth web-flow authorization code for an access token. */
+  exchangeAuthCodeForToken?(authCode: AuthCode, options: LoginOAuthWebOptions): Promise<Token>;
 
   // --- OAuth scopes ---
   // Forges without an OAuth scope concept (e.g. Gitea) report `true` for

--- a/src/renderer/utils/system/links.test.ts
+++ b/src/renderer/utils/system/links.test.ts
@@ -6,12 +6,12 @@ import { Constants } from '../../constants';
 
 import type { GitifyRepository, Link } from '../../types';
 
-import * as authUtils from '../auth/utils';
+import * as githubAuth from '../forges/github/auth';
 import * as url from '../notifications/url';
 import * as comms from './comms';
 import {
   openAccountProfile,
-  openDeveloperSettings,
+  openAccountSettings,
   openGitHubIssues,
   openGitHubNotifications,
   openGitHubParticipatingDocs,
@@ -72,11 +72,11 @@ describe('renderer/utils/links.ts', () => {
     expect(openExternalLinkSpy).toHaveBeenCalledWith('https://github.com');
   });
 
-  it('openDeveloperSettings', () => {
+  it('openAccountSettings', () => {
     const mockSettingsURL = 'https://github.com/settings/tokens' as Link;
-    vi.spyOn(authUtils, 'getDeveloperSettingsURL').mockReturnValue(mockSettingsURL);
+    vi.spyOn(githubAuth, 'getDeveloperSettingsURL').mockReturnValue(mockSettingsURL);
 
-    openDeveloperSettings(mockGitHubCloudAccount);
+    openAccountSettings(mockGitHubCloudAccount);
 
     expect(openExternalLinkSpy).toHaveBeenCalledWith(mockSettingsURL);
   });

--- a/src/renderer/utils/system/links.ts
+++ b/src/renderer/utils/system/links.ts
@@ -53,8 +53,8 @@ export function openHost(hostname: Hostname) {
   openExternalLink(`https://${hostname}` as Link);
 }
 
-export function openDeveloperSettings(account: Account) {
-  const url = getAdapter(account).getDeveloperSettingsUrl(account);
+export function openAccountSettings(account: Account) {
+  const url = getAdapter(account).getAccountSettingsUrl(account);
   openExternalLink(url);
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     pool: 'vmThreads',
+    isolate: false,
     clearMocks: true,
     // Pre-bundle @primer/react rather than re-transforming the raw package on every thread load.
     // See https://vitest.dev/guide/profiling-test-performance.html#use-the-dependency-optimizer


### PR DESCRIPTION
## Summary

Three follow-up cleanups on top of the forge adapter interface, each as its own commit:

- **Move GitHub-specific auth helpers** (`extractHostVersion`, `getGitHubAuthBaseUrl`, `getDeveloperSettingsURL`, `getNewTokenURL`, `getNewOAuthAppURL`, `isValidToken`, `isValidClientId`) out of shared `auth/utils.ts` and into a new `forges/github/auth.ts`. Tests followed.
- **Drop the `answeredDiscussion` capability** from the shared `ForgeCapabilities` contract. It only ever drove GitHub GraphQL query construction, so it now lives privately as `supportsAnsweredDiscussion` inside `forges/github/capabilities.ts`. `isAnsweredDiscussionFeatureSupported` removed from `api/features.ts` along with the Gitea stub.
- **Rename `getDeveloperSettingsUrl` → `getAccountSettingsUrl`** on the `ForgeAdapter` interface (and `openDeveloperSettings` → `openAccountSettings` on the consumer). The "developer settings" wording was GitHub-flavoured; the new name reads cleanly for any forge.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec biome check` on touched files — only pre-existing warnings
- [x] `pnpm exec vitest --run` — 1040/1040 pass

Closes #2873