### PR TITLE
chore(renovate): hold got on the v11 line

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,11 @@
       "description": "Fetch changelog details for twemoji packages",
       "matchPackageNames": ["@discordapp/twemoji"],
       "changelogUrl": "https://github.com/jdjdecked/twemoji"
+    },
+    {
+      "description": "Hold got on the v11 line. The override only exists to satisfy security scanners for dev tooling (@electron/get via electron-builder, react-devtools), which was built against the non-ESM v11 API. v11.8.5+ already includes the security fix, and v12+ is ESM-only.",
+      "matchPackageNames": ["got"],
+      "allowedVersions": "<12"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary

Stop Renovate from proposing `got` v12+ bumps.

The `got` entry in `pnpm-workspace.yaml` is a `pnpm` override that exists only to force a patched version of a transitive dev-tooling dependency so security scanners stay quiet. It does not ship in the packaged app.

A `pnpm` override forces the version on every consumer, and `got` is pulled in by `@electron/get` (via `electron-builder`) and `react-devtools`, both built against the non-ESM `got` v11 API. `got` is ESM-only from v12 with a changed API, so forcing v12+ onto those consumers risks breaking the Electron build for no benefit: `got@11.8.5+` already contains the security fix, so there is no security upside to going past v11.

This adds a `packageRules` entry constraining `got` to `<12`, which keeps future v11.x patches flowing while suppressing the v12/v13/v14/v15 major PRs (#2952-#2955, now closed).