### PR TITLE
refactor(forges): expose getAuthMethodIcon on the adapter

### DIFF
--- a/src/renderer/routes/Accounts.tsx
+++ b/src/renderer/routes/Accounts.tsx
@@ -34,7 +34,7 @@ import { toError } from '../utils/core/logger';
 import { saveState } from '../utils/core/storage';
 import { getAdapter } from '../utils/forges/registry';
 import { openAccountProfile, openAccountSettings, openHost } from '../utils/system/links';
-import { getAuthMethodIcon, getPlatformIcon } from '../utils/ui/icons';
+import { getPlatformIcon } from '../utils/ui/icons';
 
 export const AccountsRoute: FC = () => {
   const navigate = useNavigate();
@@ -153,7 +153,7 @@ export const AccountsRoute: FC = () => {
 
       <Contents>
         {auth.accounts.map((account, i) => {
-          const AuthMethodIcon = getAuthMethodIcon(account.method);
+          const AuthMethodIcon = getAdapter(account).getAuthMethodIcon(account.method);
           const PlatformIcon = getPlatformIcon(account.platform);
           const accountUUID = getAccountUUID(account);
           const accountError = getAccountError(account);

--- a/src/renderer/utils/forges/gitea/adapter.test.ts
+++ b/src/renderer/utils/forges/gitea/adapter.test.ts
@@ -1,3 +1,5 @@
+import { KeyIcon } from '@primer/octicons-react';
+
 import { mockGiteaAccount } from '../../../__mocks__/account-mocks';
 
 import type { Hostname, Link, SettingsState, Token } from '../../../types';
@@ -38,6 +40,12 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
       expect(giteaAdapter.getAccountSettingsUrl(mockGiteaAccount)).toBe(
         'https://gitea.example.com/user/settings/applications',
       );
+    });
+
+    it('returns the key icon for every auth method (PAT-only forge today)', () => {
+      expect(giteaAdapter.getAuthMethodIcon('Personal Access Token')).toBe(KeyIcon);
+      expect(giteaAdapter.getAuthMethodIcon('GitHub App')).toBe(KeyIcon);
+      expect(giteaAdapter.getAuthMethodIcon('OAuth App')).toBe(KeyIcon);
     });
   });
 

--- a/src/renderer/utils/forges/gitea/adapter.ts
+++ b/src/renderer/utils/forges/gitea/adapter.ts
@@ -103,6 +103,10 @@ export const giteaAdapter: ForgeAdapter = {
   getAccountSettingsUrl: (account: Account) =>
     `https://${account.hostname}/user/settings/applications` as Link,
   documentationUrl: GITEA_DOCS_URL,
+  // Gitea only supports PAT today, so every method falls through to the key
+  // icon. Adding device-flow/OAuth support later means returning their icons
+  // for those branches.
+  getAuthMethodIcon: () => KeyIcon,
 
   supportsOAuthScopes: false,
 

--- a/src/renderer/utils/forges/github/adapter.test.ts
+++ b/src/renderer/utils/forges/github/adapter.test.ts
@@ -1,3 +1,5 @@
+import { AppsIcon, KeyIcon, PersonIcon } from '@primer/octicons-react';
+
 import { mockGitHubCloudAccount } from '../../../__mocks__/account-mocks';
 
 import type { Hostname, Link, SettingsState, Token } from '../../../types';
@@ -36,6 +38,12 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
       expect(githubAdapter.getAccountSettingsUrl(mockGitHubCloudAccount)).toBe(
         'https://github.com/settings/tokens',
       );
+    });
+
+    it('maps each auth method to its icon', () => {
+      expect(githubAdapter.getAuthMethodIcon('GitHub App')).toBe(AppsIcon);
+      expect(githubAdapter.getAuthMethodIcon('OAuth App')).toBe(PersonIcon);
+      expect(githubAdapter.getAuthMethodIcon('Personal Access Token')).toBe(KeyIcon);
     });
 
     it('wires the device-flow and OAuth-app methods so the context can dispatch via the adapter', () => {

--- a/src/renderer/utils/forges/github/adapter.ts
+++ b/src/renderer/utils/forges/github/adapter.ts
@@ -1,8 +1,9 @@
-import { KeyIcon, MarkGithubIcon, PersonIcon } from '@primer/octicons-react';
+import { AppsIcon, KeyIcon, MarkGithubIcon, PersonIcon } from '@primer/octicons-react';
 
 import { Constants } from '../../../constants';
 
 import type { Account, Link, RawGitifyNotification, SettingsState } from '../../../types';
+import type { AuthMethod } from '../../auth/types';
 import type { ForgeAdapter, NotificationDisplayHelpers, RefreshAccountData } from '../types';
 
 import { extractHostVersion, getDeveloperSettingsURL, getNewTokenURL, isValidToken } from './auth';
@@ -99,6 +100,7 @@ export const githubAdapter: ForgeAdapter = {
   getPersonalAccessTokenSettingsUrl: getNewTokenURL,
   getAccountSettingsUrl: getDeveloperSettingsURL,
   documentationUrl: Constants.GITHUB_DOCS.PAT_URL as Link,
+  getAuthMethodIcon: githubAuthMethodIcon,
 
   supportsOAuthScopes: true,
 
@@ -142,4 +144,15 @@ function accountHasScopes(
   group: 'REQUIRED' | 'RECOMMENDED' | 'ALTERNATE',
 ): boolean {
   return Constants.OAUTH_SCOPES[group].every(({ name }) => (account.scopes ?? []).includes(name));
+}
+
+function githubAuthMethodIcon(method: AuthMethod) {
+  switch (method) {
+    case 'GitHub App':
+      return AppsIcon;
+    case 'OAuth App':
+      return PersonIcon;
+    default:
+      return KeyIcon;
+  }
 }

--- a/src/renderer/utils/forges/types.ts
+++ b/src/renderer/utils/forges/types.ts
@@ -176,6 +176,12 @@ export interface ForgeAdapter {
   loginMethods: ReadonlyArray<LoginMethodDescriptor>;
   /** External documentation link shown in the PAT login route. */
   documentationUrl: Link;
+  /**
+   * Icon for the given auth method, used in the Accounts list. Adapters that
+   * only support a subset of `AuthMethod` should return a sensible fallback
+   * (e.g. KeyIcon) for unknown values rather than throwing.
+   */
+  getAuthMethodIcon(method: AuthMethod): FC<OcticonProps>;
 
   // --- Auth flows ---
   // Optional because not every forge supports every flow. Gitea today is

--- a/src/renderer/utils/ui/__snapshots__/icons.test.ts.snap
+++ b/src/renderer/utils/ui/__snapshots__/icons.test.ts.snap
@@ -1,26 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`renderer/utils/icons.ts > getAuthMethodIcon 1`] = `
-{
-  "$$typeof": Symbol(react.forward_ref),
-  "render": [Function],
-}
-`;
-
-exports[`renderer/utils/icons.ts > getAuthMethodIcon 2`] = `
-{
-  "$$typeof": Symbol(react.forward_ref),
-  "render": [Function],
-}
-`;
-
-exports[`renderer/utils/icons.ts > getAuthMethodIcon 3`] = `
-{
-  "$$typeof": Symbol(react.forward_ref),
-  "render": [Function],
-}
-`;
-
 exports[`renderer/utils/icons.ts > getPlatformIcon 1`] = `
 {
   "$$typeof": Symbol(react.forward_ref),

--- a/src/renderer/utils/ui/icons.test.ts
+++ b/src/renderer/utils/ui/icons.test.ts
@@ -9,12 +9,7 @@ import {
 
 import { type GitifyPullRequestReview, IconColor } from '../../types';
 
-import {
-  getAuthMethodIcon,
-  getDefaultUserIcon,
-  getPlatformIcon,
-  getPullRequestReviewIcon,
-} from './icons';
+import { getDefaultUserIcon, getPlatformIcon, getPullRequestReviewIcon } from './icons';
 
 describe('renderer/utils/icons.ts', () => {
   describe('getPullRequestReviewIcon', () => {
@@ -108,14 +103,6 @@ describe('renderer/utils/icons.ts', () => {
 
       expect(getPullRequestReviewIcon(mockReviewMultipleReviewer)).toBeNull();
     });
-  });
-
-  it('getAuthMethodIcon', () => {
-    expect(getAuthMethodIcon('GitHub App')).toMatchSnapshot();
-
-    expect(getAuthMethodIcon('OAuth App')).toMatchSnapshot();
-
-    expect(getAuthMethodIcon('Personal Access Token')).toMatchSnapshot();
   });
 
   it('getPlatformIcon', () => {

--- a/src/renderer/utils/ui/icons.ts
+++ b/src/renderer/utils/ui/icons.ts
@@ -1,16 +1,13 @@
 import type { FC } from 'react';
 
 import {
-  AppsIcon,
   CheckIcon,
   CommentIcon,
   FeedPersonIcon,
   FileDiffIcon,
-  KeyIcon,
   MarkGithubIcon,
   type OcticonProps,
   OrganizationIcon,
-  PersonIcon,
   ServerIcon,
   ShieldCheckIcon,
 } from '@primer/octicons-react';
@@ -21,7 +18,7 @@ import {
   type PullRequestApprovalIcon,
   type UserType,
 } from '../../types';
-import type { AuthMethod, PlatformType } from '../auth/types';
+import type { PlatformType } from '../auth/types';
 
 export function getPullRequestReviewIcon(
   review: GitifyPullRequestReview,
@@ -57,17 +54,6 @@ export function getPullRequestReviewIcon(
       };
     default:
       return null;
-  }
-}
-
-export function getAuthMethodIcon(method: AuthMethod): FC<OcticonProps> | null {
-  switch (method) {
-    case 'GitHub App':
-      return AppsIcon;
-    case 'OAuth App':
-      return PersonIcon;
-    default:
-      return KeyIcon;
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #2874. `getAuthMethodIcon` in `ui/icons.ts` switched on `AuthMethod` strings (`'GitHub App'`, `'OAuth App'`, etc.) to pick an icon — auth methods are forge-defined so their icons should be too.

- Add `getAuthMethodIcon(method): FC<OcticonProps>` to `ForgeAdapter`.
- GitHub adapter maps `GitHub App` → AppsIcon, `OAuth App` → PersonIcon, default → KeyIcon.
- Gitea adapter returns KeyIcon for every method (PAT-only forge today).
- `Accounts.tsx` now dispatches via `getAdapter(account).getAuthMethodIcon(...)`.
- Drop the shared switch (and its snapshots/tests); add adapter-level tests.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm exec vitest --run src/renderer/utils/forges/github/adapter.test.ts src/renderer/utils/forges/gitea/adapter.test.ts src/renderer/utils/ui/icons.test.ts src/renderer/routes/Accounts.test.tsx` — passes