### PR TITLE
refactor(forges/github): move GITHUB_API_MERGE_BATCH_SIZE into forges/github

### DIFF
--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -60,7 +60,6 @@ export const Constants = {
 
   GITHUB_API_BASE_URL: 'https://api.github.com',
   GITHUB_API_GRAPHQL_URL: 'https://api.github.com/graphql',
-  GITHUB_API_MERGE_BATCH_SIZE: 100,
 
   // Emojis for different states and events
   EMOJIS: {

--- a/src/renderer/utils/forges/github/enrich.ts
+++ b/src/renderer/utils/forges/github/enrich.ts
@@ -1,11 +1,17 @@
-import { Constants } from '../../../constants';
-
 import type { GitifySubject, RawGitifyNotification, SettingsState } from '../../../types';
 
 import { rendererLogError, rendererLogWarn, toError } from '../../core/logger';
 import { fetchNotificationDetailsForList } from './client';
 import type { FetchMergedDetailsTemplateQuery } from './graphql/generated/graphql';
 import { createNotificationHandler } from './handlers';
+
+/**
+ * Maximum number of notifications batched into a single merged GraphQL query
+ * by `enrichGitHubNotifications`. GitHub's GraphQL alias cap is well above
+ * 100; this is a conservative ceiling that keeps individual responses small
+ * and parseable.
+ */
+export const GITHUB_API_MERGE_BATCH_SIZE = 100;
 
 /**
  * Enrich GitHub notifications with additional subject details (state, user,
@@ -33,7 +39,7 @@ async function fetchInBatches(
 ): Promise<Map<RawGitifyNotification, FetchMergedDetailsTemplateQuery['repository']>> {
   const merged = new Map<RawGitifyNotification, FetchMergedDetailsTemplateQuery['repository']>();
 
-  const batchSize = Constants.GITHUB_API_MERGE_BATCH_SIZE;
+  const batchSize = GITHUB_API_MERGE_BATCH_SIZE;
 
   for (let start = 0; start < notifications.length; start += batchSize) {
     const batchIndex = Math.floor(start / batchSize) + 1;

--- a/src/renderer/utils/notifications/notifications.test.ts
+++ b/src/renderer/utils/notifications/notifications.test.ts
@@ -9,8 +9,6 @@ import {
 } from '../../__mocks__/notifications-mocks';
 import { mockSettings } from '../../__mocks__/state-mocks';
 
-import { Constants } from '../../constants';
-
 import {
   type AccountNotifications,
   type GitifyNotification,
@@ -20,6 +18,7 @@ import {
 } from '../../types';
 
 import * as apiClient from '../forges/github/client';
+import { GITHUB_API_MERGE_BATCH_SIZE } from '../forges/github/enrich';
 import {
   enrichNotifications,
   getNotificationCount,
@@ -141,7 +140,7 @@ describe('renderer/utils/notifications/notifications.ts', () => {
         .spyOn(apiClient, 'fetchNotificationDetailsForList')
         .mockResolvedValue(new Map());
 
-      const notificationCount = Constants.GITHUB_API_MERGE_BATCH_SIZE * 2.5;
+      const notificationCount = GITHUB_API_MERGE_BATCH_SIZE * 2.5;
       const notifications = Array.from({ length: notificationCount }, (_, i) =>
         mockPartialGitifyNotification({
           title: `Notification ${i}`,
@@ -162,10 +161,10 @@ describe('renderer/utils/notifications/notifications.ts', () => {
 
       // Verify batch sizes
       expect(fetchNotificationDetailsForListSpy.mock.calls[0][0]).toHaveLength(
-        Constants.GITHUB_API_MERGE_BATCH_SIZE,
+        GITHUB_API_MERGE_BATCH_SIZE,
       );
       expect(fetchNotificationDetailsForListSpy.mock.calls[1][0]).toHaveLength(
-        Constants.GITHUB_API_MERGE_BATCH_SIZE,
+        GITHUB_API_MERGE_BATCH_SIZE,
       );
       expect(fetchNotificationDetailsForListSpy.mock.calls[2][0]).toHaveLength(50);
     });


### PR DESCRIPTION
## Summary

Small follow-up to #2874. The `GITHUB_API_MERGE_BATCH_SIZE` constant only governs GitHub's GraphQL enrichment batching, but it was sitting on the shared `Constants` object — implying every forge cares about it. Move it next to its sole consumer (`forges/github/enrich.ts`) and import directly from the test.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm exec vitest --run src/renderer/utils/forges/github/enrich.test.ts src/renderer/utils/notifications/notifications.test.ts` — passes