### PR TITLE
ci: add emoji prefixes to release-please changelog sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,17 +8,17 @@
       "draft": true,
       "extra-files": [{ "type": "generic", "path": "sonar-project.properties" }],
       "changelog-sections": [
-        { "type": "feat", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "perf", "section": "Performance" },
-        { "type": "refactor", "section": "Refactor" },
-        { "type": "build", "section": "Build" },
-        { "type": "ci", "section": "CI" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "test", "section": "Tests", "hidden": true },
-        { "type": "style", "section": "Styles", "hidden": true },
-        { "type": "chore(deps)", "section": "Dependencies" },
-        { "type": "chore", "section": "Chores", "hidden": true }
+        { "type": "feat", "section": "🚀 Features" },
+        { "type": "fix", "section": "🐛 Bug Fixes" },
+        { "type": "perf", "section": "⚡ Performance" },
+        { "type": "refactor", "section": "🧼 Code Refactoring" },
+        { "type": "docs", "section": "📚 Documentation" },
+        { "type": "build", "section": "🏗️ Build System" },
+        { "type": "ci", "section": "🤖 Continuous Integration" },
+        { "type": "chore(deps)", "section": "📦 Dependency Updates" },
+        { "type": "test", "section": "🧪 Testing", "hidden": true },
+        { "type": "style", "section": "🎨 Styles", "hidden": true },
+        { "type": "chore", "section": "🧹 Chore", "hidden": true }
       ]
     }
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,9 +15,9 @@
         { "type": "docs", "section": "📚 Documentation" },
         { "type": "build", "section": "🏗️ Build System" },
         { "type": "ci", "section": "🤖 Continuous Integration" },
-        { "type": "chore(deps)", "section": "📦 Dependency Updates" },
         { "type": "test", "section": "🧪 Testing", "hidden": true },
         { "type": "style", "section": "🎨 Styles", "hidden": true },
+        { "type": "chore(deps)", "section": "📦 Dependency Updates", "hidden": true },
         { "type": "chore", "section": "🧹 Chore", "hidden": true }
       ]
     }


### PR DESCRIPTION
Aligns the release-please changelog section headings with the emoji styling used in the previous GitHub auto-generated notes (`.github/release.yml`), so `CHANGELOG.md` and the generated release bodies read the same (🚀 Features, 🐛 Bug Fixes, 🧼 Code Refactoring, 📚 Documentation, 🏗️ Build System, 📦 Dependency Updates). `perf` and `ci` get their own ⚡ / 🤖 sections (they have no equivalent in the old label-based notes), and `test`/`style`/`chore` stay hidden.
