### PR TITLE
chore(deps): update electron-menubar to v10.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "electron-log": "5.4.4",
-    "electron-menubar": "10.1.2",
+    "electron-menubar": "10.1.3",
     "electron-updater": "6.8.9",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 5.4.4
         version: 5.4.4
       electron-menubar:
-        specifier: 10.1.2
-        version: 10.1.2(electron@43.2.0(supports-color@10.2.2))
+        specifier: 10.1.3
+        version: 10.1.3(electron@43.2.0(supports-color@10.2.2))
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@10.2.2)
@@ -2559,8 +2559,8 @@ packages:
     resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
     engines: {node: '>= 14'}
 
-  electron-menubar@10.1.2:
-    resolution: {integrity: sha512-85n3aRTGAF6I6xWpglHRvsKTGalam10/dNgUDib6fSmPyOvXeIy9nq3xbL6BDUtphntBptGk0bLi/iB0ecBW+w==}
+  electron-menubar@10.1.3:
+    resolution: {integrity: sha512-5XRQCmYCiObJDvjROSGP3+MX/7AEA3qp5mVUtpo/CfOGCkhNA6q1dvhKnPC8B2+aKCJDjBQBMhgVW8pMMbedCQ==}
     peerDependencies:
       electron: 43.2.0
 
@@ -6840,7 +6840,7 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-menubar@10.1.2(electron@43.2.0(supports-color@10.2.2)):
+  electron-menubar@10.1.3(electron@43.2.0(supports-color@10.2.2)):
     dependencies:
       electron: 43.2.0(supports-color@10.2.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,10 @@ allowBuilds:
   unrs-resolver: true
 catalog:
   electron: '43.2.0'
+# Adopt this freshly published, first-party release ahead of pnpm's default
+# minimumReleaseAge gate; it carries the Windows tray click fix (#3064).
+minimumReleaseAgeExclude:
+  - electron-menubar@10.1.3
 overrides:
   react-is: '19.2.8'
   # Force patched versions of transitive dev-tooling deps pulled in by


### PR DESCRIPTION
## Summary

Bumps `electron-menubar` from `10.1.2` to `10.1.3`, which ships the fix for the Windows tray click bug: [gitify-app/electron-menubar#115](https://github.com/gitify-app/electron-menubar/pull/115).

On Windows, clicking the tray icon keeps the shell (`explorer.exe`) as the foreground process, so the popup's `show()` could not pull focus and Windows immediately fired `blur`, triggering menubar's 100ms auto-hide before the first paint. The window hid itself, so the click appeared to do nothing. `10.1.3` ignores that transient post-show blur (gated to Windows), so the popup stays visible.

This supersedes the app-level workaround in #3082, which can now be closed.

Fixes #3064
