### PR TITLE
ci: skip release PR generation when a release was just created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release Please
@@ -34,7 +38,7 @@ jobs:
           echo "count=${count}" >> "$GITHUB_OUTPUT"
 
       - name: Run release-please (release PR)
-        if: ${{ steps.drafts.outputs.count == '0' }}
+        if: ${{ steps.release.outputs.release_created != 'true' && steps.drafts.outputs.count == '0' }}
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           skip-github-release: true


### PR DESCRIPTION
## What happened

Merging the 7.2.0 release PR created a bogus `7.3.0` PR (#3119) whose changelog regenerates from months-old commits — the same failure #3108 was meant to prevent.

Timeline from [the run](https://github.com/gitify-app/gitify/actions/runs/30493059947/job/90715375558):

```
21:37:18.9  ✔ Creating 1 releases for pull #3111      <- v7.2.0 draft created
21:37:21.3  Run count=$(gh api .../releases ...)      <- draft gate: reported 0
21:38:38.4  ⚠ No latest release pull request found    <- cannot anchor
21:38:50.3  ✔ Successfully opened pull request: 3119  <- bogus 7.3.0
```

Two distinct problems:

1. **The gate raced.** #3108 checks for pending draft releases via `gh api .../releases`, but that check runs ~2 seconds after phase 1 creates the draft, and the list endpoint hadn't reflected it yet. Zero drafts reported, so the release-PR phase ran.
2. **Without a tag, release-please can't anchor.** A draft release has no git tag (`v7.2.0` is a 404 right now), so release-please logs *"No latest release pull request found"* and rebuilds the changelog from the beginning of history.

## Changes

1. **Gate on release-please's own output** rather than an API read:

   ```yaml
   if: ${{ steps.release.outputs.release_created != 'true' && steps.drafts.outputs.count == '0' }}
   ```

   `release_created` comes from the same action invocation that created the draft, so it cannot race. The existing draft-count check is kept as the second condition — it covers drafts left pending by *earlier* runs, where the API has long since caught up.

2. **`concurrency` group on the workflow.** Releases now serialise. Overlapping runs are how the sibling repo ended up with a version tagged on GitHub but never published to npm, and this workflow had no protection against it.

## Effect

| Scenario | Release PR phase |
|---|---|
| Release PR merged (draft created) | skipped — `release_created == 'true'` |
| Any push while a draft is pending | skipped — draft count ≥ 1 |
| Draft published, tag exists | runs, and anchors correctly |

#3119 should be closed; it will be regenerated correctly once v7.2.0 publishes and its tag materialises.
