### PR TITLE
refactor(storage): remove legacy storage key after migration

### DIFF
--- a/src/renderer/utils/core/storage.test.ts
+++ b/src/renderer/utils/core/storage.test.ts
@@ -20,7 +20,7 @@ describe('renderer/utils/core/storage.ts', () => {
     expect(localStorage.getItem(Constants.STORAGE.LEGACY)).toBeNull();
   });
 
-  it('migrates legacy auth and settings into the stores and marks the key as migrated', () => {
+  it('migrates legacy auth and settings into the stores and removes the legacy key', () => {
     localStorage.setItem(
       Constants.STORAGE.LEGACY,
       JSON.stringify({
@@ -36,9 +36,7 @@ describe('renderer/utils/core/storage.ts', () => {
     expect(useSettingsStore.getState().theme).toBe(Theme.DARK);
     expect(useSettingsStore.getState().playSound).toBe(false);
 
-    const marker = JSON.parse(localStorage.getItem(Constants.STORAGE.LEGACY)!);
-    expect(marker.migrated).toBe(true);
-    expect(marker.migratedAt).toBeDefined();
+    expect(localStorage.getItem(Constants.STORAGE.LEGACY)).toBeNull();
   });
 
   it('drops legacy accounts with invalid hostnames during migration', () => {
@@ -68,17 +66,13 @@ describe('renderer/utils/core/storage.ts', () => {
     expect(useAccountsStore.getState().accounts).toHaveLength(1);
   });
 
-  it('skips migration when already migrated', () => {
-    localStorage.setItem(
-      Constants.STORAGE.LEGACY,
-      JSON.stringify({ migrated: true, migratedAt: '2026-01-01T00:00:00Z' }),
-    );
+  it('removes a legacy key with no migratable data', () => {
+    localStorage.setItem(Constants.STORAGE.LEGACY, JSON.stringify({}));
 
     migrateLegacyStoreToZustand();
 
     expect(useAccountsStore.getState().accounts).toEqual([]);
-    const marker = JSON.parse(localStorage.getItem(Constants.STORAGE.LEGACY)!);
-    expect(marker.migratedAt).toBe('2026-01-01T00:00:00Z');
+    expect(localStorage.getItem(Constants.STORAGE.LEGACY)).toBeNull();
   });
 
   it('logs an error and leaves stores untouched on malformed legacy data', () => {

--- a/src/renderer/utils/core/storage.ts
+++ b/src/renderer/utils/core/storage.ts
@@ -22,18 +22,7 @@ export function migrateLegacyStoreToZustand() {
   }
 
   try {
-    const parsed = JSON.parse(existing);
-
-    // Skip if already migrated
-    if (parsed.migrated) {
-      rendererLogInfo(
-        'migrateLegacyStoreToZustand',
-        `Storage already migrated on ${parsed.migratedAt}`,
-      );
-      return;
-    }
-
-    const { auth, settings } = parsed;
+    const { auth, settings } = JSON.parse(existing);
 
     // Migrate auth to AccountsStore if it exists and store is empty
     if (auth?.accounts && useAccountsStore.getState().accounts.length === 0) {
@@ -49,14 +38,8 @@ export function migrateLegacyStoreToZustand() {
       useSettingsStore.setState(knownSettings);
     }
 
-    // Mark old storage key as migrated instead of removing it
-    localStorage.setItem(
-      Constants.STORAGE.LEGACY,
-      JSON.stringify({
-        migrated: true,
-        migratedAt: new Date().toISOString(),
-      }),
-    );
+    // Remove the legacy key so subsequent launches skip migration entirely
+    localStorage.removeItem(Constants.STORAGE.LEGACY);
 
     rendererLogInfo(
       'migrateLegacyStoreToZustand',


### PR DESCRIPTION
## Summary

Split from #3034. The legacy-storage migration now self-cleans:

- After a successful migration the `gitify-storage` key is removed instead of overwritten with a `{migrated}` marker, so subsequent launches short-circuit on a null read instead of parsing and logging on every startup.
- Full removal of the migration is intentionally NOT included: it has not shipped in a release yet, so deleting it would strand existing users' accounts and settings. It stays (isolated in `utils/core/storage.ts` with a removal TODO) until at least one release containing it has shipped.
