### PR TITLE
fix: increase polling interval for GitHub device code flow

### DIFF
--- a/src/renderer/routes/LoginWithDeviceFlow.tsx
+++ b/src/renderer/routes/LoginWithDeviceFlow.tsx
@@ -83,7 +83,6 @@ export const LoginWithDeviceFlowRoute: FC = () => {
 
     const startPolling = async () => {
       setIsPolling(true);
-      const intervalMs = Math.max(5000, session.intervalSeconds * 1000);
 
       try {
         while (isActive && Date.now() < session.expiresAt) {
@@ -95,6 +94,7 @@ export const LoginWithDeviceFlowRoute: FC = () => {
             return;
           }
 
+          const intervalMs = Math.max(5000, session.intervalSeconds * 1000);
           await new Promise((resolve) => {
             timeoutId = setTimeout(resolve, intervalMs);
           });

--- a/src/renderer/utils/forges/github/flows.test.ts
+++ b/src/renderer/utils/forges/github/flows.test.ts
@@ -102,15 +102,30 @@ describe('renderer/utils/forges/github/flows.ts', () => {
         expect(token).toBe('device-token-xyz');
       });
 
-      it('returns null when authorization is pending or slow_down', async () => {
+      it('returns null and does not change interval when authorization is pending', async () => {
         const pendingErr = Object.create(RequestError.prototype);
         pendingErr.response = { data: { error: 'authorization_pending' } };
 
         exchangeDeviceCodeMock.mockRejectedValueOnce(pendingErr);
 
-        const token = await flows.pollGitHubDeviceFlow(baseSession as DeviceFlowSession);
+        const session = { ...baseSession } as DeviceFlowSession;
+        const token = await flows.pollGitHubDeviceFlow(session);
 
         expect(token).toBeNull();
+        expect(session.intervalSeconds).toBe(5);
+      });
+
+      it('returns null and increases interval by 5 when slow_down', async () => {
+        const slowDownErr = Object.create(RequestError.prototype);
+        slowDownErr.response = { data: { error: 'slow_down' } };
+
+        exchangeDeviceCodeMock.mockRejectedValueOnce(slowDownErr);
+
+        const session = { ...baseSession } as DeviceFlowSession;
+        const token = await flows.pollGitHubDeviceFlow(session);
+
+        expect(token).toBeNull();
+        expect(session.intervalSeconds).toBe(10);
       });
 
       it('throws on other errors', async () => {

--- a/src/renderer/utils/forges/github/flows.ts
+++ b/src/renderer/utils/forges/github/flows.ts
@@ -141,7 +141,12 @@ export async function pollGitHubDeviceFlow(session: DeviceFlowSession): Promise<
       const response = err.response?.data as DeviceFlowErrorResponse;
       const errorCode = response.error;
 
-      if (errorCode === 'authorization_pending' || errorCode === 'slow_down') {
+      if (errorCode === 'authorization_pending') {
+        return null;
+      }
+
+      if (errorCode === 'slow_down') {
+        session.intervalSeconds += 5;
         return null;
       }
     }


### PR DESCRIPTION
## Description

This PR fixes #2867 where the GitHub device auth flow gets stuck and gets rate-limited with `excessive requests` due to the app ignoring `slow_down` responses from the GitHub API.

According to RFC 8628, when a `slow_down` error is received, the polling interval must be increased by 5 seconds. 

### Changes
- `flows.ts`: Differentiated the `authorization_pending` and `slow_down` in `pollGitHubDeviceFlow`. When `slow_down`, `session.intervalSeconds` is now incremented by 5.
- `LoginWithDeviceFlow.tsx`: Moved `intervalMs` inside the polling loop to ensure that any adjustments made to `session.intervalSeconds` by the API response are immediately applied to the next cycle.
- `flows.test.ts`: Updated the tests to explicitly verify that the interval remains unchanged on `authorization_pending` and correctly increases by 5 on `slow_down`.
