### PR TITLE
refactor(forges): expose participatingDocsUrl on the adapter

### DIFF
--- a/src/renderer/components/settings/NotificationSettings.test.tsx
+++ b/src/renderer/components/settings/NotificationSettings.test.tsx
@@ -212,9 +212,7 @@ describe('renderer/components/settings/NotificationSettings.tsx', () => {
     const tooltipElement = screen.getByLabelText('tooltip-showOnlyParticipating');
 
     await userEvent.click(tooltipElement);
-    await userEvent.click(
-      screen.getByTitle('Open GitHub documentation for participating and watching notifications'),
-    );
+    await userEvent.click(screen.getByTitle('Open the participating-vs-watching documentation'));
 
     expect(openExternalLinkSpy).toHaveBeenCalledTimes(1);
     expect(openExternalLinkSpy).toHaveBeenCalledWith(

--- a/src/renderer/components/settings/NotificationSettings.tsx
+++ b/src/renderer/components/settings/NotificationSettings.tsx
@@ -34,7 +34,8 @@ import { Title } from '../primitives/Title';
 import { FetchType, GroupBy, Size } from '../../types';
 
 import { hasAlternateScopes, hasRecommendedScopes } from '../../utils/auth/scopes';
-import { openGitHubParticipatingDocs } from '../../utils/system/links';
+import { getAdapter } from '../../utils/forges/registry';
+import { openExternalLink } from '../../utils/system/comms';
 
 export const NotificationSettings: FC = () => {
   const navigate = useNavigate();
@@ -42,6 +43,12 @@ export const NotificationSettings: FC = () => {
   const { auth, settings, updateSetting } = useAppContext();
 
   const [fetchInterval, setFetchInterval] = useState<number>(settings.fetchInterval);
+
+  // Surface the first signed-in forge's participating-vs-watching docs link.
+  // Hidden when no registered account advertises one (e.g. Gitea-only setups).
+  const participatingDocsUrl = auth.accounts
+    .map((account) => getAdapter(account).participatingDocsUrl)
+    .find((url): url is NonNullable<typeof url> => Boolean(url));
 
   useEffect(() => {
     setFetchInterval(settings.fetchInterval);
@@ -332,22 +339,24 @@ export const NotificationSettings: FC = () => {
                 When <Text as="u">unchecked</Text>, {APPLICATION.NAME} will fetch participating and
                 watching notifications.
               </Text>
-              <Text>
-                See{' '}
-                <button
-                  className="text-gitify-link cursor-pointer"
-                  onClick={(event: MouseEvent<HTMLElement>) => {
-                    // Don't trigger onClick of parent element.
-                    event.stopPropagation();
-                    openGitHubParticipatingDocs();
-                  }}
-                  title="Open GitHub documentation for participating and watching notifications"
-                  type="button"
-                >
-                  official docs
-                </button>{' '}
-                for more details.
-              </Text>
+              {participatingDocsUrl && (
+                <Text>
+                  See{' '}
+                  <button
+                    className="text-gitify-link cursor-pointer"
+                    onClick={(event: MouseEvent<HTMLElement>) => {
+                      // Don't trigger onClick of parent element.
+                      event.stopPropagation();
+                      openExternalLink(participatingDocsUrl);
+                    }}
+                    title="Open the participating-vs-watching documentation"
+                    type="button"
+                  >
+                    official docs
+                  </button>{' '}
+                  for more details.
+                </Text>
+              )}
             </Stack>
           }
         />

--- a/src/renderer/utils/forges/github/adapter.ts
+++ b/src/renderer/utils/forges/github/adapter.ts
@@ -99,6 +99,7 @@ export const githubAdapter: ForgeAdapter = {
   getPersonalAccessTokenSettingsUrl: getNewTokenURL,
   getAccountSettingsUrl: getDeveloperSettingsURL,
   documentationUrl: Constants.GITHUB_DOCS.PAT_URL as Link,
+  participatingDocsUrl: Constants.GITHUB_DOCS.PARTICIPATING_URL,
 
   supportsOAuthScopes: true,
 

--- a/src/renderer/utils/forges/types.ts
+++ b/src/renderer/utils/forges/types.ts
@@ -176,6 +176,12 @@ export interface ForgeAdapter {
   loginMethods: ReadonlyArray<LoginMethodDescriptor>;
   /** External documentation link shown in the PAT login route. */
   documentationUrl: Link;
+  /**
+   * Optional link to the forge's docs explaining participating-vs-watching
+   * notification behaviour. Surfaced in NotificationSettings; the button is
+   * hidden when no registered account exposes one.
+   */
+  participatingDocsUrl?: Link;
 
   // --- Auth flows ---
   // Optional because not every forge supports every flow. Gitea today is

--- a/src/renderer/utils/system/links.test.ts
+++ b/src/renderer/utils/system/links.test.ts
@@ -14,7 +14,6 @@ import {
   openAccountSettings,
   openHostIssues,
   openHostNotifications,
-  openGitHubParticipatingDocs,
   openHostPulls,
   openGitifyReleaseNotes,
   openHost,
@@ -99,11 +98,5 @@ describe('renderer/utils/links.ts', () => {
     await openNotification(mockGitifyNotification);
 
     expect(openExternalLinkSpy).toHaveBeenCalledWith(mockNotificationUrl);
-  });
-
-  it('openParticipatingDocs', () => {
-    openGitHubParticipatingDocs();
-
-    expect(openExternalLinkSpy).toHaveBeenCalledWith(Constants.GITHUB_DOCS.PARTICIPATING_URL);
   });
 });

--- a/src/renderer/utils/system/links.ts
+++ b/src/renderer/utils/system/links.ts
@@ -1,7 +1,5 @@
 import { APPLICATION } from '../../../shared/constants';
 
-import { Constants } from '../../constants';
-
 import type {
   Account,
   GitifyNotification,
@@ -65,8 +63,4 @@ export function openRepository(repository: GitifyRepository) {
 export async function openNotification(notification: GitifyNotification) {
   const url = await generateGitHubWebUrl(notification);
   openExternalLink(url);
-}
-
-export function openGitHubParticipatingDocs() {
-  openExternalLink(Constants.GITHUB_DOCS.PARTICIPATING_URL);
 }


### PR DESCRIPTION
## Summary

Another follow-up to #2874. The "see official docs" link in NotificationSettings opened a hardcoded GitHub docs URL via a dedicated helper, but the button was shown for every forge — including Gitea-only setups where the link is irrelevant.

- Add `participatingDocsUrl?: Link` to `ForgeAdapter`. Optional because not every forge has equivalent docs.
- Wire `Constants.GITHUB_DOCS.PARTICIPATING_URL` onto `githubAdapter`.
- `NotificationSettings` picks the first signed-in forge's URL and hides the button when none expose one.
- Drop the dedicated `openGitHubParticipatingDocs` helper from `system/links.ts` plus its test.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm exec vitest --run src/renderer/utils/system/links.test.ts src/renderer/components/settings/NotificationSettings.test.tsx` — passes