### PR TITLE
fix: prevent Windows tray blur→hide race on window show (#3064)

### DIFF
--- a/src/main/lifecycle/window.ts
+++ b/src/main/lifecycle/window.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron';
 import type { Menubar } from 'electron-menubar';
 
-import { isMacOS } from '../../shared/platform';
+import { isMacOS, isWindows } from '../../shared/platform';
 
 import { WindowConfig } from '../config';
 import type MenuBuilder from '../menu';
@@ -60,6 +60,25 @@ export function configureWindowEvents(mb: Menubar, menuBuilder: MenuBuilder): vo
   win.on('hide', () => {
     menuBuilder.setWindowVisibility(false);
   });
+
+  // Windows tray blur race workaround:
+  // On Windows, clicking the tray icon may not transfer focus to the window,
+  // triggering electron-menubar's internal blur→hide timeout before first paint.
+  // Temporarily set alwaysOnTop so the blur handler emits 'focus-lost' instead
+  // of hiding; restore the user's preference after the blur window passes.
+  if (isWindows()) {
+    mb.on('after-show', () => {
+      const w = mb.window;
+      if (!w || w.isDestroyed()) return;
+      const restoreOnBlur = keepWindowOnBlur;
+      w.setAlwaysOnTop(true);
+      setTimeout(() => {
+        if (!w.isDestroyed()) {
+          w.setAlwaysOnTop(restoreOnBlur);
+        }
+      }, 400);
+    });
+  }
 
   app.on('before-quit', () => {
     isQuitting = true;


### PR DESCRIPTION
## Problem

Issue #3064: On Windows v7.0.0/v7.0.1, clicking the tray icon produces no visible result. The app runs in background (notifications, colored icon) but the window never appears. Silent failure — no errors in logs.

## Root Cause

\lectron-menubar\'s internal blur handler hides the window 100ms after it loses focus. On Windows, clicking the tray icon may not transfer focus to the window, causing the blur→hide timeout to fire immediately after \showWindow()\. When this timeout fires before the first paint cycle, the user sees no visible result.

Relevant Menubar.ts code:
\\\	ypescript
this._browserWindow.on('blur', () => {
  if (!this._browserWindow) return;
  this._browserWindow.isAlwaysOnTop()
    ? this.emit('focus-lost')
    : (this._blurTimeout = setTimeout(() => {
        this.hideWindow();
      }, 100));
});
\\\

If \lwaysOnTop\ is true, the blur handler emits \ocus-lost\ instead of hiding — this is the escape hatch.

## Fix

Listen for the \fter-show\ event and temporarily set \lwaysOnTop=true\ for 400ms after showing the window. This causes the blur handler to short-circuit via the \ocus-lost\ path instead of hiding. The user's \keepWindowOnBlur\ preference is restored after the blur race window passes.

Fixes #3064