### PR TITLE
fix: drop cached forge clients on app reset

### DIFF
--- a/src/renderer/stores/useAccountsStore.test.ts
+++ b/src/renderer/stores/useAccountsStore.test.ts
@@ -14,6 +14,7 @@ import type { GetAuthenticatedUserResponse } from '../utils/forges/github/types'
 import { getRecommendedScopeNames } from '../utils/auth/scopes';
 import * as logger from '../utils/core/logger';
 import * as apiClient from '../utils/forges/github/client';
+import { getAdapter } from '../utils/forges/registry';
 import { DEFAULT_ACCOUNTS_STATE } from './defaults';
 import useAccountsStore from './useAccountsStore';
 
@@ -263,6 +264,26 @@ describe('renderer/stores/useAccountsStore.ts', () => {
 
       expect(result.current).toMatchObject(DEFAULT_ACCOUNTS_STATE);
       expect(result.current.accounts).toEqual([]);
+    });
+
+    test('should drop forge client state for every account', () => {
+      const onAccountTokenChangeSpy = vi
+        .spyOn(getAdapter(mockGitHubCloudAccount), 'onAccountTokenChange')
+        .mockImplementation(vi.fn());
+
+      useAccountsStore.setState({
+        accounts: [mockGitHubCloudAccount, mockGitHubEnterpriseServerAccount],
+      });
+
+      const { result } = renderHook(() => useAccountsStore());
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(onAccountTokenChangeSpy).toHaveBeenCalledTimes(2);
+      expect(onAccountTokenChangeSpy).toHaveBeenCalledWith(mockGitHubCloudAccount);
+      expect(onAccountTokenChangeSpy).toHaveBeenCalledWith(mockGitHubEnterpriseServerAccount);
     });
   });
 });

--- a/src/renderer/stores/useAccountsStore.ts
+++ b/src/renderer/stores/useAccountsStore.ts
@@ -166,6 +166,12 @@ const useAccountsStore = create<AccountsStore>()(
       },
 
       reset: () => {
+        // Drop forge-specific HTTP client state (e.g. cached authenticated
+        // Octokit clients) for every account being wiped.
+        for (const account of get().accounts) {
+          getAdapter(account).onAccountTokenChange?.(account);
+        }
+
         set({ ...DEFAULT_ACCOUNTS_STATE });
       },
     }),


### PR DESCRIPTION
Since the TanStack Query / store refactor, "Reset App" wiped accounts and the query cache but left authenticated Octokit clients cached in memory (v6 cleared them via `clearOctokitClientCache` in `AppContext`, and that call was dropped in the migration). `reset()` now drops per-account forge client state the same way `removeAccount` already does, so no token-bearing clients outlive a reset.
