### PR TITLE
chore: remove minimum age threshold for first-party `electron-menubar`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,11 @@
         "@octokit/**"
       ],
       "semanticCommitScope": "deps-core"
+    },
+    {
+      "description": "electron-menubar is a first-party dependency, so skip the minimum release age gate applied to other packages",
+      "matchPackageNames": ["electron-menubar"],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
follow on from the pnpm minimumReleaseAgeExclusion within https://github.com/gitify-app/gitify/pull/3115