### PR TITLE
ci: add `core-deps` scope to surface within release-please generated changelog/release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,7 +17,8 @@
         { "type": "ci", "section": "🤖 Continuous Integration" },
         { "type": "test", "section": "🧪 Testing", "hidden": true },
         { "type": "style", "section": "🎨 Styles", "hidden": true },
-        { "type": "chore(deps)", "section": "📦 Dependency Updates", "hidden": true },
+        { "type": "chore(deps-core)", "section": "📦 Dependency Updates (Core)" },
+        { "type": "chore(deps)", "section": "📦 Dependency Updates (Other)", "hidden": true },
         { "type": "chore", "section": "🧹 Chore", "hidden": true }
       ]
     }

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,19 @@
       "description": "Group vite-plus with vitest and @vitest/coverage-v8 so their versions always stay in sync. vite-plus bundles vitest as a direct dep; a mismatch causes SnapshotClient errors at runtime.",
       "matchPackageNames": ["vite-plus", "vitest", "@vitest/coverage-v8"],
       "groupName": "vite-plus / vitest"
+    },
+    {
+      "description": "Give updates to core runtime dependencies (Electron shell, tray integration, UI primitives, GitHub API client) a distinct commit scope so release-please can surface them in the changelog instead of hiding them with routine dependency bumps",
+      "matchPackageNames": [
+        "electron",
+        "electron-menubar",
+        "electron-updater",
+        "@primer/react",
+        "@primer/octicons-react",
+        "@primer/css",
+        "@octokit/**"
+      ],
+      "semanticCommitScope": "deps-core"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Configure renovate to add a commit scope to specific core dependencies.

Use this scope within release-pleases changelog and release notes generation to make these updates visible, while hiding those that are non-core