### PR TITLE
refactor(links): rename openGitHub* host helpers to openHost*

### DIFF
--- a/src/renderer/components/GlobalShortcuts.test.tsx
+++ b/src/renderer/components/GlobalShortcuts.test.tsx
@@ -32,9 +32,9 @@ describe('components/GlobalShortcuts.tsx', () => {
       });
     });
 
-    describe('openGitHubNotifications', () => {
-      const openGitHubNotificationsSpy = vi
-        .spyOn(links, 'openGitHubNotifications')
+    describe('openHostNotifications', () => {
+      const openHostNotificationsSpy = vi
+        .spyOn(links, 'openHostNotifications')
         .mockImplementation(vi.fn());
 
       it('opens primary account GitHub notifications webpage when pressing N while logged in', async () => {
@@ -44,7 +44,7 @@ describe('components/GlobalShortcuts.tsx', () => {
 
         await userEvent.keyboard('n');
 
-        expect(openGitHubNotificationsSpy).toHaveBeenCalledTimes(1);
+        expect(openHostNotificationsSpy).toHaveBeenCalledTimes(1);
       });
 
       it('does not open primary account GitHub notifications webpage when logged out', async () => {
@@ -54,7 +54,7 @@ describe('components/GlobalShortcuts.tsx', () => {
 
         await userEvent.keyboard('n');
 
-        expect(openGitHubNotificationsSpy).not.toHaveBeenCalled();
+        expect(openHostNotificationsSpy).not.toHaveBeenCalled();
       });
     });
 
@@ -116,8 +116,8 @@ describe('components/GlobalShortcuts.tsx', () => {
       });
     });
 
-    describe('openGitHubIssues', () => {
-      const openGitHubIssuesSpy = vi.spyOn(links, 'openGitHubIssues').mockImplementation(vi.fn());
+    describe('openHostIssues', () => {
+      const openHostIssuesSpy = vi.spyOn(links, 'openHostIssues').mockImplementation(vi.fn());
 
       it('opens primary account GitHub issues webpage when pressing I while logged in', async () => {
         renderWithProviders(<GlobalShortcuts />, {
@@ -126,7 +126,7 @@ describe('components/GlobalShortcuts.tsx', () => {
 
         await userEvent.keyboard('i');
 
-        expect(openGitHubIssuesSpy).toHaveBeenCalledTimes(1);
+        expect(openHostIssuesSpy).toHaveBeenCalledTimes(1);
       });
 
       it('does not open primary account GitHub issues webpage when logged out', async () => {
@@ -136,12 +136,12 @@ describe('components/GlobalShortcuts.tsx', () => {
 
         await userEvent.keyboard('n');
 
-        expect(openGitHubIssuesSpy).not.toHaveBeenCalled();
+        expect(openHostIssuesSpy).not.toHaveBeenCalled();
       });
     });
 
-    describe('openGitHubPulls', () => {
-      const openGitHubPullsSpy = vi.spyOn(links, 'openGitHubPulls').mockImplementation(vi.fn());
+    describe('openHostPulls', () => {
+      const openHostPullsSpy = vi.spyOn(links, 'openHostPulls').mockImplementation(vi.fn());
 
       it('opens primary account GitHub pull requests webpage when pressing N while logged in', async () => {
         renderWithProviders(<GlobalShortcuts />, {
@@ -150,7 +150,7 @@ describe('components/GlobalShortcuts.tsx', () => {
 
         await userEvent.keyboard('p');
 
-        expect(openGitHubPullsSpy).toHaveBeenCalledTimes(1);
+        expect(openHostPullsSpy).toHaveBeenCalledTimes(1);
       });
 
       it('does not open primary account GitHub pull requests webpage when logged out', async () => {
@@ -160,7 +160,7 @@ describe('components/GlobalShortcuts.tsx', () => {
 
         await userEvent.keyboard('n');
 
-        expect(openGitHubPullsSpy).not.toHaveBeenCalled();
+        expect(openHostPullsSpy).not.toHaveBeenCalled();
       });
     });
 

--- a/src/renderer/components/notifications/AccountNotifications.test.tsx
+++ b/src/renderer/components/notifications/AccountNotifications.test.tsx
@@ -126,7 +126,7 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
   });
 
   it('should open my issues when clicked', async () => {
-    const openGitHubIssuesSpy = vi.spyOn(links, 'openGitHubIssues').mockImplementation(vi.fn());
+    const openHostIssuesSpy = vi.spyOn(links, 'openHostIssues').mockImplementation(vi.fn());
 
     const props: AccountNotificationsProps = {
       account: mockGitHubCloudAccount,
@@ -139,12 +139,12 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
 
     await userEvent.click(screen.getByTestId('account-issues'));
 
-    expect(openGitHubIssuesSpy).toHaveBeenCalledTimes(1);
-    expect(openGitHubIssuesSpy).toHaveBeenCalledWith(mockGitHubCloudAccount.hostname);
+    expect(openHostIssuesSpy).toHaveBeenCalledTimes(1);
+    expect(openHostIssuesSpy).toHaveBeenCalledWith(mockGitHubCloudAccount.hostname);
   });
 
   it('should open my pull requests when clicked', async () => {
-    const openGitHubPullsSpy = vi.spyOn(links, 'openGitHubPulls').mockImplementation(vi.fn());
+    const openHostPullsSpy = vi.spyOn(links, 'openHostPulls').mockImplementation(vi.fn());
 
     const props: AccountNotificationsProps = {
       account: mockGitHubCloudAccount,
@@ -157,8 +157,8 @@ describe('renderer/components/notifications/AccountNotifications.tsx', () => {
 
     await userEvent.click(screen.getByTestId('account-pull-requests'));
 
-    expect(openGitHubPullsSpy).toHaveBeenCalledTimes(1);
-    expect(openGitHubPullsSpy).toHaveBeenCalledWith(mockGitHubCloudAccount.hostname);
+    expect(openHostPullsSpy).toHaveBeenCalledTimes(1);
+    expect(openHostPullsSpy).toHaveBeenCalledWith(mockGitHubCloudAccount.hostname);
   });
 
   it('should toggle account notifications visibility', async () => {

--- a/src/renderer/components/notifications/AccountNotifications.tsx
+++ b/src/renderer/components/notifications/AccountNotifications.tsx
@@ -15,7 +15,7 @@ import {
   groupNotificationsByRepository,
   isGroupByRepository,
 } from '../../utils/notifications/group';
-import { openAccountProfile, openGitHubIssues, openGitHubPulls } from '../../utils/system/links';
+import { openAccountProfile, openHostIssues, openHostPulls } from '../../utils/system/links';
 import { cn } from '../../utils/ui/cn';
 import { getChevronDetails } from '../../utils/ui/display';
 import { AllRead } from '../AllRead';
@@ -98,14 +98,14 @@ export const AccountNotifications: FC<AccountNotificationsProps> = (
             }
           >
             <HoverButton
-              action={() => openGitHubIssues(account.hostname)}
+              action={() => openHostIssues(account.hostname)}
               icon={IssueOpenedIcon}
               label="My issues ↗"
               testid="account-issues"
             />
 
             <HoverButton
-              action={() => openGitHubPulls(account.hostname)}
+              action={() => openHostPulls(account.hostname)}
               icon={GitPullRequestIcon}
               label="My pull requests ↗"
               testid="account-pull-requests"

--- a/src/renderer/hooks/useShortcutActions.ts
+++ b/src/renderer/hooks/useShortcutActions.ts
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { getPrimaryAccountHostname } from '../utils/auth/utils';
 import { quitApp } from '../utils/system/comms';
-import { openGitHubIssues, openGitHubNotifications, openGitHubPulls } from '../utils/system/links';
+import { openHostIssues, openHostNotifications, openHostPulls } from '../utils/system/links';
 import { useAppContext } from './useAppContext';
 
 type ShortcutName =
@@ -55,7 +55,7 @@ export function useShortcutActions(): { shortcuts: ShortcutConfigs } {
       myNotifications: {
         key: 'n',
         isAllowed: isLoggedIn,
-        action: () => openGitHubNotifications(primaryAccountHostname),
+        action: () => openHostNotifications(primaryAccountHostname),
       },
       focusedMode: {
         key: 'w',
@@ -76,12 +76,12 @@ export function useShortcutActions(): { shortcuts: ShortcutConfigs } {
       myIssues: {
         key: 'i',
         isAllowed: isLoggedIn,
-        action: () => openGitHubIssues(primaryAccountHostname),
+        action: () => openHostIssues(primaryAccountHostname),
       },
       myPullRequests: {
         key: 'p',
         isAllowed: isLoggedIn,
-        action: () => openGitHubPulls(primaryAccountHostname),
+        action: () => openHostPulls(primaryAccountHostname),
       },
       refresh: {
         key: 'r',

--- a/src/renderer/utils/system/links.test.ts
+++ b/src/renderer/utils/system/links.test.ts
@@ -12,10 +12,10 @@ import * as comms from './comms';
 import {
   openAccountProfile,
   openAccountSettings,
-  openGitHubIssues,
-  openGitHubNotifications,
+  openHostIssues,
+  openHostNotifications,
   openGitHubParticipatingDocs,
-  openGitHubPulls,
+  openHostPulls,
   openGitifyReleaseNotes,
   openHost,
   openNotification,
@@ -34,20 +34,20 @@ describe('renderer/utils/links.ts', () => {
     );
   });
 
-  it('openGitHubNotifications', () => {
-    openGitHubNotifications(mockGitHubCloudAccount.hostname);
+  it('openHostNotifications', () => {
+    openHostNotifications(mockGitHubCloudAccount.hostname);
 
     expect(openExternalLinkSpy).toHaveBeenCalledWith('https://github.com/notifications');
   });
 
-  it('openGitHubIssues', () => {
-    openGitHubIssues(mockGitHubCloudAccount.hostname);
+  it('openHostIssues', () => {
+    openHostIssues(mockGitHubCloudAccount.hostname);
 
     expect(openExternalLinkSpy).toHaveBeenCalledWith('https://github.com/issues');
   });
 
-  it('openGitHubPulls', () => {
-    openGitHubPulls(mockGitHubCloudAccount.hostname);
+  it('openHostPulls', () => {
+    openHostPulls(mockGitHubCloudAccount.hostname);
 
     expect(openExternalLinkSpy).toHaveBeenCalledWith('https://github.com/pulls');
   });

--- a/src/renderer/utils/system/links.ts
+++ b/src/renderer/utils/system/links.ts
@@ -21,19 +21,19 @@ export function openGitifyReleaseNotes(version: string) {
   );
 }
 
-export function openGitHubNotifications(hostname: Hostname) {
+export function openHostNotifications(hostname: Hostname) {
   const url = new URL(`https://${hostname}`);
   url.pathname = 'notifications';
   openExternalLink(url.toString() as Link);
 }
 
-export function openGitHubIssues(hostname: Hostname) {
+export function openHostIssues(hostname: Hostname) {
   const url = new URL(`https://${hostname}`);
   url.pathname = 'issues';
   openExternalLink(url.toString() as Link);
 }
 
-export function openGitHubPulls(hostname: Hostname) {
+export function openHostPulls(hostname: Hostname) {
   const url = new URL(`https://${hostname}`);
   url.pathname = 'pulls';
   openExternalLink(url.toString() as Link);


### PR DESCRIPTION
## Summary

Follow-up to #2874. `openGitHubNotifications`, `openGitHubIssues`, `openGitHubPulls` in `system/links.ts` build `https://{hostname}/notifications` (and friends) from a passed hostname. The function names imply GitHub-specific behavior, but the paths happen to be portable — Gitea uses the same `/notifications`, `/issues`, `/pulls` routes.

Pure rename — no semantic change. The helpers now match their actual behavior (open a host-level page on whatever forge the user is on). If a future forge needs different paths, this naming is closer to where the per-forge dispatch would go.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm exec vitest --run src/renderer/utils/system/links.test.ts src/renderer/components/GlobalShortcuts.test.tsx src/renderer/components/notifications/AccountNotifications.test.tsx` — passes