### PR TITLE
fix(notifications): drop subject type suffix from native notification body

### DIFF
--- a/src/renderer/utils/system/native.test.ts
+++ b/src/renderer/utils/system/native.test.ts
@@ -22,7 +22,7 @@ describe('renderer/utils/system/native.ts', () => {
       expect.stringContaining(
         mockSingleAccountNotifications[0].notifications[0].repository.fullName,
       ),
-      expect.stringContaining(mockSingleAccountNotifications[0].notifications[0].subject.title),
+      mockSingleAccountNotifications[0].notifications[0].subject.title,
       expect.stringContaining(mockHtmlUrl),
     );
     expect(url.generateNotificationWebUrl).toHaveBeenCalledTimes(1);

--- a/src/renderer/utils/system/native.ts
+++ b/src/renderer/utils/system/native.ts
@@ -21,9 +21,7 @@ export async function raiseNativeNotification(notifications: GitifyNotification[
   if (notifications.length === 1) {
     const notification = notifications[0];
     title = notification.repository.fullName;
-    body = notification.subject.type
-      ? `${notification.subject.title} [${notification.subject.type}]`
-      : notification.subject.title;
+    body = notification.subject.title;
     url = await generateNotificationWebUrl(notification);
   } else {
     title = APPLICATION.NAME;


### PR DESCRIPTION
## Summary

Drops the `[subject type]` suffix from the body of native OS notifications for a single notification, leaving just the subject title. The repository name stays as the notification title.

Before: `some/repo` — `Fix the thing [PullRequest]`
After: `some/repo` — `Fix the thing`

This trims the part of #3058 that appended the subject type; the repository name in the title (the more useful half of that change) is untouched.

## Tests

The existing assertion used `expect.stringContaining(subject.title)`, which passes either way and so did not actually cover the body format. Tightened it to an exact match, verified it fails without the source change and passes with it.

Full suite (1198 tests), `pnpm check` and `tsc --noEmit` all pass.
