### PR TITLE
fix(bitbucket): fallback for missing notification URLs

### DIFF
--- a/src/renderer/utils/forges/bitbucket/adapter.test.ts
+++ b/src/renderer/utils/forges/bitbucket/adapter.test.ts
@@ -286,17 +286,22 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
       expect(helpers.defaultUserType).toBe('User');
     });
 
-    it('falls back to an empty string when the subject has no URL', () => {
-      const notification = mockPartialGitifyNotification({
-        title: 'Bitbucket notification',
-        type: 'BitbucketNotification',
-        url: null,
-      });
+    it('falls back to the repository URL when the subject has no URL', () => {
+      const notification = mockPartialGitifyNotification(
+        {
+          title: 'Bitbucket notification',
+          type: 'BitbucketNotification',
+          url: null,
+        },
+        {
+          htmlUrl: 'https://bitbucket.org/myorg/myrepo' as Link,
+        },
+      );
       notification.account = mockBitbucketAccount;
 
       const helpers = bitbucketAdapter.getDisplayHelpers(notification);
 
-      expect(helpers.defaultUrl).toBe('');
+      expect(helpers.defaultUrl).toBe('https://bitbucket.org/myorg/myrepo');
     });
   });
 });

--- a/src/renderer/utils/forges/bitbucket/adapter.ts
+++ b/src/renderer/utils/forges/bitbucket/adapter.ts
@@ -61,7 +61,7 @@ function getDisplayHelpers(notification: RawGitifyNotification): NotificationDis
   return {
     iconType: BitbucketIcon,
     iconColor: IconColor.GRAY,
-    defaultUrl: notification.subject.url ?? ('' as Link),
+    defaultUrl: notification.subject.url ?? notification.repository.htmlUrl,
     defaultUserType: 'User',
   };
 }

--- a/src/renderer/utils/notifications/url.test.ts
+++ b/src/renderer/utils/notifications/url.test.ts
@@ -1,7 +1,7 @@
-import { mockGitHubCloudAccount } from '../../__mocks__/account-mocks';
+import { mockBitbucketAccount, mockGitHubCloudAccount } from '../../__mocks__/account-mocks';
 import { mockGitifyNotification } from '../../__mocks__/notifications-mocks';
 
-import type { GitifySubject, Link, SubjectType } from '../../types';
+import type { GitifyNotification, GitifySubject, Link, SubjectType } from '../../types';
 
 import { githubAdapter } from '../forges/github/adapter';
 import { generateNotificationReferrerId, generateNotificationWebUrl } from './url';
@@ -96,6 +96,31 @@ describe('renderer/utils/notifications/url.ts', () => {
       expect(followUrlSpy).toHaveBeenCalledTimes(1);
       expect(followUrlSpy).toHaveBeenCalledWith(mockGitHubCloudAccount, mockSubjectUrl);
       expect(result).toBe(`${mockHtmlUrl}?${mockNotificationReferrer}`);
+    });
+
+    it('falls back to the repository URL when a Bitbucket notification has no subject URL', async () => {
+      const repositoryUrl = 'https://bitbucket.org/myorg/myrepo' as Link;
+      const notification: GitifyNotification = {
+        ...mockGitifyNotification,
+        account: mockBitbucketAccount,
+        subject: {
+          title: 'Bitbucket notification',
+          type: 'BitbucketNotification',
+          url: null,
+          latestCommentUrl: null,
+        },
+        repository: {
+          ...mockGitifyNotification.repository,
+          htmlUrl: repositoryUrl,
+        },
+      };
+      const expectedUrl = new URL(repositoryUrl);
+      expectedUrl.searchParams.set(
+        'notification_referrer_id',
+        generateNotificationReferrerId(notification),
+      );
+
+      await expect(generateNotificationWebUrl(notification)).resolves.toBe(expectedUrl.toString());
     });
   });
 });


### PR DESCRIPTION
## Summary

- Use the repository URL when a Bitbucket notification has no entity or content URL.
- Cover the adapter fallback and shared notification URL generation with regressions.

## Root cause

Bitbucket permits both notification URL fields to be null. That left the adapter with an empty default URL, which the shared URL builder tried to construct before it could apply a fallback.

## Validation

- `pnpm check`
- `pnpm test` — 158 files, 1218 tests passed
- `pnpm build`
