### PR TITLE
refactor(forges): read settings store inside the forge layer

### DIFF
--- a/src/renderer/utils/forges/gitea/adapter.test.ts
+++ b/src/renderer/utils/forges/gitea/adapter.test.ts
@@ -3,7 +3,9 @@ import { KeyIcon } from '@primer/octicons-react';
 import { mockGiteaAccount } from '../../../__mocks__/account-mocks';
 import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
 
-import type { Hostname, Link, SettingsState, Token } from '../../../types';
+import { useSettingsStore } from '../../../stores';
+
+import type { Hostname, Link, Token } from '../../../types';
 
 import { giteaAdapter } from './adapter';
 import * as client from './client';
@@ -129,10 +131,9 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
         },
       ]);
 
-      const result = await giteaAdapter.listNotifications(mockGiteaAccount, {
-        fetchAllNotifications: false,
-        fetchReadNotifications: false,
-      } as SettingsState);
+      useSettingsStore.setState({ fetchAllNotifications: false, fetchReadNotifications: false });
+
+      const result = await giteaAdapter.listNotifications(mockGiteaAccount);
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('99');

--- a/src/renderer/utils/forges/gitea/adapter.ts
+++ b/src/renderer/utils/forges/gitea/adapter.ts
@@ -1,13 +1,6 @@
 import { KeyIcon, ServerIcon } from '@primer/octicons-react';
 
-import type {
-  Account,
-  Hostname,
-  Link,
-  RawGitifyNotification,
-  SettingsState,
-  Token,
-} from '../../../types';
+import type { Account, Hostname, Link, RawGitifyNotification, Token } from '../../../types';
 import type {
   ForgeAdapter,
   ForgeCapabilities,
@@ -43,11 +36,8 @@ async function fetchAuthenticatedUser(account: Account): Promise<RefreshAccountD
   };
 }
 
-async function listNotifications(
-  account: Account,
-  settings: SettingsState,
-): Promise<RawGitifyNotification[]> {
-  const raw = await listGiteaNotifications(account, settings);
+async function listNotifications(account: Account): Promise<RawGitifyNotification[]> {
+  const raw = await listGiteaNotifications(account);
   return transformGiteaNotifications(raw, account);
 }
 

--- a/src/renderer/utils/forges/gitea/client.test.ts
+++ b/src/renderer/utils/forges/gitea/client.test.ts
@@ -1,6 +1,8 @@
 import { mockGiteaAccount } from '../../../__mocks__/account-mocks';
 
-import type { Hostname, SettingsState } from '../../../types';
+import { useSettingsStore } from '../../../stores';
+
+import type { Hostname } from '../../../types';
 
 import * as comms from '../../system/comms';
 import {
@@ -37,10 +39,9 @@ describe('renderer/utils/forges/gitea/client.ts', () => {
     it('fetches a single page when fetchAllNotifications is false', async () => {
       fetchMock().mockResolvedValueOnce(jsonResponse([{ id: 1 }]));
 
-      const result = await listGiteaNotifications(mockGiteaAccount, {
-        fetchAllNotifications: false,
-        fetchReadNotifications: false,
-      } as SettingsState);
+      useSettingsStore.setState({ fetchAllNotifications: false, fetchReadNotifications: false });
+
+      const result = await listGiteaNotifications(mockGiteaAccount);
 
       expect(result).toEqual([{ id: 1 }]);
       expect(fetchMock()).toHaveBeenCalledTimes(1);
@@ -54,10 +55,9 @@ describe('renderer/utils/forges/gitea/client.ts', () => {
     it('includes read status when fetchReadNotifications is true', async () => {
       fetchMock().mockResolvedValueOnce(jsonResponse([]));
 
-      await listGiteaNotifications(mockGiteaAccount, {
-        fetchAllNotifications: false,
-        fetchReadNotifications: true,
-      } as SettingsState);
+      useSettingsStore.setState({ fetchAllNotifications: false, fetchReadNotifications: true });
+
+      await listGiteaNotifications(mockGiteaAccount);
 
       const calledUrl = fetchMock().mock.calls[0][0] as string;
       expect(calledUrl).toContain('status-types=unread');
@@ -70,10 +70,9 @@ describe('renderer/utils/forges/gitea/client.ts', () => {
         .mockResolvedValueOnce(jsonResponse([{ id: 100 }]))
         .mockResolvedValueOnce(jsonResponse([]));
 
-      const result = await listGiteaNotifications(mockGiteaAccount, {
-        fetchAllNotifications: true,
-        fetchReadNotifications: false,
-      } as SettingsState);
+      useSettingsStore.setState({ fetchAllNotifications: true, fetchReadNotifications: false });
+
+      const result = await listGiteaNotifications(mockGiteaAccount);
 
       expect(result).toHaveLength(101);
       expect(fetchMock()).toHaveBeenCalledTimes(2);
@@ -87,20 +86,14 @@ describe('renderer/utils/forges/gitea/client.ts', () => {
         }),
       );
 
-      await expect(
-        listGiteaNotifications(mockGiteaAccount, {
-          fetchAllNotifications: false,
-          fetchReadNotifications: false,
-        } as SettingsState),
-      ).rejects.toThrow(/^Gitea API 403 Forbidden$/);
+      useSettingsStore.setState({ fetchAllNotifications: false, fetchReadNotifications: false });
+
+      await expect(listGiteaNotifications(mockGiteaAccount)).rejects.toThrow(
+        /^Gitea API 403 Forbidden$/,
+      );
       // The thrown error must not include the response body — a hostile
       // server could echo back the Authorization header into logs.
-      await expect(
-        listGiteaNotifications(mockGiteaAccount, {
-          fetchAllNotifications: false,
-          fetchReadNotifications: false,
-        } as SettingsState),
-      ).rejects.toThrow();
+      await expect(listGiteaNotifications(mockGiteaAccount)).rejects.toThrow();
     });
   });
 

--- a/src/renderer/utils/forges/gitea/client.ts
+++ b/src/renderer/utils/forges/gitea/client.ts
@@ -1,4 +1,6 @@
-import type { Account, Hostname, SettingsState } from '../../../types';
+import { useSettingsStore } from '../../../stores';
+
+import type { Account, Hostname } from '../../../types';
 import type { GiteaNotificationThread, GiteaUser } from './types';
 
 import { isValidHostname } from '../../auth/utils';
@@ -53,7 +55,9 @@ async function giteaRequest<T>(account: Account, pathname: string, init?: Reques
   return response.json() as Promise<T>;
 }
 
-function buildNotificationQuery(settings: SettingsState): string {
+function buildNotificationQuery(): string {
+  const settings = useSettingsStore.getState();
+
   const params = new URLSearchParams();
   params.set('limit', String(PAGE_SIZE));
 
@@ -66,13 +70,10 @@ function buildNotificationQuery(settings: SettingsState): string {
   return params.toString();
 }
 
-export async function listGiteaNotifications(
-  account: Account,
-  settings: SettingsState,
-): Promise<GiteaNotificationThread[]> {
-  const query = buildNotificationQuery(settings);
+export async function listGiteaNotifications(account: Account): Promise<GiteaNotificationThread[]> {
+  const query = buildNotificationQuery();
 
-  if (!settings.fetchAllNotifications) {
+  if (!useSettingsStore.getState().fetchAllNotifications) {
     return giteaRequest<GiteaNotificationThread[]>(account, `notifications?${query}&page=1`);
   }
 

--- a/src/renderer/utils/forges/gitea/client.ts
+++ b/src/renderer/utils/forges/gitea/client.ts
@@ -1,4 +1,4 @@
-import { useSettingsStore } from '../../../stores';
+import useSettingsStore from '../../../stores/useSettingsStore';
 
 import type { Account, Hostname } from '../../../types';
 import type { GiteaNotificationThread, GiteaUser } from './types';

--- a/src/renderer/utils/forges/github/adapter.test.ts
+++ b/src/renderer/utils/forges/github/adapter.test.ts
@@ -2,7 +2,7 @@ import { AppsIcon, KeyIcon, PersonIcon } from '@primer/octicons-react';
 
 import { mockGitHubCloudAccount } from '../../../__mocks__/account-mocks';
 
-import type { Hostname, Link, SettingsState, Token } from '../../../types';
+import type { Hostname, Link, Token } from '../../../types';
 
 import { githubAdapter } from './adapter';
 import * as client from './client';
@@ -102,7 +102,6 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
 
   describe('listNotifications', () => {
     it('lists notifications and transforms them to GitifyNotification', async () => {
-      const settings = {} as SettingsState;
       vi.spyOn(client, 'listNotificationsForAuthenticatedUser').mockResolvedValue([
         {
           id: '1',
@@ -128,7 +127,7 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
         },
       ] as unknown as Awaited<ReturnType<typeof client.listNotificationsForAuthenticatedUser>>);
 
-      const result = await githubAdapter.listNotifications(mockGitHubCloudAccount, settings);
+      const result = await githubAdapter.listNotifications(mockGitHubCloudAccount);
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('1');

--- a/src/renderer/utils/forges/github/adapter.ts
+++ b/src/renderer/utils/forges/github/adapter.ts
@@ -2,7 +2,7 @@ import { AppsIcon, KeyIcon, MarkGithubIcon, PersonIcon } from '@primer/octicons-
 
 import { Constants } from '../../../constants';
 
-import type { Account, Link, RawGitifyNotification, SettingsState } from '../../../types';
+import type { Account, Link, RawGitifyNotification } from '../../../types';
 import type { AuthMethod } from '../../auth/types';
 import type { ForgeAdapter, NotificationDisplayHelpers, RefreshAccountData } from '../types';
 
@@ -52,11 +52,8 @@ async function fetchAuthenticatedUser(account: Account): Promise<RefreshAccountD
   };
 }
 
-async function listNotifications(
-  account: Account,
-  settings: SettingsState,
-): Promise<RawGitifyNotification[]> {
-  const raw = await listNotificationsForAuthenticatedUser(account, settings);
+async function listNotifications(account: Account): Promise<RawGitifyNotification[]> {
+  const raw = await listNotificationsForAuthenticatedUser(account);
   return transformNotifications(raw, account);
 }
 

--- a/src/renderer/utils/forges/github/client.test.ts
+++ b/src/renderer/utils/forges/github/client.test.ts
@@ -8,7 +8,9 @@ import {
 
 import { Constants } from '../../../constants';
 
-import type { Link, SettingsState } from '../../../types';
+import { useSettingsStore } from '../../../stores';
+
+import type { Link } from '../../../types';
 
 import {
   fetchAuthenticatedUserDetails,
@@ -125,16 +127,13 @@ describe('renderer/utils/forges/github/client.ts', () => {
 
   describe('listNotificationsForAuthenticatedUser', () => {
     it('should list only participating notifications for user', async () => {
-      const mockSettings: Partial<SettingsState> = {
+      useSettingsStore.setState({
         participating: true,
         fetchReadNotifications: false,
         fetchAllNotifications: false,
-      };
+      });
 
-      await listNotificationsForAuthenticatedUser(
-        mockGitHubCloudAccount,
-        mockSettings as SettingsState,
-      );
+      await listNotificationsForAuthenticatedUser(mockGitHubCloudAccount);
 
       expect(createOctokitClientSpy).toHaveBeenCalledWith(mockGitHubCloudAccount, 'rest');
       expect(mockOctokit.rest.activity.listNotificationsForAuthenticatedUser).toHaveBeenCalledWith({
@@ -148,16 +147,13 @@ describe('renderer/utils/forges/github/client.ts', () => {
     });
 
     it('should list participating and watching notifications for user', async () => {
-      const mockSettings: Partial<SettingsState> = {
+      useSettingsStore.setState({
         participating: false,
         fetchReadNotifications: false,
         fetchAllNotifications: false,
-      };
+      });
 
-      await listNotificationsForAuthenticatedUser(
-        mockGitHubCloudAccount,
-        mockSettings as SettingsState,
-      );
+      await listNotificationsForAuthenticatedUser(mockGitHubCloudAccount);
 
       expect(createOctokitClientSpy).toHaveBeenCalledWith(mockGitHubCloudAccount, 'rest');
       expect(mockOctokit.rest.activity.listNotificationsForAuthenticatedUser).toHaveBeenCalledWith({
@@ -171,16 +167,13 @@ describe('renderer/utils/forges/github/client.ts', () => {
     });
 
     it('should list read and done notifications for user', async () => {
-      const mockSettings: Partial<SettingsState> = {
+      useSettingsStore.setState({
         participating: false,
         fetchReadNotifications: true,
         fetchAllNotifications: false,
-      };
+      });
 
-      await listNotificationsForAuthenticatedUser(
-        mockGitHubCloudAccount,
-        mockSettings as SettingsState,
-      );
+      await listNotificationsForAuthenticatedUser(mockGitHubCloudAccount);
 
       expect(createOctokitClientSpy).toHaveBeenCalledWith(mockGitHubCloudAccount, 'rest');
       expect(mockOctokit.rest.activity.listNotificationsForAuthenticatedUser).toHaveBeenCalledWith({
@@ -194,16 +187,13 @@ describe('renderer/utils/forges/github/client.ts', () => {
     });
 
     it('should unpaginate notifications list for user', async () => {
-      const mockSettings: Partial<SettingsState> = {
+      useSettingsStore.setState({
         participating: false,
         fetchReadNotifications: false,
         fetchAllNotifications: true,
-      };
+      });
 
-      await listNotificationsForAuthenticatedUser(
-        mockGitHubCloudAccount,
-        mockSettings as SettingsState,
-      );
+      await listNotificationsForAuthenticatedUser(mockGitHubCloudAccount);
 
       expect(createOctokitClientSpy).toHaveBeenCalledWith(mockGitHubCloudAccount, 'rest');
       expect(mockOctokit.paginate).toHaveBeenCalledWith(

--- a/src/renderer/utils/forges/github/client.ts
+++ b/src/renderer/utils/forges/github/client.ts
@@ -1,6 +1,8 @@
 import { Constants } from '../../../constants';
 
-import type { Account, Link, RawGitifyNotification, SettingsState } from '../../../types';
+import { useSettingsStore } from '../../../stores';
+
+import type { Account, Link, RawGitifyNotification } from '../../../types';
 import type {
   GetCommitCommentResponse,
   GetCommitResponse,
@@ -49,8 +51,8 @@ export async function fetchAuthenticatedUserDetails(account: Account) {
  */
 export async function listNotificationsForAuthenticatedUser(
   account: Account,
-  settings: SettingsState,
 ): Promise<ListNotificationsForAuthenticatedUserResponse> {
+  const settings = useSettingsStore.getState();
   const octokit = await createOctokitClient(account, 'rest');
 
   if (settings.fetchAllNotifications) {

--- a/src/renderer/utils/forges/github/client.ts
+++ b/src/renderer/utils/forges/github/client.ts
@@ -1,6 +1,6 @@
 import { Constants } from '../../../constants';
 
-import { useSettingsStore } from '../../../stores';
+import useSettingsStore from '../../../stores/useSettingsStore';
 
 import type { Account, Link, RawGitifyNotification } from '../../../types';
 import type {

--- a/src/renderer/utils/forges/github/enrich.test.ts
+++ b/src/renderer/utils/forges/github/enrich.test.ts
@@ -1,5 +1,4 @@
 import { mockPartialGitifyNotification } from '../../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../../__mocks__/state-mocks';
 
 import type { GitifyRepository, Link } from '../../../types';
 
@@ -45,7 +44,7 @@ describe('renderer/utils/forges/github/enrich.ts', () => {
 
     vi.mocked(client.fetchIssueByNumber).mockRejectedValue(mockError);
 
-    const [result] = await enrichGitHubNotifications([mockNotification], mockSettings);
+    const [result] = await enrichGitHubNotifications([mockNotification]);
 
     expect(result).toBeDefined();
     expect(rendererLogErrorSpy).toHaveBeenCalledWith(

--- a/src/renderer/utils/forges/github/enrich.ts
+++ b/src/renderer/utils/forges/github/enrich.ts
@@ -1,4 +1,4 @@
-import type { GitifySubject, RawGitifyNotification, SettingsState } from '../../../types';
+import type { GitifySubject, RawGitifyNotification } from '../../../types';
 
 import { rendererLogError, rendererLogWarn, toError } from '../../core/logger';
 import { fetchNotificationDetailsForList } from './client';
@@ -23,14 +23,11 @@ export const GITHUB_API_MERGE_BATCH_SIZE = 100;
  */
 export async function enrichGitHubNotifications(
   notifications: RawGitifyNotification[],
-  settings: SettingsState,
 ): Promise<RawGitifyNotification[]> {
   const fragments = await fetchInBatches(notifications);
 
   return Promise.all(
-    notifications.map((notification) =>
-      enrichSingle(notification, settings, fragments.get(notification)),
-    ),
+    notifications.map((notification) => enrichSingle(notification, fragments.get(notification))),
   );
 }
 
@@ -67,14 +64,13 @@ async function fetchInBatches(
 
 async function enrichSingle(
   notification: RawGitifyNotification,
-  settings: SettingsState,
   fetchedData: FetchMergedDetailsTemplateQuery['repository'] | undefined,
 ): Promise<RawGitifyNotification> {
   let additionalSubjectDetails: Partial<GitifySubject> = {};
 
   try {
     const handler = createNotificationHandler(notification);
-    additionalSubjectDetails = await handler.enrich(notification, settings, fetchedData);
+    additionalSubjectDetails = await handler.enrich(notification, fetchedData);
   } catch (err) {
     rendererLogError(
       'enrichGitHubNotifications',

--- a/src/renderer/utils/forges/github/handlers/checkSuite.test.ts
+++ b/src/renderer/utils/forges/github/handlers/checkSuite.test.ts
@@ -1,5 +1,4 @@
 import { mockPartialGitifyNotification } from '../../../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../../../__mocks__/state-mocks';
 
 import type { GitifyNotification } from '../../../../types';
 import { type GitifyCheckSuiteStatus, IconColor, type Link } from '../../../../types';
@@ -14,7 +13,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
         type: 'CheckSuite',
       });
 
-      const result = await checkSuiteHandler.enrich(mockNotification, mockSettings);
+      const result = await checkSuiteHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: 'CANCELLED',
@@ -30,7 +29,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
         type: 'CheckSuite',
       });
 
-      const result = await checkSuiteHandler.enrich(mockNotification, mockSettings);
+      const result = await checkSuiteHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: 'FAILURE',
@@ -46,7 +45,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
         type: 'CheckSuite',
       });
 
-      const result = await checkSuiteHandler.enrich(mockNotification, mockSettings);
+      const result = await checkSuiteHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: 'FAILURE',
@@ -62,7 +61,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
         type: 'CheckSuite',
       });
 
-      const result = await checkSuiteHandler.enrich(mockNotification, mockSettings);
+      const result = await checkSuiteHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: 'FAILURE',
@@ -78,7 +77,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
         type: 'CheckSuite',
       });
 
-      const result = await checkSuiteHandler.enrich(mockNotification, mockSettings);
+      const result = await checkSuiteHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: 'SKIPPED',
@@ -94,7 +93,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
         type: 'CheckSuite',
       });
 
-      const result = await checkSuiteHandler.enrich(mockNotification, mockSettings);
+      const result = await checkSuiteHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: 'SUCCESS',
@@ -110,7 +109,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
         type: 'CheckSuite',
       });
 
-      const result = await checkSuiteHandler.enrich(mockNotification, mockSettings);
+      const result = await checkSuiteHandler.enrich(mockNotification);
 
       // Returns empty object when state cannot be determined
       expect(result).toEqual({});
@@ -122,7 +121,7 @@ describe('renderer/utils/notifications/handlers/checkSuite.ts', () => {
         type: 'CheckSuite',
       });
 
-      const result = await checkSuiteHandler.enrich(mockNotification, mockSettings);
+      const result = await checkSuiteHandler.enrich(mockNotification);
 
       // Returns empty object when title cannot be parsed
       expect(result).toEqual({});

--- a/src/renderer/utils/forges/github/handlers/checkSuite.ts
+++ b/src/renderer/utils/forges/github/handlers/checkSuite.ts
@@ -9,7 +9,6 @@ import {
   type GitifySubject,
   IconColor,
   type Link,
-  type SettingsState,
 } from '../../../../types';
 
 import { DefaultHandler, defaultHandler } from './default';
@@ -24,10 +23,7 @@ export interface CheckSuiteAttributes {
 }
 
 class CheckSuiteHandler extends DefaultHandler {
-  override async enrich(
-    notification: GitifyNotification,
-    _settings: SettingsState,
-  ): Promise<Partial<GitifySubject>> {
+  override async enrich(notification: GitifyNotification): Promise<Partial<GitifySubject>> {
     const state = getCheckSuiteAttributes(notification)?.status;
 
     if (state) {

--- a/src/renderer/utils/forges/github/handlers/commit.test.ts
+++ b/src/renderer/utils/forges/github/handlers/commit.test.ts
@@ -1,5 +1,4 @@
 import { mockPartialGitifyNotification } from '../../../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../../../__mocks__/state-mocks';
 import { mockRawUser } from '../__mocks__/response-mocks';
 
 import { useFiltersStore } from '../../../../stores';
@@ -35,7 +34,7 @@ describe('renderer/utils/notifications/handlers/commit.ts', () => {
         user: mockCommenter,
       } as GetCommitCommentResponse);
 
-      const result = await commitHandler.enrich(mockNotification, mockSettings);
+      const result = await commitHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: undefined,
@@ -72,7 +71,7 @@ describe('renderer/utils/notifications/handlers/commit.ts', () => {
         author: mockAuthor,
       } as GetCommitResponse);
 
-      const result = await commitHandler.enrich(mockNotification, mockSettings);
+      const result = await commitHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: undefined,
@@ -103,7 +102,7 @@ describe('renderer/utils/notifications/handlers/commit.ts', () => {
         author: null,
       } as GetCommitResponse);
 
-      const result = await commitHandler.enrich(mockNotification, mockSettings);
+      const result = await commitHandler.enrich(mockNotification);
 
       expect(result.user).toBeUndefined();
       expect(result.author).toBeUndefined();
@@ -120,7 +119,7 @@ describe('renderer/utils/notifications/handlers/commit.ts', () => {
         latestCommentUrl: null,
       });
 
-      const result = await commitHandler.enrich(mockNotification, mockSettings);
+      const result = await commitHandler.enrich(mockNotification);
 
       // Returns empty object when filtered (no API call made)
       expect(result).toEqual({});

--- a/src/renderer/utils/forges/github/handlers/commit.ts
+++ b/src/renderer/utils/forges/github/handlers/commit.ts
@@ -9,7 +9,6 @@ import type {
   GitifyNotificationUser,
   GitifySubject,
   Link,
-  SettingsState,
 } from '../../../../types';
 import type { RawUser } from '../types';
 
@@ -33,10 +32,7 @@ function toNotificationUser(
 }
 
 class CommitHandler extends DefaultHandler {
-  override async enrich(
-    notification: GitifyNotification,
-    _settings: SettingsState,
-  ): Promise<Partial<GitifySubject>> {
+  override async enrich(notification: GitifyNotification): Promise<Partial<GitifySubject>> {
     const commitState: GitifyNotificationState | undefined = undefined; // Commit notifications are stateless
 
     // Return early if this notification would be hidden by filters

--- a/src/renderer/utils/forges/github/handlers/default.test.ts
+++ b/src/renderer/utils/forges/github/handlers/default.test.ts
@@ -1,5 +1,4 @@
 import { mockPartialGitifyNotification } from '../../../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../../../__mocks__/state-mocks';
 
 import type { GitifyNotification } from '../../../../types';
 import { type GitifyNotificationState, IconColor, type Link } from '../../../../types';
@@ -20,7 +19,7 @@ describe('renderer/utils/notifications/handlers/default.ts', () => {
         type: 'RepositoryInvitation',
       });
 
-      const result = await defaultHandler.enrich(mockNotification, mockSettings);
+      const result = await defaultHandler.enrich(mockNotification);
 
       // Default handler returns empty object (no enrichment)
       expect(result).toEqual({});

--- a/src/renderer/utils/forges/github/handlers/default.ts
+++ b/src/renderer/utils/forges/github/handlers/default.ts
@@ -8,7 +8,6 @@ import {
   type GitifySubject,
   IconColor,
   type Link,
-  type SettingsState,
   type UserType,
 } from '../../../../types';
 import type { NotificationTypeHandler } from './types';
@@ -16,10 +15,7 @@ import type { NotificationTypeHandler } from './types';
 export class DefaultHandler implements NotificationTypeHandler {
   supportsMergedQueryEnrichment = false;
 
-  async enrich(
-    _notification: GitifyNotification,
-    _settings: SettingsState,
-  ): Promise<Partial<GitifySubject>> {
+  async enrich(_notification: GitifyNotification): Promise<Partial<GitifySubject>> {
     return {};
   }
 

--- a/src/renderer/utils/forges/github/handlers/discussion.test.ts
+++ b/src/renderer/utils/forges/github/handlers/discussion.test.ts
@@ -1,5 +1,4 @@
 import { mockPartialGitifyNotification } from '../../../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../../../__mocks__/state-mocks';
 import {
   mockAuthor,
   mockCommenter,
@@ -55,7 +54,7 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
         },
       } satisfies FetchDiscussionByNumberQuery);
 
-      const result = await discussionHandler.enrich(mockNotification, mockSettings);
+      const result = await discussionHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -89,7 +88,7 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
         },
       } satisfies FetchDiscussionByNumberQuery);
 
-      const result = await discussionHandler.enrich(mockNotification, mockSettings);
+      const result = await discussionHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -126,7 +125,7 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
         },
       } satisfies FetchDiscussionByNumberQuery);
 
-      const result = await discussionHandler.enrich(mockNotification, mockSettings);
+      const result = await discussionHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -168,7 +167,7 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
         },
       } satisfies FetchDiscussionByNumberQuery);
 
-      const result = await discussionHandler.enrich(mockNotification, mockSettings);
+      const result = await discussionHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -220,7 +219,7 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
         },
       } satisfies FetchDiscussionByNumberQuery);
 
-      const result = await discussionHandler.enrich(mockNotification, mockSettings);
+      const result = await discussionHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -289,7 +288,7 @@ describe('renderer/utils/notifications/handlers/discussion.ts', () => {
         },
       } satisfies FetchDiscussionByNumberQuery);
 
-      const result = await discussionHandler.enrich(mockNotification, mockSettings);
+      const result = await discussionHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,

--- a/src/renderer/utils/forges/github/handlers/discussion.ts
+++ b/src/renderer/utils/forges/github/handlers/discussion.ts
@@ -16,7 +16,6 @@ import {
   type GitifySubject,
   IconColor,
   type Link,
-  type SettingsState,
 } from '../../../../types';
 
 import { fetchDiscussionByNumber } from '../client';
@@ -33,7 +32,6 @@ class DiscussionHandler extends DefaultHandler {
 
   override async enrich(
     notification: GitifyNotification,
-    _settings: SettingsState,
     fetchedData?: DiscussionDetailsFragment,
   ): Promise<Partial<GitifySubject>> {
     const discussion =

--- a/src/renderer/utils/forges/github/handlers/issue.test.ts
+++ b/src/renderer/utils/forges/github/handlers/issue.test.ts
@@ -1,5 +1,4 @@
 import { mockPartialGitifyNotification } from '../../../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../../../__mocks__/state-mocks';
 import {
   mockAuthor,
   mockCommenter,
@@ -51,7 +50,7 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
         },
       } satisfies FetchIssueByNumberQuery);
 
-      const result = await issueHandler.enrich(mockNotification, mockSettings);
+      const result = await issueHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -89,7 +88,7 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
         },
       } satisfies FetchIssueByNumberQuery);
 
-      const result = await issueHandler.enrich(mockNotification, mockSettings);
+      const result = await issueHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -139,7 +138,7 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
         },
       } satisfies FetchIssueByNumberQuery);
 
-      const result = await issueHandler.enrich(mockNotification, mockSettings);
+      const result = await issueHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -186,7 +185,7 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
         },
       } satisfies FetchIssueByNumberQuery);
 
-      const result = await issueHandler.enrich(mockNotification, mockSettings);
+      const result = await issueHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -227,7 +226,7 @@ describe('renderer/utils/notifications/handlers/issue.ts', () => {
         },
       } satisfies FetchIssueByNumberQuery);
 
-      const result = await issueHandler.enrich(mockNotification, mockSettings);
+      const result = await issueHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,

--- a/src/renderer/utils/forges/github/handlers/issue.ts
+++ b/src/renderer/utils/forges/github/handlers/issue.ts
@@ -8,13 +8,7 @@ import {
   SkipIcon,
 } from '@primer/octicons-react';
 
-import type {
-  GitifyIssueState,
-  GitifyNotification,
-  GitifySubject,
-  Link,
-  SettingsState,
-} from '../../../../types';
+import type { GitifyIssueState, GitifyNotification, GitifySubject, Link } from '../../../../types';
 import { IconColor } from '../../../../types';
 
 import { fetchIssueByNumber } from '../client';
@@ -27,7 +21,6 @@ class IssueHandler extends DefaultHandler {
 
   override async enrich(
     notification: GitifyNotification,
-    _settings: SettingsState,
     fetchedData?: IssueDetailsFragment,
   ): Promise<Partial<GitifySubject>> {
     const issue = fetchedData ?? (await fetchIssueByNumber(notification)).repository?.issue;

--- a/src/renderer/utils/forges/github/handlers/pullRequest.test.ts
+++ b/src/renderer/utils/forges/github/handlers/pullRequest.test.ts
@@ -1,5 +1,4 @@
 import { mockPartialGitifyNotification } from '../../../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../../../__mocks__/state-mocks';
 import {
   mockAuthor,
   mockCommenter,
@@ -63,7 +62,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
         },
       } satisfies FetchPullRequestByNumberQuery);
 
-      const result = await pullRequestHandler.enrich(mockNotification, mockSettings);
+      const result = await pullRequestHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -104,7 +103,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
         },
       } satisfies FetchPullRequestByNumberQuery);
 
-      const result = await pullRequestHandler.enrich(mockNotification, mockSettings);
+      const result = await pullRequestHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -145,7 +144,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
         },
       } satisfies FetchPullRequestByNumberQuery);
 
-      const result = await pullRequestHandler.enrich(mockNotification, mockSettings);
+      const result = await pullRequestHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -186,7 +185,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
         },
       } satisfies FetchPullRequestByNumberQuery);
 
-      const result = await pullRequestHandler.enrich(mockNotification, mockSettings);
+      const result = await pullRequestHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -239,7 +238,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
         },
       } satisfies FetchPullRequestByNumberQuery);
 
-      const result = await pullRequestHandler.enrich(mockNotification, mockSettings);
+      const result = await pullRequestHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -294,7 +293,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
         },
       } satisfies FetchPullRequestByNumberQuery);
 
-      const result = await pullRequestHandler.enrich(mockNotification, mockSettings);
+      const result = await pullRequestHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -341,7 +340,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
         },
       } satisfies FetchPullRequestByNumberQuery);
 
-      const result = await pullRequestHandler.enrich(mockNotification, mockSettings);
+      const result = await pullRequestHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,
@@ -385,7 +384,7 @@ describe('renderer/utils/notifications/handlers/pullRequest.ts', () => {
         },
       } satisfies FetchPullRequestByNumberQuery);
 
-      const result = await pullRequestHandler.enrich(mockNotification, mockSettings);
+      const result = await pullRequestHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         number: 123,

--- a/src/renderer/utils/forges/github/handlers/pullRequest.ts
+++ b/src/renderer/utils/forges/github/handlers/pullRequest.ts
@@ -17,7 +17,6 @@ import {
   IconColor,
   type Link,
   type ReviewRequestType,
-  type SettingsState,
 } from '../../../../types';
 
 import { formatGitHubNumber } from '../../../notifications/formatters';
@@ -34,7 +33,6 @@ class PullRequestHandler extends DefaultHandler {
 
   override async enrich(
     notification: GitifyNotification,
-    _settings: SettingsState,
     fetchedData?: PullRequestDetailsFragment,
   ): Promise<Partial<GitifySubject>> {
     const pr = fetchedData ?? (await fetchPullByNumber(notification)).repository?.pullRequest;

--- a/src/renderer/utils/forges/github/handlers/release.test.ts
+++ b/src/renderer/utils/forges/github/handlers/release.test.ts
@@ -1,5 +1,4 @@
 import { mockPartialGitifyNotification } from '../../../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../../../__mocks__/state-mocks';
 import { mockRawUser } from '../__mocks__/response-mocks';
 
 import { useFiltersStore } from '../../../../stores';
@@ -29,7 +28,7 @@ describe('renderer/utils/notifications/handlers/release.ts', () => {
         author: mockAuthor,
       } as GetReleaseResponse);
 
-      const result = await releaseHandler.enrich(mockNotification, mockSettings);
+      const result = await releaseHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: undefined,
@@ -51,7 +50,7 @@ describe('renderer/utils/notifications/handlers/release.ts', () => {
     it('return early if release state filtered', async () => {
       useFiltersStore.setState({ states: ['closed'] });
 
-      const result = await releaseHandler.enrich(mockNotification, mockSettings);
+      const result = await releaseHandler.enrich(mockNotification);
 
       // Returns empty object when filtered (no API call made)
       expect(result).toEqual({});

--- a/src/renderer/utils/forges/github/handlers/release.ts
+++ b/src/renderer/utils/forges/github/handlers/release.ts
@@ -9,7 +9,6 @@ import type {
   GitifyNotificationUser,
   GitifySubject,
   Link,
-  SettingsState,
   UserType,
 } from '../../../../types';
 
@@ -18,10 +17,7 @@ import { getRelease } from '../client';
 import { DefaultHandler, defaultHandler } from './default';
 
 class ReleaseHandler extends DefaultHandler {
-  override async enrich(
-    notification: GitifyNotification,
-    _settings: SettingsState,
-  ): Promise<Partial<GitifySubject>> {
+  override async enrich(notification: GitifyNotification): Promise<Partial<GitifySubject>> {
     const releaseState: GitifyNotificationState | undefined = undefined; // Release notifications are stateless
 
     // Return early if this notification would be hidden by filters

--- a/src/renderer/utils/forges/github/handlers/types.ts
+++ b/src/renderer/utils/forges/github/handlers/types.ts
@@ -7,7 +7,6 @@ import type {
   IconColor,
   Link,
   RawGitifyNotification,
-  SettingsState,
   UserType,
 } from '../../../../types';
 
@@ -21,12 +20,10 @@ export interface NotificationTypeHandler {
    * Enriches a base notification with additional information (state, author, metrics, etc).
    *
    * @param notification The base notification being enriched
-   * @param settings The app settings, which for some handlers may not be used during enrichment.
    * @param fetchedData Previously fetched enrichment data (upstream).  If present, then enrich will skip fetching detailed data inline.
    */
   enrich(
     notification: RawGitifyNotification,
-    settings: SettingsState,
     fetchedData?: unknown,
   ): Promise<Partial<GitifySubject>>;
 

--- a/src/renderer/utils/forges/github/handlers/workflowRun.test.ts
+++ b/src/renderer/utils/forges/github/handlers/workflowRun.test.ts
@@ -1,5 +1,4 @@
 import { mockPartialGitifyNotification } from '../../../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../../../__mocks__/state-mocks';
 
 import type { GitifyNotification, Link } from '../../../../types';
 
@@ -13,7 +12,7 @@ describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
         type: 'WorkflowRun',
       });
 
-      const result = await workflowRunHandler.enrich(mockNotification, mockSettings);
+      const result = await workflowRunHandler.enrich(mockNotification);
 
       expect(result).toEqual({
         state: 'WAITING',
@@ -28,7 +27,7 @@ describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
         type: 'WorkflowRun',
       });
 
-      const result = await workflowRunHandler.enrich(mockNotification, mockSettings);
+      const result = await workflowRunHandler.enrich(mockNotification);
 
       // Returns empty object when state cannot be determined
       expect(result).toEqual({});
@@ -40,7 +39,7 @@ describe('renderer/utils/notifications/handlers/workflowRun.ts', () => {
         type: 'WorkflowRun',
       });
 
-      const result = await workflowRunHandler.enrich(mockNotification, mockSettings);
+      const result = await workflowRunHandler.enrich(mockNotification);
 
       // Returns empty object when title cannot be parsed
       expect(result).toEqual({});

--- a/src/renderer/utils/forges/github/handlers/workflowRun.ts
+++ b/src/renderer/utils/forges/github/handlers/workflowRun.ts
@@ -8,7 +8,6 @@ import type {
   GitifyNotification,
   GitifySubject,
   Link,
-  SettingsState,
 } from '../../../../types';
 
 import { DefaultHandler } from './default';
@@ -21,10 +20,7 @@ export interface WorkflowRunAttributes {
 }
 
 class WorkflowRunHandler extends DefaultHandler {
-  override async enrich(
-    notification: GitifyNotification,
-    _settings: SettingsState,
-  ): Promise<Partial<GitifySubject>> {
+  override async enrich(notification: GitifyNotification): Promise<Partial<GitifySubject>> {
     const state = getWorkflowRunAttributes(notification)?.status;
 
     if (state) {

--- a/src/renderer/utils/forges/types.ts
+++ b/src/renderer/utils/forges/types.ts
@@ -10,7 +10,6 @@ import type {
   IconColor,
   Link,
   RawGitifyNotification,
-  SettingsState,
   Token,
   UserType,
 } from '../../types';
@@ -119,7 +118,7 @@ export interface ForgeAdapter {
    * Returns `RawGitifyNotification[]` — `display` is populated later by the
    * orchestrator's `formatNotification` step.
    */
-  listNotifications(account: Account, settings: SettingsState): Promise<RawGitifyNotification[]>;
+  listNotifications(account: Account): Promise<RawGitifyNotification[]>;
 
   markThreadAsRead(account: Account, threadId: string): Promise<void>;
   markThreadAsDone(account: Account, threadId: string): Promise<void>;
@@ -134,10 +133,7 @@ export interface ForgeAdapter {
    * @see ../notifications/notifications.ts `enrichNotifications` — orchestrator
    *      that delegates here when the user has detailed notifications enabled.
    */
-  enrichNotifications?(
-    notifications: RawGitifyNotification[],
-    settings: SettingsState,
-  ): Promise<RawGitifyNotification[]>;
+  enrichNotifications?(notifications: RawGitifyNotification[]): Promise<RawGitifyNotification[]>;
 
   /**
    * GET an arbitrary forge URL and return JSON. Used by notification

--- a/src/renderer/utils/notifications/notifications.test.ts
+++ b/src/renderer/utils/notifications/notifications.test.ts
@@ -7,7 +7,6 @@ import {
   mockPartialGitifyNotification,
   mockSingleAccountNotifications,
 } from '../../__mocks__/notifications-mocks';
-import { mockSettings } from '../../__mocks__/state-mocks';
 
 import { useSettingsStore } from '../../stores';
 
@@ -16,7 +15,6 @@ import {
   type GitifyNotification,
   GroupBy,
   type Link,
-  type SettingsState,
 } from '../../types';
 
 import * as apiClient from '../forges/github/client';
@@ -108,12 +106,9 @@ describe('renderer/utils/notifications/notifications.ts', () => {
         type: 'Issue',
         url: 'https://api.github.com/repos/gitify-app/notifications-test/issues/1' as Link,
       }) as GitifyNotification;
-      const settings: SettingsState = {
-        ...mockSettings,
-        detailedNotifications: false,
-      };
+      useSettingsStore.setState({ detailedNotifications: false });
 
-      const result = await enrichNotifications([notification], settings);
+      const result = await enrichNotifications([notification]);
 
       expect(result).toEqual([notification]);
     });
@@ -125,12 +120,9 @@ describe('renderer/utils/notifications/notifications.ts', () => {
         type: 'CheckSuite',
         url: null,
       }) as GitifyNotification;
-      const settings: SettingsState = {
-        ...mockSettings,
-        detailedNotifications: true,
-      };
+      useSettingsStore.setState({ detailedNotifications: true });
 
-      const result = await enrichNotifications([notification], settings);
+      const result = await enrichNotifications([notification]);
 
       expect(result).toHaveLength(1);
       expect(result[0].subject.title).toBe('CI workflow run');
@@ -138,12 +130,9 @@ describe('renderer/utils/notifications/notifications.ts', () => {
     });
 
     it('should handle empty notifications array', async () => {
-      const settings: SettingsState = {
-        ...mockSettings,
-        detailedNotifications: true,
-      };
+      useSettingsStore.setState({ detailedNotifications: true });
 
-      const result = await enrichNotifications([], settings);
+      const result = await enrichNotifications([]);
 
       expect(result).toEqual([]);
       expect(apiClient.fetchNotificationDetailsForList).not.toHaveBeenCalled();
@@ -165,12 +154,9 @@ describe('renderer/utils/notifications/notifications.ts', () => {
         }),
       ) as GitifyNotification[];
 
-      const settings: SettingsState = {
-        ...mockSettings,
-        detailedNotifications: true,
-      };
+      useSettingsStore.setState({ detailedNotifications: true });
 
-      await enrichNotifications(notifications, settings);
+      await enrichNotifications(notifications);
 
       // Should be called 3 times: batches of 100, 100, 50
       expect(fetchNotificationDetailsForListSpy).toHaveBeenCalledTimes(3);
@@ -200,12 +186,9 @@ describe('renderer/utils/notifications/notifications.ts', () => {
         }),
       ) as GitifyNotification[];
 
-      const settings: SettingsState = {
-        ...mockSettings,
-        detailedNotifications: true,
-      };
+      useSettingsStore.setState({ detailedNotifications: true });
 
-      await enrichNotifications(notifications, settings);
+      await enrichNotifications(notifications);
 
       // Should be called once for single batch
       expect(fetchNotificationDetailsForListSpy).toHaveBeenCalledTimes(1);

--- a/src/renderer/utils/notifications/notifications.ts
+++ b/src/renderer/utils/notifications/notifications.ts
@@ -1,11 +1,6 @@
 import { useAccountsStore, useSettingsStore } from '../../stores';
 
-import type {
-  AccountNotifications,
-  AuthState,
-  RawGitifyNotification,
-  SettingsState,
-} from '../../types';
+import type { AccountNotifications, AuthState, RawGitifyNotification } from '../../types';
 
 import { determineFailureType } from '../api/errors';
 import { rendererLogError, toError } from '../core/logger';
@@ -37,11 +32,11 @@ export function getUnreadNotificationCount(accountNotifications: AccountNotifica
   );
 }
 
-function getNotifications(auth: AuthState, settings: SettingsState) {
+function getNotifications(auth: AuthState) {
   return auth.accounts.map((account) => {
     return {
       account,
-      notifications: getAdapter(account).listNotifications(account, settings),
+      notifications: getAdapter(account).listNotifications(account),
     };
   });
 }
@@ -62,10 +57,9 @@ function getNotifications(auth: AuthState, settings: SettingsState) {
  */
 export async function getAllNotifications(): Promise<AccountNotifications[]> {
   const auth: AuthState = { accounts: useAccountsStore.getState().accounts };
-  const settings = useSettingsStore.getState();
 
   const accountNotifications: AccountNotifications[] = await Promise.all(
-    getNotifications(auth, settings)
+    getNotifications(auth)
       .filter((response) => !!response)
       .map(async (accountNotifications) => {
         try {
@@ -79,7 +73,7 @@ export async function getAllNotifications(): Promise<AccountNotifications[]> {
           // become visible.
           const baseFiltered = filterBaseNotifications(notifications);
 
-          const enriched = await enrichNotifications(baseFiltered, settings);
+          const enriched = await enrichNotifications(baseFiltered);
           const enrichedById = new Map(
             enriched.map((notification) => [notification.id, notification]),
           );
@@ -123,14 +117,12 @@ export async function getAllNotifications(): Promise<AccountNotifications[]> {
  * GraphQL to avoid overwhelming the API.
  *
  * @param notifications - The notifications to enrich.
- * @param settings - Application settings; controls whether enrichment runs.
  * @returns The same notifications with subject fields populated from the API.
  */
 export async function enrichNotifications(
   notifications: RawGitifyNotification[],
-  settings: SettingsState,
 ): Promise<RawGitifyNotification[]> {
-  if (!settings.detailedNotifications || !notifications.length) {
+  if (!useSettingsStore.getState().detailedNotifications || !notifications.length) {
     return notifications;
   }
 
@@ -140,7 +132,7 @@ export async function enrichNotifications(
   if (!enrich) {
     return notifications;
   }
-  return enrich(notifications, settings);
+  return enrich(notifications);
 }
 
 /**


### PR DESCRIPTION
## Summary

Split from #3034. Pushes the settings-store boundary into the forge layer:

- `ForgeAdapter.listNotifications` / `enrichNotifications`, both forge clients, and the notification-type handlers no longer thread a `settings` parameter through every call; they read `useSettingsStore` where the values are consumed.
- The handlers' universally unused `_settings` parameter is removed.
- Forge clients import the settings store leaf module directly (not the stores barrel), keeping the module graph free of a stores -> forges -> stores import cycle.
- Forge tests seed the settings store instead of passing settings objects.
