### PR TITLE
feat(settings): add "Keep window open when it loses focus" option

### DIFF
--- a/src/main/handlers/system.test.ts
+++ b/src/main/handlers/system.test.ts
@@ -3,7 +3,12 @@ import type { Menubar } from 'menubar';
 
 import { EVENTS } from '../../shared/events';
 
+import { applyKeepWindowOnBlur } from '../lifecycle/window';
 import { registerSystemHandlers } from './system';
+
+vi.mock('../lifecycle/window', () => ({
+  applyKeepWindowOnBlur: vi.fn(),
+}));
 
 const onMock = vi.fn();
 const handleMock = vi.fn();
@@ -66,7 +71,21 @@ describe('main/handlers/system.ts', () => {
 
       expect(onEvents).toContain(EVENTS.OPEN_EXTERNAL);
       expect(onEvents).toContain(EVENTS.UPDATE_AUTO_LAUNCH);
+      expect(onEvents).toContain(EVENTS.UPDATE_KEEP_WINDOW_ON_BLUR);
       expect(handleEvents).toContain(EVENTS.UPDATE_KEYBOARD_SHORTCUT);
+    });
+  });
+
+  describe('UPDATE_KEEP_WINDOW_ON_BLUR', () => {
+    it('forwards the value to applyKeepWindowOnBlur', () => {
+      registerSystemHandlers(menubar);
+
+      const handler = onMock.mock.calls.find(
+        (call: unknown[]) => call[0] === EVENTS.UPDATE_KEEP_WINDOW_ON_BLUR,
+      )?.[1];
+      handler?.({}, true);
+
+      expect(applyKeepWindowOnBlur).toHaveBeenCalledWith(menubar, true);
     });
   });
 

--- a/src/main/handlers/system.ts
+++ b/src/main/handlers/system.ts
@@ -4,6 +4,7 @@ import type { Menubar } from 'menubar';
 import { EVENTS } from '../../shared/events';
 
 import { handleMainEvent, onMainEvent } from '../events';
+import { applyKeepWindowOnBlur } from '../lifecycle/window';
 
 /**
  * Register IPC handlers for OS-level system operations.
@@ -68,5 +69,12 @@ export function registerSystemHandlers(mb: Menubar): void {
    */
   onMainEvent(EVENTS.UPDATE_AUTO_LAUNCH, (_, settings) => {
     app.setLoginItemSettings(settings);
+  });
+
+  /**
+   * Toggle whether the window stays open when it loses focus.
+   */
+  onMainEvent(EVENTS.UPDATE_KEEP_WINDOW_ON_BLUR, (_, value: boolean) => {
+    applyKeepWindowOnBlur(mb, value);
   });
 }

--- a/src/main/lifecycle/window.test.ts
+++ b/src/main/lifecycle/window.test.ts
@@ -1,7 +1,11 @@
 import type { Menubar } from 'menubar';
 
 import type MenuBuilder from '../menu';
-import { __resetWindowLifecycleForTests, configureWindowEvents } from './window';
+import {
+  __resetWindowLifecycleForTests,
+  configureWindowEvents,
+  applyKeepWindowOnBlur,
+} from './window';
 
 const appOnMock = vi.fn();
 const appQuitMock = vi.fn();
@@ -41,6 +45,12 @@ const findWindowHandler = (
   const onMock = menubar.window?.on as ReturnType<typeof vi.fn>;
   const call = onMock.mock.calls.find(([name]) => name === eventName);
   return call?.[1] as ((event: { preventDefault: () => void }) => void) | undefined;
+};
+
+const findWebContentsHandler = (menubar: Menubar, eventName: string): (() => void) | undefined => {
+  const onMock = menubar.window?.webContents.on as ReturnType<typeof vi.fn>;
+  const call = onMock.mock.calls.find(([name]) => name === eventName);
+  return call?.[1] as (() => void) | undefined;
 };
 
 const flushDeferred = () => new Promise((resolve) => setImmediate(resolve));
@@ -186,6 +196,42 @@ describe('main/lifecycle/window.ts', () => {
 
       expect(event.preventDefault).not.toHaveBeenCalled();
       expect(menubar.window?.hide).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('applyKeepWindowOnBlur', () => {
+    it('forwards the value to the underlying window', () => {
+      applyKeepWindowOnBlur(menubar, true);
+
+      expect(menubar.window?.setAlwaysOnTop).toHaveBeenCalledWith(true);
+    });
+
+    it('skips the call when the window is destroyed', () => {
+      // oxlint-disable-next-line no-unsafe-optional-chaining -- window is guaranteed defined in this test
+      (menubar.window?.isDestroyed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      applyKeepWindowOnBlur(menubar, true);
+
+      expect(menubar.window?.setAlwaysOnTop).not.toHaveBeenCalled();
+    });
+
+    it('is restored after DevTools closes', () => {
+      configureWindowEvents(menubar, menuBuilder);
+      applyKeepWindowOnBlur(menubar, true);
+      // oxlint-disable-next-line no-unsafe-optional-chaining -- window is guaranteed defined in this test
+      (menubar.window?.setAlwaysOnTop as ReturnType<typeof vi.fn>).mockClear();
+
+      findWebContentsHandler(menubar, 'devtools-closed')?.();
+
+      expect(menubar.window?.setAlwaysOnTop).toHaveBeenCalledWith(true);
+    });
+
+    it('is cleared after DevTools closes when the user did not opt in', () => {
+      configureWindowEvents(menubar, menuBuilder);
+
+      findWebContentsHandler(menubar, 'devtools-closed')?.();
+
+      expect(menubar.window?.setAlwaysOnTop).toHaveBeenCalledWith(false);
     });
   });
 

--- a/src/main/lifecycle/window.ts
+++ b/src/main/lifecycle/window.ts
@@ -8,6 +8,7 @@ import { WindowConfig } from '../config';
 import type MenuBuilder from '../menu';
 
 let isQuitting = false;
+let keepWindowOnBlur = false;
 
 /**
  * Reset module-level lifecycle flags. Module-level state is unavoidable
@@ -18,6 +19,22 @@ let isQuitting = false;
  */
 export function __resetWindowLifecycleForTests(): void {
   isQuitting = false;
+  keepWindowOnBlur = false;
+}
+
+/**
+ * Apply the user's "keep window open when it loses focus" preference.
+ *
+ * Implemented by toggling the window's `alwaysOnTop` flag, which the
+ * `menubar` library checks to short-circuit its blur-driven hide. The
+ * value is also remembered so the `devtools-closed` handler can restore
+ * it after DevTools temporarily forces it on.
+ */
+export function applyKeepWindowOnBlur(mb: Menubar, value: boolean): void {
+  keepWindowOnBlur = value;
+  if (mb.window && !mb.window.isDestroyed()) {
+    mb.window.setAlwaysOnTop(value);
+  }
 }
 
 /**
@@ -147,6 +164,10 @@ export function configureWindowEvents(mb: Menubar, menuBuilder: MenuBuilder): vo
 
   /**
    * When DevTools is closed, restore the window to its original size and position it centered on the tray icon.
+   *
+   * `devtools-opened` forces `alwaysOnTop` true for usability while
+   * debugging; restore it to the user's preference here so DevTools
+   * doesn't leave the flag stuck on.
    */
   mb.window.webContents.on('devtools-closed', () => {
     if (!mb.window) {
@@ -157,5 +178,6 @@ export function configureWindowEvents(mb: Menubar, menuBuilder: MenuBuilder): vo
     mb.window.setSize(WindowConfig.width!, WindowConfig.height!);
     mb.positioner.move('trayCenter', trayBounds);
     mb.window.resizable = false;
+    mb.window.setAlwaysOnTop(keepWindowOnBlur);
   });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -54,6 +54,16 @@ export const api = {
     }),
 
   /**
+   * Enable or disable keeping the window open when it loses focus.
+   *
+   * Implemented by toggling the window's `alwaysOnTop` flag, which the
+   * `menubar` library uses to short-circuit its blur-driven hide.
+   *
+   * @param value - `true` to keep the window open on blur, `false` to hide.
+   */
+  setKeepWindowOnBlur: (value: boolean) => sendMainEvent(EVENTS.UPDATE_KEEP_WINDOW_ON_BLUR, value),
+
+  /**
    * Apply the global keyboard shortcut for toggling the app window visibility.
    *
    * @param payload - Whether the shortcut is enabled and the Electron accelerator string.

--- a/src/renderer/__helpers__/vitest.setup.ts
+++ b/src/renderer/__helpers__/vitest.setup.ts
@@ -59,6 +59,7 @@ window.gitify = {
   onAuthCallback: vi.fn(),
   onResetApp: vi.fn(),
   setAutoLaunch: vi.fn(),
+  setKeepWindowOnBlur: vi.fn(),
   applyKeyboardShortcut: vi.fn().mockResolvedValue({ success: true }),
   raiseNativeNotification: vi.fn(),
 };

--- a/src/renderer/__mocks__/state-mocks.ts
+++ b/src/renderer/__mocks__/state-mocks.ts
@@ -62,6 +62,7 @@ const mockSystemSettings: SystemSettingsState = {
   playSound: true,
   notificationVolume: 20 as Percentage,
   openAtStartup: false,
+  keepWindowOnBlur: false,
 };
 
 export const mockSettings: SettingsState = {

--- a/src/renderer/components/settings/SystemSettings.test.tsx
+++ b/src/renderer/components/settings/SystemSettings.test.tsx
@@ -255,4 +255,17 @@ describe('renderer/components/settings/SystemSettings.tsx', () => {
     expect(updateSettingMock).toHaveBeenCalledTimes(1);
     expect(updateSettingMock).toHaveBeenCalledWith('openAtStartup', true);
   });
+
+  it('should toggle the keepWindowOnBlur checkbox', async () => {
+    await act(async () => {
+      renderWithProviders(<SystemSettings />, {
+        updateSetting: updateSettingMock,
+      });
+    });
+
+    await userEvent.click(screen.getByTestId('checkbox-keepWindowOnBlur'));
+
+    expect(updateSettingMock).toHaveBeenCalledTimes(1);
+    expect(updateSettingMock).toHaveBeenCalledWith('keepWindowOnBlur', true);
+  });
 });

--- a/src/renderer/components/settings/SystemSettings.tsx
+++ b/src/renderer/components/settings/SystemSettings.tsx
@@ -297,15 +297,6 @@ export const SystemSettings: FC = () => {
         </Stack>
 
         <Checkbox
-          checked={settings.openAtStartup}
-          label="Open at startup"
-          name="openAtStartup"
-          onChange={() => updateSetting('openAtStartup', !settings.openAtStartup)}
-          tooltip={<Text>Launch {APPLICATION.NAME} automatically at startup.</Text>}
-          visible={!window.gitify.platform.isLinux()}
-        />
-
-        <Checkbox
           checked={settings.keepWindowOnBlur}
           label="Keep window open when it loses focus"
           name="keepWindowOnBlur"
@@ -316,6 +307,15 @@ export const SystemSettings: FC = () => {
               it.
             </Text>
           }
+        />
+
+        <Checkbox
+          checked={settings.openAtStartup}
+          label="Open at startup"
+          name="openAtStartup"
+          onChange={() => updateSetting('openAtStartup', !settings.openAtStartup)}
+          tooltip={<Text>Launch {APPLICATION.NAME} automatically at startup.</Text>}
+          visible={!window.gitify.platform.isLinux()}
         />
       </Stack>
     </fieldset>

--- a/src/renderer/components/settings/SystemSettings.tsx
+++ b/src/renderer/components/settings/SystemSettings.tsx
@@ -304,6 +304,19 @@ export const SystemSettings: FC = () => {
           tooltip={<Text>Launch {APPLICATION.NAME} automatically at startup.</Text>}
           visible={!window.gitify.platform.isLinux()}
         />
+
+        <Checkbox
+          checked={settings.keepWindowOnBlur}
+          label="Keep window open when it loses focus"
+          name="keepWindowOnBlur"
+          onChange={() => updateSetting('keepWindowOnBlur', !settings.keepWindowOnBlur)}
+          tooltip={
+            <Text>
+              Prevent the {APPLICATION.NAME} window from automatically hiding when you click outside
+              it.
+            </Text>
+          }
+        />
       </Stack>
     </fieldset>
   );

--- a/src/renderer/context/App.tsx
+++ b/src/renderer/context/App.tsx
@@ -58,6 +58,7 @@ import {
   decryptValue,
   encryptValue,
   setAutoLaunch,
+  setKeepWindowOnBlur,
   setUseAlternateIdleIcon,
   setUseUnreadActiveIcon,
 } from '../utils/system/comms';
@@ -369,6 +370,10 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     setAutoLaunch(settings.openAtStartup);
   }, [settings.openAtStartup]);
+
+  useEffect(() => {
+    setKeepWindowOnBlur(settings.keepWindowOnBlur);
+  }, [settings.keepWindowOnBlur]);
 
   useEffect(() => {
     window.gitify.onResetApp(() => {

--- a/src/renderer/context/defaults.ts
+++ b/src/renderer/context/defaults.ts
@@ -56,6 +56,7 @@ const defaultSystemSettings: SystemSettingsState = {
   playSound: true,
   notificationVolume: 20 as Percentage,
   openAtStartup: false,
+  keepWindowOnBlur: false,
 };
 
 export const defaultSettings: SettingsState = {

--- a/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
@@ -2138,6 +2138,55 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
               </svg>
             </button>
           </div>
+          <div
+            class="text-sm prc-Stack-Stack-UQ9k6"
+            data-align="center"
+            data-direction="horizontal"
+            data-gap="condensed"
+            data-justify="start"
+            data-padding="none"
+            data-wrap="nowrap"
+          >
+            <input
+              class="size-4 rounded-sm cursor-pointer"
+              data-testid="checkbox-keepWindowOnBlur"
+              id="keepWindowOnBlur"
+              type="checkbox"
+            />
+            <label
+              class="font-medium text-gitify-font cursor-pointer"
+              for="keepWindowOnBlur"
+            >
+              Keep window open when it loses focus
+            </label>
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              aria-label="tooltip-keepWindowOnBlur"
+              data-testid="tooltip-icon-tooltip-keepWindowOnBlur"
+              id="tooltip-keepWindowOnBlur"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="octicon octicon-question text-gitify-tooltip-icon"
+                data-component="Octicon"
+                display="inline-block"
+                fill="currentColor"
+                focusable="false"
+                height="16"
+                overflow="visible"
+                style="vertical-align: text-bottom;"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <path
+                  d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.92 6.085h.001a.749.749 0 1 1-1.342-.67c.169-.339.436-.701.849-.977C6.845 4.16 7.369 4 8 4a2.756 2.756 0 0 1 1.637.525c.503.377.863.965.863 1.725 0 .448-.115.83-.329 1.15-.205.307-.47.513-.692.662-.109.072-.22.138-.313.195l-.006.004a6.24 6.24 0 0 0-.26.16.952.952 0 0 0-.276.245.75.75 0 0 1-1.248-.832c.184-.264.42-.489.692-.661.103-.067.207-.132.313-.195l.007-.004c.1-.061.182-.11.258-.161a.969.969 0 0 0 .277-.245C8.96 6.514 9 6.427 9 6.25a.612.612 0 0 0-.262-.525A1.27 1.27 0 0 0 8 5.5c-.369 0-.595.09-.74.187a1.01 1.01 0 0 0-.34.398ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </fieldset>
       <div
@@ -2194,7 +2243,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
         data-wrap="nowrap"
       >
         <button
-          aria-describedby="_r_1p_"
+          aria-describedby="_r_1r_"
           class="prc-Button-ButtonBase-9n-Xk"
           data-component="Button"
           data-loading="false"
@@ -2224,7 +2273,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           class="prc-TooltipV2-Tooltip-tLeuB"
           data-component="Tooltip"
           data-direction="ne"
-          id="_r_1p_"
+          id="_r_1r_"
           popover="auto"
           role="tooltip"
         >
@@ -2241,7 +2290,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
         data-wrap="nowrap"
       >
         <button
-          aria-describedby="_r_1r_"
+          aria-describedby="_r_1t_"
           aria-label="Accounts"
           class="prc-Button-ButtonBase-9n-Xk prc-Button-IconButton-fyge7"
           data-component="IconButton"
@@ -2279,7 +2328,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           role="tooltip"
         >
           <span
-            id="_r_1r_"
+            id="_r_1t_"
           >
             Accounts
             <span
@@ -2319,7 +2368,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           </span>
         </span>
         <button
-          aria-describedby="_r_1t_"
+          aria-describedby="_r_1v_"
           aria-label="Quit Gitify"
           class="prc-Button-ButtonBase-9n-Xk prc-Button-IconButton-fyge7"
           data-component="IconButton"
@@ -2357,7 +2406,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           role="tooltip"
         >
           <span
-            id="_r_1t_"
+            id="_r_1v_"
           >
             Quit Gitify
             <span

--- a/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
@@ -2100,22 +2100,22 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           >
             <input
               class="size-4 rounded-sm cursor-pointer"
-              data-testid="checkbox-openAtStartup"
-              id="openAtStartup"
+              data-testid="checkbox-keepWindowOnBlur"
+              id="keepWindowOnBlur"
               type="checkbox"
             />
             <label
               class="font-medium text-gitify-font cursor-pointer"
-              for="openAtStartup"
+              for="keepWindowOnBlur"
             >
-              Open at startup
+              Keep window open when it loses focus
             </label>
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              aria-label="tooltip-openAtStartup"
-              data-testid="tooltip-icon-tooltip-openAtStartup"
-              id="tooltip-openAtStartup"
+              aria-label="tooltip-keepWindowOnBlur"
+              data-testid="tooltip-icon-tooltip-keepWindowOnBlur"
+              id="tooltip-keepWindowOnBlur"
               tabindex="0"
               type="button"
             >
@@ -2149,22 +2149,22 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
           >
             <input
               class="size-4 rounded-sm cursor-pointer"
-              data-testid="checkbox-keepWindowOnBlur"
-              id="keepWindowOnBlur"
+              data-testid="checkbox-openAtStartup"
+              id="openAtStartup"
               type="checkbox"
             />
             <label
               class="font-medium text-gitify-font cursor-pointer"
-              for="keepWindowOnBlur"
+              for="openAtStartup"
             >
-              Keep window open when it loses focus
+              Open at startup
             </label>
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              aria-label="tooltip-keepWindowOnBlur"
-              data-testid="tooltip-icon-tooltip-keepWindowOnBlur"
-              id="tooltip-keepWindowOnBlur"
+              aria-label="tooltip-openAtStartup"
+              data-testid="tooltip-icon-tooltip-openAtStartup"
+              id="tooltip-openAtStartup"
               tabindex="0"
               type="button"
             >

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -143,6 +143,7 @@ export interface SystemSettingsState {
   playSound: boolean;
   notificationVolume: Percentage;
   openAtStartup: boolean;
+  keepWindowOnBlur: boolean;
 }
 
 export interface AuthState {

--- a/src/renderer/utils/system/comms.test.ts
+++ b/src/renderer/utils/system/comms.test.ts
@@ -13,6 +13,7 @@ import {
   openExternalLink,
   quitApp,
   setAutoLaunch,
+  setKeepWindowOnBlur,
   setUseAlternateIdleIcon,
   showWindow,
   updateTrayColor,
@@ -119,6 +120,13 @@ describe('renderer/utils/comms.ts', () => {
 
       expect(window.gitify.tray.useAlternateIdleIcon).toHaveBeenCalledTimes(1);
       expect(window.gitify.tray.useAlternateIdleIcon).toHaveBeenCalledWith(false);
+    });
+
+    it('sets keep window on blur', () => {
+      setKeepWindowOnBlur(true);
+
+      expect(window.gitify.setKeepWindowOnBlur).toHaveBeenCalledTimes(1);
+      expect(window.gitify.setKeepWindowOnBlur).toHaveBeenCalledWith(true);
     });
 
     it('applies keyboard shortcut', async () => {

--- a/src/renderer/utils/system/comms.ts
+++ b/src/renderer/utils/system/comms.ts
@@ -87,6 +87,15 @@ export function setAutoLaunch(value: boolean): void {
 }
 
 /**
+ * Enables or disables keeping the window open when it loses focus.
+ *
+ * @param value - `true` to keep the window open on blur, `false` to hide.
+ */
+export function setKeepWindowOnBlur(value: boolean): void {
+  window.gitify.setKeepWindowOnBlur(value);
+}
+
+/**
  * Switch the tray icon to an alternate idle icon variant.
  *
  * @param value - `true` to use the alternate idle icon, `false` for the default.

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -16,6 +16,7 @@ export const EVENTS = {
   USE_UNREAD_ACTIVE_ICON: `${P}use-unread-active-icon`,
   UPDATE_KEYBOARD_SHORTCUT: `${P}update-keyboard-shortcut`,
   UPDATE_AUTO_LAUNCH: `${P}update-auto-launch`,
+  UPDATE_KEEP_WINDOW_ON_BLUR: `${P}update-keep-window-on-blur`,
   SAFE_STORAGE_ENCRYPT: `${P}safe-storage-encrypt`,
   SAFE_STORAGE_DECRYPT: `${P}safe-storage-decrypt`,
   NOTIFICATION_SOUND_PATH: `${P}notification-sound-path`,
@@ -94,6 +95,10 @@ export type EventContracts = AssertEventCoverage<{
     response: IKeyboardShortcutResult;
   };
   [EVENTS.UPDATE_AUTO_LAUNCH]: { request: IAutoLaunch; response: undefined };
+  [EVENTS.UPDATE_KEEP_WINDOW_ON_BLUR]: {
+    request: boolean;
+    response: undefined;
+  };
   [EVENTS.SAFE_STORAGE_ENCRYPT]: { request: string; response: string };
   [EVENTS.SAFE_STORAGE_DECRYPT]: {
     request: string;


### PR DESCRIPTION
## Summary

Adds an opt-in **"Keep window open when it loses focus"** checkbox to **System** settings (default **off**). When enabled, the Gitify popup stays visible after focus moves to another window — useful when triaging notifications side-by-side with the browser, an editor, or a chat client.

## Why

By default, Electron menubar apps hide the popup as soon as it loses focus (the `menubar` library's blur-driven hide). That matches the glance-and-go menubar convention but actively gets in the way of side-by-side workflows: read a PR in the browser while keeping the notification list visible, drag-and-drop URLs into another tool, etc. On tiling WMs (Hyprland, i3, Sway) where there's no fixed "menubar" zone, the convention itself feels out of place.

The setting is **off by default**, preserving existing behavior.

## Where it lives

At the bottom of `Settings → System`, after the existing checkboxes. One-line tooltip explains the behavior.

## Implementation notes for reviewers

1. **The mechanism is purely JS-level.** `menubar`'s blur listener short-circuits its own hide when the underlying `BrowserWindow.isAlwaysOnTop()` returns true (`node_modules/menubar/lib/Menubar.js:343-353`). We toggle that flag from the renderer-driven setting via a new IPC event (`UPDATE_KEEP_WINDOW_ON_BLUR`). No window-manager hints or platform-specific paths involved — works uniformly on macOS, Windows, X11, and (verified) Hyprland.

2. **Small bug fix folded in.** The existing `devtools-opened` handler in `src/main/lifecycle/window.ts` sets `alwaysOnTop=true` for DevTools usability. The matching `devtools-closed` handler previously did **not** restore it, so opening and closing DevTools left the flag stuck on for the rest of the session. The new `applyKeepWindowOnBlur` setter owns this flag's lifecycle, and the `devtools-closed` handler now restores it to the user's preference (`false` by default, matching the prior intent). One line of behavior change, inseparable from owning the flag — calling it out so the diff doesn't look surprising.

3. **Naming across the IPC boundary.** Renderer concept: `keepWindowOnBlur`. Main-side setter: `applyKeepWindowOnBlur(mb, value)`. The fact that we implement it via `setAlwaysOnTop` is an implementation detail and not exposed in the public name.

## Behavior matrix

| Setting | Click outside window | `Esc` | Tray icon click | Open DevTools → close DevTools |
|---------|---------------------|-------|-----------------|-------------------------------|
| **Off** (default) | hides popup | hides popup | toggles | flag returns to `false` ✓ (was previously stuck on) |
| **On** | popup stays | hides popup | toggles | flag returns to `true` ✓ |

## Test plan

- [ ] With setting **off** (default): clicking outside the window hides it — same as `main`.
- [ ] With setting **on**: clicking outside leaves the popup visible; `Esc` still hides it; tray icon click still toggles.
- [ ] Setting persists across app restart.
- [ ] Open DevTools, then close it — `alwaysOnTop` returns to the setting's current value (regression check on the bug fix above).
- [ ] `pnpm test` — 1038 tests pass; new tests cover `applyKeepWindowOnBlur`, `devtools-closed` restoration, the settings checkbox, and the IPC handler; Settings snapshot regenerated.
- [ ] `pnpm check` and `pnpm tsc --noEmit` clean.
- [ ] Manually verified on Hyprland (Wayland). Mechanism is JS-level so other platforms should behave identically — I don't have macOS or Windows to verify locally.