### PR TITLE
ci: publish draft release by id to avoid HTTP 422 on tag lookup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,8 +109,22 @@ jobs:
       # signed artifacts to it. Now that every platform has uploaded, flip it to
       # published: this materialises the git tag and fires the `release: published`
       # event that redeploys the website.
+      #
+      # We resolve the release by id rather than `gh release edit <tag>`: a draft
+      # has no git tag yet, so the tag lookup fails with HTTP 422. Patching the
+      # draft flag by id is also idempotent, so re-running an already-published
+      # release is a no-op.
       - name: Publish draft release
-        run: gh release edit "${TAG_NAME}" --draft=false --repo "${REPO}"
+        run: |
+          # The draft is the newest release, so a single page comfortably covers it.
+          release_id=$(gh api "repos/${REPO}/releases?per_page=100" \
+            --jq 'map(select(.tag_name == env.TAG_NAME)) | .[0].id // empty')
+          if [ -z "${release_id}" ]; then
+            echo "::error::No release found for tag ${TAG_NAME}"
+            exit 1
+          fi
+          gh api --method PATCH "repos/${REPO}/releases/${release_id}" -F draft=false > /dev/null
+          echo "Published ${TAG_NAME} (release id ${release_id})"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ inputs.tag_name }}


### PR DESCRIPTION
## Problem

During the 7.1.0 release, the `publish-release` job failed with **HTTP 422 Validation Failed** on:

```
gh release edit "$TAG_NAME" --draft=false
```

`gh release edit` resolves a release **by tag name**, but release-please keeps the release a draft and GitHub does not materialize the git tag until it is published. With no tag to resolve, the call fails, so the draft is never flipped to published and the artifacts (which uploaded fine) stay on an unpublished draft. This is deterministic and would break the un-draft step on **every** release.

For 7.1.0 it was un-drafted manually by patching the release by id.

## Fix

Resolve the release **by id** (looked up via `tag_name`) and flip the draft flag with a direct API PATCH:

```yaml
release_id=$(gh api "repos/${REPO}/releases?per_page=100" \
  --jq 'map(select(.tag_name == env.TAG_NAME)) | .[0].id // empty')
gh api --method PATCH "repos/${REPO}/releases/${release_id}" -F draft=false
```

- Works for drafts (no tag required).
- Idempotent: re-running on an already-published release is a no-op.
- Errors clearly if no release matches the tag.
- Injection-safe: `TAG_NAME`/`REPO` come via `env:`, and jq reads `env.TAG_NAME` rather than interpolating into the shell or jq program.

Validated locally with `actionlint` and `zizmor` (both clean).
