### PR TITLE
refactor(forges): route device-flow revoke-access hint through the adapter

### DIFF
--- a/src/renderer/routes/LoginWithDeviceFlow.tsx
+++ b/src/renderer/routes/LoginWithDeviceFlow.tsx
@@ -18,8 +18,8 @@ import type { DeviceFlowSession } from '../utils/auth/types';
 
 import { getAlternateScopeNames, getRecommendedScopeNames } from '../utils/auth/scopes';
 import { rendererLogError, toError } from '../utils/core/logger';
+import { getAdapter } from '../utils/forges/registry';
 import { copyToClipboard, openExternalLink } from '../utils/system/comms';
-import { openAccountSettings } from '../utils/system/links';
 
 interface LocationState {
   account?: Account;
@@ -37,6 +37,9 @@ export const LoginWithDeviceFlowRoute: FC = () => {
   // here through a registered adapter, so a missing forge would indicate a
   // mis-registered route — fall back to 'github' to preserve existing UX.
   const forge: Forge = routeForge ?? reAuthAccount?.forge ?? 'github';
+  const adapter = getAdapter(forge);
+  const revokeHostname = reAuthAccount?.hostname ?? Constants.GITHUB_HOSTNAME;
+  const revokeAccessUrl = adapter.getDeviceFlowRevokeAccessUrl?.(revokeHostname);
 
   const { loginWithDeviceFlowStart, loginWithDeviceFlowPoll, loginWithDeviceFlowComplete } =
     useAppContext();
@@ -229,25 +232,22 @@ export const LoginWithDeviceFlowRoute: FC = () => {
           </Stack>
         </Button>
 
-        <Stack gap="none">
-          <Text as="em" size="small">
-            Note: to change previously granted permissions, revoke Gitify's access at{' '}
-            <button
-              className="text-gitify-link cursor-pointer"
-              onClick={() =>
-                openAccountSettings({
-                  hostname: Constants.GITHUB_HOSTNAME,
-                  method: 'GitHub App',
-                } as Account)
-              }
-              title="GitHub → Developer Settings"
-              type="button"
-            >
-              GitHub → Developer Settings
-            </button>
-            , then re-authorize above.
-          </Text>
-        </Stack>
+        {revokeAccessUrl && (
+          <Stack gap="none">
+            <Text as="em" size="small">
+              Note: to change previously granted permissions, revoke Gitify's access at{' '}
+              <button
+                className="text-gitify-link cursor-pointer"
+                onClick={() => openExternalLink(revokeAccessUrl)}
+                title={`${adapter.displayName} → Developer Settings`}
+                type="button"
+              >
+                {adapter.displayName} → Developer Settings
+              </button>
+              , then re-authorize above.
+            </Text>
+          </Stack>
+        )}
       </Stack>
     </Stack>
   );

--- a/src/renderer/utils/forges/github/adapter.ts
+++ b/src/renderer/utils/forges/github/adapter.ts
@@ -131,6 +131,8 @@ export const githubAdapter: ForgeAdapter = {
   pollDeviceFlow: pollGitHubDeviceFlow,
   performWebOAuth: performGitHubWebOAuth,
   exchangeAuthCodeForToken: exchangeAuthCodeForAccessToken,
+  getDeviceFlowRevokeAccessUrl: (hostname) =>
+    getDeveloperSettingsURL({ hostname, method: 'GitHub App' } as Account),
 
   hasRequiredScopes: (account) => accountHasScopes(account, 'REQUIRED'),
   hasRecommendedScopes: (account) => accountHasScopes(account, 'RECOMMENDED'),

--- a/src/renderer/utils/forges/types.ts
+++ b/src/renderer/utils/forges/types.ts
@@ -196,6 +196,13 @@ export interface ForgeAdapter {
   performWebOAuth?(options: LoginOAuthWebOptions): Promise<AuthResponse>;
   /** Exchange an OAuth web-flow authorization code for an access token. */
   exchangeAuthCodeForToken?(authCode: AuthCode, options: LoginOAuthWebOptions): Promise<Token>;
+  /**
+   * URL where the user can revoke the device-flow OAuth grant on the given
+   * hostname (so they can re-authorize with different scopes). Required when
+   * `startDeviceFlow` is provided — the route uses it to render the
+   * "revoke access" hint.
+   */
+  getDeviceFlowRevokeAccessUrl?(hostname: Hostname): Link;
 
   // --- OAuth scopes ---
   // Forges without an OAuth scope concept (e.g. Gitea) report `true` for


### PR DESCRIPTION
## Summary

Follow-up to #2874. The "revoke Gitify's access at GitHub → Developer Settings" hint in `LoginWithDeviceFlow` synthesized a fake Account (`{ hostname: GITHUB_HOSTNAME, method: 'GitHub App' }`) and shoved it through `openAccountSettings`. The label was hardcoded "GitHub" and the URL was reconstructed via account-settings dispatch rather than declared by the adapter directly.

- Add `getDeviceFlowRevokeAccessUrl?(hostname): Link` to `ForgeAdapter`.
- GitHub adapter returns the developer-settings URL.
- `LoginWithDeviceFlow` now uses `adapter.displayName` for the label and opens the adapter-provided URL. The whole hint hides when the adapter doesn't expose one — defensive against future non-GitHub forges that may register a device-flow route.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm exec vitest --run src/renderer/routes/LoginWithDeviceFlow.test.tsx src/renderer/utils/forges/github/adapter.test.ts\` — passes