### PR TITLE
chore(deps): update electron-menubar to v10.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "electron-log": "5.4.4",
-    "electron-menubar": "10.1.4",
+    "electron-menubar": "10.1.5",
     "electron-updater": "6.8.9",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "electron-log": "5.4.4",
-    "electron-menubar": "10.1.5",
+    "electron-menubar": "10.1.7",
     "electron-updater": "6.8.9",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 5.4.4
         version: 5.4.4
       electron-menubar:
-        specifier: 10.1.5
-        version: 10.1.5(electron@43.2.0(supports-color@10.2.2))
+        specifier: 10.1.7
+        version: 10.1.7(electron@43.2.0(supports-color@10.2.2))
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@10.2.2)
@@ -2552,8 +2552,8 @@ packages:
     resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
     engines: {node: '>= 14'}
 
-  electron-menubar@10.1.5:
-    resolution: {integrity: sha512-hlgWb8dWQ42T0DEcHYPtF9LWR+hNgFTpU2XbLcVm3dmHISDMFxj5MWM9FeirNHaEShNSKlblLH7mX4wHK17eLw==}
+  electron-menubar@10.1.7:
+    resolution: {integrity: sha512-bziv/6r4CYYQadI6uwjP1xS/zwwsnsybYPKgoZfwpsOnzbJkOyStHKLLdHLbFs3UtUxXjAvH1STVaUm5l7dsZw==}
     peerDependencies:
       electron: 43.2.0
 
@@ -6840,7 +6840,7 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-menubar@10.1.5(electron@43.2.0(supports-color@10.2.2)):
+  electron-menubar@10.1.7(electron@43.2.0(supports-color@10.2.2)):
     dependencies:
       electron: 43.2.0(supports-color@10.2.2)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 5.4.4
         version: 5.4.4
       electron-menubar:
-        specifier: 10.1.4
-        version: 10.1.4(electron@43.2.0(supports-color@10.2.2))
+        specifier: 10.1.5
+        version: 10.1.5(electron@43.2.0(supports-color@10.2.2))
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@10.2.2)
@@ -2552,8 +2552,8 @@ packages:
     resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
     engines: {node: '>= 14'}
 
-  electron-menubar@10.1.4:
-    resolution: {integrity: sha512-Ly3jNCr1IKEric9iP9w2G5oCZ7lxJCCrH6EXVKrY2JkzQUcAEUduMgJYciE1sewwhcmlzZHGq/1mOlfdRlHr6w==}
+  electron-menubar@10.1.5:
+    resolution: {integrity: sha512-hlgWb8dWQ42T0DEcHYPtF9LWR+hNgFTpU2XbLcVm3dmHISDMFxj5MWM9FeirNHaEShNSKlblLH7mX4wHK17eLw==}
     peerDependencies:
       electron: 43.2.0
 
@@ -6840,7 +6840,7 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-menubar@10.1.4(electron@43.2.0(supports-color@10.2.2)):
+  electron-menubar@10.1.5(electron@43.2.0(supports-color@10.2.2)):
     dependencies:
       electron: 43.2.0(supports-color@10.2.2)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,10 +9,8 @@ allowBuilds:
   unrs-resolver: true
 catalog:
   electron: '43.2.0'
-# Adopt this freshly published, first-party release ahead of pnpm's default
-# minimumReleaseAge gate; it carries the Windows tray hang fix (#3064).
 minimumReleaseAgeExclude:
-  - electron-menubar@10.1.5
+  - electron-menubar
 overrides:
   react-is: '19.2.8'
   # Force patched versions of transitive dev-tooling deps pulled in by

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,9 +10,9 @@ allowBuilds:
 catalog:
   electron: '43.2.0'
 # Adopt this freshly published, first-party release ahead of pnpm's default
-# minimumReleaseAge gate; it carries the macOS dock icon fix (#3069).
+# minimumReleaseAge gate; it carries the Windows tray hang fix (#3064).
 minimumReleaseAgeExclude:
-  - electron-menubar@10.1.4
+  - electron-menubar@10.1.5
 overrides:
   react-is: '19.2.8'
   # Force patched versions of transitive dev-tooling deps pulled in by


### PR DESCRIPTION
## Summary

Bumps `electron-menubar` to `10.1.7`, which carries the fix for the Windows tray hang: [gitify-app/electron-menubar#124](https://github.com/gitify-app/electron-menubar/pull/124).

## What it fixes

On Windows, `positionWindow` and the window's `resize` listener recursed into each other: `setPosition` makes Windows emit `resize` synchronously, which re-enters `positionWindow`, which calls `setPosition` again. The recursion never unwinds, so the main process wedges with its event loop blocked — the popup never appears and **all** subsequent tray clicks (left *and* right) stop responding until the app is restarted.

Confirmed from a reporter's instrumented-build log in #3064: the diagnostic heartbeat stops immediately after the menubar `show` event and never resumes, pinning the hang inside `showWindow` between `emit('show')` and `emit('after-show')`. It matches the two other symptoms reported there — sustained CPU use after the left-click, and a window that grows "somewhat larger than a maximized window" as each recursion pass nudges it.

`10.1.7` guards against re-entrant `positionWindow` calls; a genuine later resize still repositions as before.

## Why 10.1.7 and not 10.1.5

The fix first shipped in `10.1.5`. `10.1.6` then widened the `electron` peer dependency from an exact pin to `>=35.0.0` (it was uninstallable for anyone not on the exact version), but that release tagged on GitHub without reaching npm, so it was re-cut as `10.1.7`. This bump therefore picks up both the tray fix and the peer-range fix.

## Notes

- `pnpm-workspace.yaml` excludes `electron-menubar` (all versions) from pnpm's `minimumReleaseAge` gate rather than pinning one version. It's a first-party package, so the supply-chain delay buys nothing, and this avoids re-editing the exclude on every bump — the gate verifies the *existing* lockfile before resolving, so a version-pinned entry has to list both old and new version mid-transition.
- Verified locally: the re-entrancy guard is present in the installed `lib/index.cjs`, `pnpm install --frozen-lockfile` passes the supply-chain check, and the full suite (1198 tests), `pnpm check`, `tsc --noEmit` and `pnpm build` are all clean.

Fixes #3064
