### PR TITLE
feat(ui): fade scrollable content at the top and bottom edges

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -32,6 +32,60 @@ body,
   background-color: var(--gitify-scrollbar-thumb-hover);
 }
 
+/**
+ * Softens the top and bottom edges of a scroll container, revealing each edge
+ * only while there is more content to scroll in that direction.
+ */
+@property --gitify-scroll-fade-top {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0px;
+}
+
+@property --gitify-scroll-fade-bottom {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 0px;
+}
+
+@keyframes gitify-scroll-fade-top {
+  from {
+    --gitify-scroll-fade-top: 0px;
+  }
+  to {
+    --gitify-scroll-fade-top: var(--gitify-scroll-fade-size);
+  }
+}
+
+@keyframes gitify-scroll-fade-bottom {
+  from {
+    --gitify-scroll-fade-bottom: var(--gitify-scroll-fade-size);
+  }
+  to {
+    --gitify-scroll-fade-bottom: 0px;
+  }
+}
+
+.gitify-scroll-fade {
+  --gitify-scroll-fade-size: 1.5rem;
+
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    black var(--gitify-scroll-fade-top),
+    black calc(100% - var(--gitify-scroll-fade-bottom)),
+    transparent
+  );
+
+  animation:
+    gitify-scroll-fade-top linear both,
+    gitify-scroll-fade-bottom linear both;
+  animation-timeline: scroll(self block);
+  animation-range:
+    0px var(--gitify-scroll-fade-size),
+    calc(100% - var(--gitify-scroll-fade-size)) 100%;
+}
+
 body {
   font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',

--- a/src/renderer/components/layout/Contents.test.tsx
+++ b/src/renderer/components/layout/Contents.test.tsx
@@ -8,4 +8,10 @@ describe('renderer/components/layout/Contents.tsx', () => {
 
     expect(tree.container).toMatchSnapshot();
   });
+
+  it('should render with scroll fade', () => {
+    const tree = renderWithProviders(<Contents scrollFade>Test</Contents>);
+
+    expect(tree.container).toMatchSnapshot();
+  });
 });

--- a/src/renderer/components/layout/Contents.tsx
+++ b/src/renderer/components/layout/Contents.tsx
@@ -6,6 +6,7 @@ interface IContents {
   children: ReactNode;
   paddingHorizontal?: boolean;
   paddingBottom?: boolean;
+  scrollFade?: boolean;
 }
 
 /**
@@ -16,6 +17,7 @@ export const Contents: FC<IContents> = ({
   children,
   paddingHorizontal = true,
   paddingBottom = false,
+  scrollFade = false,
 }) => {
   return (
     <div
@@ -23,6 +25,7 @@ export const Contents: FC<IContents> = ({
         'grow overflow-x-hidden overflow-y-auto',
         paddingHorizontal && 'px-5',
         paddingBottom && 'pb-2',
+        scrollFade && 'gitify-scroll-fade',
       )}
     >
       {children}

--- a/src/renderer/components/layout/__snapshots__/Contents.test.tsx.snap
+++ b/src/renderer/components/layout/__snapshots__/Contents.test.tsx.snap
@@ -9,3 +9,13 @@ exports[`renderer/components/layout/Contents.tsx > should render itself & its ch
   </div>
 </div>
 `;
+
+exports[`renderer/components/layout/Contents.tsx > should render with scroll fade 1`] = `
+<div>
+  <div
+    class="grow overflow-x-hidden overflow-y-auto px-5 gitify-scroll-fade"
+  >
+    Test
+  </div>
+</div>
+`;

--- a/src/renderer/components/login/LoginWithPersonalAccessTokenForm.tsx
+++ b/src/renderer/components/login/LoginWithPersonalAccessTokenForm.tsx
@@ -170,7 +170,7 @@ export const LoginWithPersonalAccessTokenForm: FC<LoginWithPersonalAccessTokenFo
     <Page testId="Login With Personal Access Token">
       <Header icon={KeyIcon}>{title}</Header>
 
-      <Contents>
+      <Contents scrollFade>
         {errors.invalidCredentialsForHost && (
           <Banner
             data-testid="login-errors"

--- a/src/renderer/routes/AccountScopes.tsx
+++ b/src/renderer/routes/AccountScopes.tsx
@@ -49,7 +49,7 @@ export const AccountScopesRoute: FC = () => {
   return (
     <Page testId="account-scopes">
       <Header icon={ShieldCheckIcon}>Scopes</Header>
-      <Contents>
+      <Contents scrollFade>
         <Stack direction="vertical" gap="none">
           {!scopesLoaded && (
             <Stack

--- a/src/renderer/routes/Accounts.tsx
+++ b/src/renderer/routes/Accounts.tsx
@@ -135,7 +135,7 @@ export const AccountsRoute: FC = () => {
     <Page testId="accounts">
       <Header icon={PersonIcon}>Accounts</Header>
 
-      <Contents>
+      <Contents scrollFade>
         {accounts.map((account, i) => {
           const adapter = getAdapter(account);
           const AuthMethodIcon = adapter.getAuthMethodIcon(account.method);

--- a/src/renderer/routes/Filters.tsx
+++ b/src/renderer/routes/Filters.tsx
@@ -28,7 +28,7 @@ export const FiltersRoute: FC = () => {
         Filters
       </Header>
 
-      <Contents paddingBottom>
+      <Contents paddingBottom scrollFade>
         <Stack direction="vertical" gap="spacious">
           {hasMultipleAccounts && <AccountFilter />}
           <SearchFilter />

--- a/src/renderer/routes/Settings.tsx
+++ b/src/renderer/routes/Settings.tsx
@@ -20,7 +20,7 @@ export const SettingsRoute: FC = () => {
         Settings
       </Header>
 
-      <Contents paddingBottom>
+      <Contents paddingBottom scrollFade>
         <Stack direction="vertical" gap="spacious">
           <AppearanceSettings />
           <NotificationSettings />

--- a/src/renderer/routes/__snapshots__/Filters.test.tsx.snap
+++ b/src/renderer/routes/__snapshots__/Filters.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`renderer/routes/Filters.tsx > General > should render itself & its chil
     </div>
   </div>
   <div
-    class="grow overflow-x-hidden overflow-y-auto px-5 pb-2"
+    class="grow overflow-x-hidden overflow-y-auto px-5 pb-2 gitify-scroll-fade"
   >
     <div
       class="prc-Stack-Stack-UQ9k6"

--- a/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
+++ b/src/renderer/routes/__snapshots__/Settings.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`renderer/routes/Settings.tsx > should render itself & its children 1`] 
     </div>
   </div>
   <div
-    class="grow overflow-x-hidden overflow-y-auto px-5 pb-2"
+    class="grow overflow-x-hidden overflow-y-auto px-5 pb-2 gitify-scroll-fade"
   >
     <div
       class="prc-Stack-Stack-UQ9k6"

--- a/src/renderer/routes/bitbucket/__snapshots__/LoginWithPersonalAccessToken.test.tsx.snap
+++ b/src/renderer/routes/bitbucket/__snapshots__/LoginWithPersonalAccessToken.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`renderer/routes/bitbucket/LoginWithPersonalAccessToken.tsx > renders co
       </div>
     </div>
     <div
-      class="grow overflow-x-hidden overflow-y-auto px-5"
+      class="grow overflow-x-hidden overflow-y-auto px-5 gitify-scroll-fade"
     >
       <div
         class="prc-Stack-Stack-UQ9k6"

--- a/src/renderer/routes/gitea/__snapshots__/LoginWithPersonalAccessToken.test.tsx.snap
+++ b/src/renderer/routes/gitea/__snapshots__/LoginWithPersonalAccessToken.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`renderer/routes/gitea/LoginWithPersonalAccessToken.tsx > renders correc
       </div>
     </div>
     <div
-      class="grow overflow-x-hidden overflow-y-auto px-5"
+      class="grow overflow-x-hidden overflow-y-auto px-5 gitify-scroll-fade"
     >
       <div
         class="prc-Stack-Stack-UQ9k6"

--- a/src/renderer/routes/github/LoginWithDeviceFlow.tsx
+++ b/src/renderer/routes/github/LoginWithDeviceFlow.tsx
@@ -297,7 +297,7 @@ export const GitHubLoginWithDeviceFlowRoute: FC = () => {
     <Page testId="Login With Device Flow">
       <Header icon={SignInIcon}>Authorize with GitHub</Header>
 
-      <Contents>
+      <Contents scrollFade>
         {error && (
           <Banner
             data-testid="login-errors"

--- a/src/renderer/routes/github/LoginWithOAuthApp.tsx
+++ b/src/renderer/routes/github/LoginWithOAuthApp.tsx
@@ -122,7 +122,7 @@ export const GitHubLoginWithOAuthAppRoute: FC = () => {
     <Page testId="Login With OAuth App">
       <Header icon={PersonIcon}>Login with OAuth App</Header>
 
-      <Contents>
+      <Contents scrollFade>
         {errors.invalidCredentialsForHost && (
           <Banner
             data-testid="login-errors"

--- a/src/renderer/routes/github/__snapshots__/LoginWithOAuthApp.test.tsx.snap
+++ b/src/renderer/routes/github/__snapshots__/LoginWithOAuthApp.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`renderer/routes/github/LoginWithOAuthApp.tsx > renders correctly 1`] = 
       </div>
     </div>
     <div
-      class="grow overflow-x-hidden overflow-y-auto px-5"
+      class="grow overflow-x-hidden overflow-y-auto px-5 gitify-scroll-fade"
     >
       <div
         class="prc-Stack-Stack-UQ9k6"

--- a/src/renderer/routes/github/__snapshots__/LoginWithPersonalAccessToken.test.tsx.snap
+++ b/src/renderer/routes/github/__snapshots__/LoginWithPersonalAccessToken.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`renderer/routes/github/LoginWithPersonalAccessToken.tsx > renders corre
       </div>
     </div>
     <div
-      class="grow overflow-x-hidden overflow-y-auto px-5"
+      class="grow overflow-x-hidden overflow-y-auto px-5 gitify-scroll-fade"
     >
       <div
         class="prc-Stack-Stack-UQ9k6"


### PR DESCRIPTION
Scrollable views currently cut off hard at the top and bottom edges, so content collides abruptly with the header and footer chrome. This adds a `scrollFade` opt-in to the shared `Contents` layout component that softly fades content in and out at both edges while scrolling.

The fade is driven entirely by CSS scroll-driven animations (`animation-timeline: scroll(self block)`) masking the scroll container, so there are no scroll listeners or re-renders, and each edge only fades while there is actually more content to scroll in that direction (measured in Chromium: no top fade at scroll position 0, no bottom fade at the end). Containers whose content fits leave the scroll timeline inactive and render no fade at all.

Enabled on Settings, Filters, Accounts, Scopes and the three login screens. Notifications is deliberately left out for now: read notifications are removed from the list, so it can go from overflowing to fitting while mounted, and Chromium holds the last fade value rather than clearing it, which would strand a fade above a list that can no longer scroll.