### PR TITLE
ci: deploy website after the release pipeline publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,3 +79,11 @@ jobs:
       APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
       APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
       APPLE_ID_TEAM_ID: ${{ secrets.APPLE_ID_TEAM_ID }}
+
+  website:
+    name: Website
+    uses: ./.github/workflows/website.yml
+    needs: publish
+    permissions: {}
+    secrets:
+      NETLIFY_BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,14 +1,14 @@
 name: Website
 
 on:
-  workflow_call: # For chaining onto the release pipeline
+  workflow_call:
     secrets:
       NETLIFY_BUILD_HOOK_URL:
         required: true
-  workflow_dispatch: # For manually running website deployment
+  workflow_dispatch:
   release:
     types:
-      - published # For releases published by hand via the GitHub UI
+      - published
 
 permissions: {}
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,10 +1,14 @@
 name: Website
 
 on:
+  workflow_call: # For chaining onto the release pipeline
+    secrets:
+      NETLIFY_BUILD_HOOK_URL:
+        required: true
   workflow_dispatch: # For manually running website deployment
   release:
     types:
-      - published # For running on release publish
+      - published # For releases published by hand via the GitHub UI
 
 permissions: {}
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -18,4 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - run: curl -X POST -d {} ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
+      - name: Trigger Netlify build
+        env:
+          BUILD_HOOK_URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}
+        run: curl --fail --silent --show-error -X POST -d '{}' "$BUILD_HOOK_URL"


### PR DESCRIPTION
Since the release-please migration, the draft release is published via `gh api` with `GITHUB_TOKEN`, and GitHub suppresses workflow triggers for token-driven events, so the `release: published` trigger on `website.yml` never fires. gitify.io has been stuck on `v7.1.0` while `v7.1.1` and `v7.2.0` shipped.

`website.yml` now accepts `workflow_call`, and `release.yml` chains it as a `needs: publish` job so the Netlify build hook fires once every platform has uploaded and the draft is published. The `release: published` trigger stays as a fallback for drafts published by hand through the UI.

The build hook `curl` also gained `--fail`, so a 5xx from Netlify now fails the job instead of exiting 0 silently, and the secret moved into `env:` rather than being interpolated into the shell line.

~gitify.io still needs a one-off `gh workflow run website.yml` to catch up to `v7.2.0`; this change only takes effect from the next release.~ Done ✅ 