### PR TITLE
build: prepare `v7.0.1` release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitify",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "private": true,
   "description": "Git notifications on your menu bar.",
   "keywords": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@
 # =====================================================
 sonar.projectKey=gitify-app_gitify
 sonar.organization=gitify-app
-sonar.projectVersion=v7.0.0
+sonar.projectVersion=v7.0.1
 sonar.projectDescription=GitHub notifications on your menu bar.
 
 


### PR DESCRIPTION
Patch release for the v7 notification request storm (gitify-app/gitify#3065, fixed in gitify-app/gitify#3066).

https://github.com/gitify-app/gitify/milestone/64
