### PR TITLE
ci: defer release-please PR creation while a draft release is pending

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,37 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - name: Run release-please
+      # Phase 1: create releases only. The release PR phase is deliberately
+      # skipped here because our releases start as drafts (electron-builder can
+      # only upload artifacts to a draft): a draft has no git tag yet, and a
+      # release-please PR pass that runs before the tag exists cannot find the
+      # just-released version, so it regenerates a bogus next-release PR from a
+      # months-old base (#3096, #3107).
+      - name: Run release-please (releases)
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          skip-github-pull-request: true
+
+      # A pending draft means a release pipeline is in flight (or stuck): its
+      # tag does not exist yet, so the PR phase must wait. This also covers the
+      # draft the step above may have just created.
+      - name: Check for unpublished draft releases
+        id: drafts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          count=$(gh api "repos/${REPO}/releases?per_page=20" --jq '[.[] | select(.draft)] | length')
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+
+      # Phase 2: create or refresh the next release PR, only when every
+      # release is published and its tag exists.
+      - name: Run release-please (release PR)
+        if: ${{ steps.drafts.outputs.count == '0' }}
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          skip-github-release: true
 
   lint:
     name: Lint App

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,21 +18,12 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      # Phase 1: create releases only. The release PR phase is deliberately
-      # skipped here because our releases start as drafts (electron-builder can
-      # only upload artifacts to a draft): a draft has no git tag yet, and a
-      # release-please PR pass that runs before the tag exists cannot find the
-      # just-released version, so it regenerates a bogus next-release PR from a
-      # months-old base (#3096, #3107).
       - name: Run release-please (releases)
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           skip-github-pull-request: true
 
-      # A pending draft means a release pipeline is in flight (or stuck): its
-      # tag does not exist yet, so the PR phase must wait. This also covers the
-      # draft the step above may have just created.
       - name: Check for unpublished draft releases
         id: drafts
         env:
@@ -42,8 +33,6 @@ jobs:
           count=$(gh api "repos/${REPO}/releases?per_page=20" --jq '[.[] | select(.draft)] | length')
           echo "count=${count}" >> "$GITHUB_OUTPUT"
 
-      # Phase 2: create or refresh the next release PR, only when every
-      # release is published and its tag exists.
       - name: Run release-please (release PR)
         if: ${{ steps.drafts.outputs.count == '0' }}
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0


### PR DESCRIPTION
## Problem

After every release-PR merge, release-please opens a bogus next-version PR whose changelog regenerates from a months-old base (#3096 after 7.1.0, #3107 after 7.1.1).

## Root cause

Our releases start as **drafts** (electron-builder can only upload signed artifacts to a draft), and a draft release has no git tag until the publish pipeline flips it ~15 minutes later. release-please's single invocation creates the draft and then immediately runs its release-PR phase: with the manifest already at the new version but no matching tag (googleapis/release-please#1650), it finds no anchor and regenerates a "next release" from its full search window - hence a 7.2.0 PR re-listing features from May. Any push to `main` during the draft window does the same. Once the tag exists, later runs report "no user facing commits - skipping" and never clean the stale PR up.

## Fix

Split release-please into two phased steps inside the existing job:

1. **Releases only** (`skip-github-pull-request: true`) - unchanged behavior for release creation; keeps the `release_created` / `tag_name` outputs the downstream jobs consume.
2. **Draft gate**: count unpublished draft releases (including the one step 1 may have just created).
3. **Release PR only** (`skip-github-release: true`), run only when there are **no pending drafts** - i.e. the previous release's tag exists and a correct anchor is available.

The next release PR is then created on the first push to `main` after the draft publishes, which is the earliest moment it can be generated correctly anyway. A permanently stuck draft intentionally pauses release-PR creation until it is resolved, which is the safe behavior (see 7.1.0's stuck draft).

Validated with `actionlint` and `zizmor` (both clean).

Note: #3107 still needs to be closed manually once v7.1.1 publishes; this change prevents recurrence, it does not clean up existing stale PRs.
