### PR TITLE
feat(macos): launch as an agent app so no dock tile is ever created

### DIFF
--- a/electron-builder.js
+++ b/electron-builder.js
@@ -25,11 +25,6 @@ const config = {
     category: 'public.app-category.developer-tools',
     icon: 'assets/images/app-icon.icns',
     extendInfo: {
-      // Launch as a macOS agent app so no dock tile is ever created. Without
-      // this the app starts as a regular dock app and `app.dock.hide()` has to
-      // transform it after the fact, leaving a ~300ms window where the icon is
-      // real; macOS can silently drop that transform and strand the icon for
-      // the whole session, which only a restart clears (#3069).
       LSUIElement: true,
     },
     identity: 'Adam Setch (5KD23H9729)',

--- a/electron-builder.js
+++ b/electron-builder.js
@@ -24,6 +24,14 @@ const config = {
   mac: {
     category: 'public.app-category.developer-tools',
     icon: 'assets/images/app-icon.icns',
+    extendInfo: {
+      // Launch as a macOS agent app so no dock tile is ever created. Without
+      // this the app starts as a regular dock app and `app.dock.hide()` has to
+      // transform it after the fact, leaving a ~300ms window where the icon is
+      // real; macOS can silently drop that transform and strand the icon for
+      // the whole session, which only a restart clears (#3069).
+      LSUIElement: true,
+    },
     identity: 'Adam Setch (5KD23H9729)',
     type: 'distribution',
     notarize: false, // Handle notarization in afterSign.js

--- a/src/main/lifecycle/first-run.test.ts
+++ b/src/main/lifecycle/first-run.test.ts
@@ -19,7 +19,6 @@ vi.mock('node:fs', () => ({
 const moveToApplicationsFolderMock = vi.fn();
 const isInApplicationsFolderMock = vi.fn(() => false);
 const getPathMock = vi.fn(() => '/User/Data');
-const dockHideMock = vi.fn();
 
 const showMessageBoxMock = vi.fn(async () => ({
   response: 0,
@@ -31,15 +30,7 @@ vi.mock('electron', () => ({
     getPath: () => getPathMock(),
     isInApplicationsFolder: () => isInApplicationsFolderMock(),
     moveToApplicationsFolder: () => moveToApplicationsFolderMock(),
-    dock: {
-      hide: () => dockHideMock(),
-    },
-  } satisfies Pick<
-    Electron.App,
-    'getPath' | 'isInApplicationsFolder' | 'moveToApplicationsFolder'
-  > & {
-    dock: { hide: () => void };
-  },
+  } satisfies Pick<Electron.App, 'getPath' | 'isInApplicationsFolder' | 'moveToApplicationsFolder'>,
   dialog: {
     showMessageBox: () => showMessageBoxMock(),
   } satisfies Pick<Electron.Dialog, 'showMessageBox'>,
@@ -132,19 +123,6 @@ describe('main/lifecycle/first-run', () => {
     await onFirstRunMaybe();
 
     expect(moveToApplicationsFolderMock).not.toHaveBeenCalled();
-  });
-
-  it('re-hides the dock icon after the prompt closes (#3069)', async () => {
-    existsSyncMock.mockReturnValueOnce(false);
-    existsSyncMock.mockReturnValueOnce(false);
-    showMessageBoxMock.mockResolvedValueOnce({
-      response: 1,
-      checkboxChecked: false,
-    });
-
-    await onFirstRunMaybe();
-
-    expect(dockHideMock).toHaveBeenCalled();
   });
 
   it('does not prompt on non-macOS', async () => {

--- a/src/main/lifecycle/first-run.ts
+++ b/src/main/lifecycle/first-run.ts
@@ -38,10 +38,6 @@ async function promptMoveToApplicationsFolder() {
     message: 'Move to Applications Folder?',
   });
 
-  // Parentless dialogs pull a dock-hidden (accessory) app into the Dock and
-  // macOS does not restore the accessory policy on close; re-hide (#3069).
-  app.dock?.hide();
-
   if (response === 0) {
     app.moveToApplicationsFolder();
   }

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1,4 +1,4 @@
-import { app, dialog } from 'electron';
+import { dialog } from 'electron';
 import type { Menubar } from 'electron-menubar';
 
 import { APPLICATION } from '../shared/constants';
@@ -45,11 +45,6 @@ vi.mock('electron', () => {
     }
   }
   return {
-    app: {
-      dock: {
-        hide: vi.fn(),
-      },
-    },
     dialog: {
       showMessageBox: vi.fn(),
     } satisfies Pick<Electron.Dialog, 'showMessageBox'>,
@@ -145,7 +140,7 @@ describe('main/updater.ts', () => {
       expect(autoUpdater.quitAndInstall).toHaveBeenCalled();
     });
 
-    it('re-hides the dock icon when user dismisses the dialog (#3069)', async () => {
+    it('does not install when user dismisses the dialog', async () => {
       vi.mocked(dialog.showMessageBox).mockResolvedValue({
         response: 1, // "Later" button index
         checkboxChecked: false,
@@ -159,7 +154,6 @@ describe('main/updater.ts', () => {
       await Promise.resolve();
 
       expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
-      expect(app.dock?.hide).toHaveBeenCalled();
     });
   });
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,4 +1,4 @@
-import { app, dialog, type MessageBoxOptions } from 'electron';
+import { dialog, type MessageBoxOptions } from 'electron';
 import type { Menubar } from 'electron-menubar';
 import { autoUpdater } from 'electron-updater';
 
@@ -200,14 +200,7 @@ export default class AppUpdater {
     dialog.showMessageBox(dialogOpts).then((returnValue) => {
       if (returnValue.response === 0) {
         autoUpdater.quitAndInstall();
-        return;
       }
-
-      // Presenting a parentless dialog forces a dock-hidden (accessory) macOS
-      // app to activate into the Dock, and the accessory policy is not
-      // restored when the dialog closes. Re-assert it so the dock icon
-      // disappears again (#3069).
-      app.dock?.hide();
     });
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3100 after reports that the dock icon was still showing on `v7.1.1`, so the startup re-hide added in gitify-app/electron-menubar#123 treated a symptom rather than the cause. This declares `LSUIElement` in the macOS `Info.plist` so the process is *born* as an accessory app and no dock tile ever exists.

## Root cause

Gitify shipped without `LSUIElement`, so macOS launched it as a regular dock app. Hiding the icon depended entirely on `electron-menubar` calling `app.dock.hide()` at `app.ready`, which runs `TransformProcessType(kProcessTransformToUIElementApplication)` after the tile is already on screen. That transform is asynchronous and can be silently dropped, and when it is, the icon stays for the whole session, which is why a restart was the only fix.

Measured on the shipped `v7.1.1` build by sampling the activation policy from outside the process (`lsappinfo info -only ApplicationType -app Gitify`) from launch:

| build | activation policy over time |
| --- | --- |
| `v7.1.1` (`/Applications`, as shipped) | `Foreground` @ +128ms → `UIElement` @ +529ms |
| same bundle, ad-hoc re-signed (control) | `Foreground` @ +137ms → `UIElement` @ +3150ms |
| control, repeat | `Foreground` @ +119ms → `UIElement` @ +392ms |
| control, repeat | `Foreground` @ +119ms → `UIElement` @ +272ms |
| **+ `LSUIElement: true`** | **`UIElement` @ +110ms, never `Foreground`** |
| **+ `LSUIElement: true`, repeat ×3** | **`UIElement` from first sample, never `Foreground`** |

`Foreground` is `NSApplicationActivationPolicyRegular`, i.e. the dock tile is real and visible. Every unpatched launch passes through it for 150ms-3s; that is the window in which the transform can be lost. With `LSUIElement` the window does not exist.

## Fix

`mac.extendInfo.LSUIElement: true` in `electron-builder.js`. One key, macOS only; Windows and Linux packaging is untouched.

The `electron-menubar` startup re-hide stays as-is and is still worth having: `pnpm dev` runs against `node_modules/electron/dist/Electron.app`, whose `Info.plist` we don't control, and other consumers of `showDockIcon: false` may not set `LSUIElement`. It just stops being the only line of defence for packaged builds.

The dialog-close re-hides that #3100 added in `updater.ts` / `first-run.ts` are removed here: with `LSUIElement` they are dead code on packaged builds (both call sites are packaged-only, the updater skips unpacked apps and the first-run prompt skips dev mode), and the live test below confirms parentless dialogs no longer pull an agent app into the Dock. Their tests go with them.

## Verification

Packaged this branch (`electron-builder --mac dir --arm64`), ad-hoc signed it, and ran it:

- `Contents/Info.plist` contains `LSUIElement = true`; `CFBundleIdentifier`, `LSApplicationCategoryType` and the `gitify` / `gitify-dev` `CFBundleURLTypes` are intact.
- Launch never reaches `Foreground` (`UIElement` @ +83ms, first sample).
- Tray icon renders with a live notification count, so the renderer, stored auth and API path all work.
- Protocol dispatch still reaches the running instance (`main:second-instance` → forward, `main:gotTheLock` → quit in `main.log`).
- The parentless first-run "Move to Applications Folder?" prompt still appears, and the app stays `UIElement` for the whole time it is up (sampled every 500ms for 6s), as does an external `activate`.
- `pnpm check` clean, `tsc --noEmit` clean, full suite green (1202 tests).

No test is added for the fix itself: it is a single build-config literal, and asserting `config.mac.extendInfo.LSUIElement === true` in a unit test would only restate it. The behaviour it fixes is only observable in a packaged macOS bundle, which is what the measurements above cover.

Closes #3069

