### PR TITLE
refactor(api): configure gc and stale time

### DIFF
--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -81,11 +81,15 @@ export const Constants = {
 
   REFRESH_ACCOUNTS_INTERVAL_MS: 60 * 60 * 1000, // 1 hour
 
-  // Query stale time in milliseconds, used by TanStack Query client
-  QUERY_STALE_TIME_MS: 30 * 1000, // 30 seconds
-
   // Cooldown before retrying a failed query, used by TanStack Query client
   QUERY_RETRY_DELAY_MS: 30 * 1000, // 30 seconds
+
+  // Garbage-collection time for inactive query cache entries, used by
+  // TanStack Query client. Comfortably longer than either query's own
+  // refetch interval (notifications: 60s-60min, accounts: 1hr), so stale
+  // cache entries (e.g. from account churn) are collected well after they
+  // stop being read.
+  QUERY_GC_TIME_MS: 10 * 60 * 1000, // 10 minutes
 
   // GraphQL Argument Defaults
   GRAPHQL_ARGS: {

--- a/src/renderer/constants.ts
+++ b/src/renderer/constants.ts
@@ -84,11 +84,12 @@ export const Constants = {
   // Cooldown before retrying a failed query, used by TanStack Query client
   QUERY_RETRY_DELAY_MS: 30 * 1000, // 30 seconds
 
-  // Garbage-collection time for inactive query cache entries, used by
-  // TanStack Query client. Comfortably longer than either query's own
-  // refetch interval (notifications: 60s-60min, accounts: 1hr), so stale
-  // cache entries (e.g. from account churn) are collected well after they
-  // stop being read.
+  // How long an unobserved query cache entry is kept before collection, used
+  // by TanStack Query client. Only entries nothing is subscribed to are
+  // collected, so this never applies to the notifications or accounts
+  // queries while the app runs - both are observed for the lifetime of
+  // `GlobalEffects`. It governs keys that fall out of use, such as the
+  // per-account-list keys left behind by adding or removing an account.
   QUERY_GC_TIME_MS: 10 * 60 * 1000, // 10 minutes
 
   // GraphQL Argument Defaults

--- a/src/renderer/hooks/useAccounts.test.tsx
+++ b/src/renderer/hooks/useAccounts.test.tsx
@@ -1,0 +1,62 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { mockGitHubCloudAccount } from '../__mocks__/account-mocks';
+
+import { useAccountsStore } from '../stores';
+
+import * as authUtils from '../utils/auth/utils';
+import { useAccounts } from './useAccounts';
+
+describe('renderer/hooks/useAccounts.ts', () => {
+  const refreshAccountSpy = vi
+    .spyOn(authUtils, 'refreshAccount')
+    .mockImplementation(async (account) => account);
+
+  beforeEach(() => {
+    refreshAccountSpy.mockClear();
+    useAccountsStore.setState({ accounts: [mockGitHubCloudAccount] });
+  });
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          refetchOnWindowFocus: false,
+          refetchInterval: false,
+        },
+      },
+    });
+
+    return {
+      queryClient,
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    };
+  };
+
+  it('refreshes accounts on mount', async () => {
+    const { wrapper } = createWrapper();
+
+    renderHook(() => useAccounts(), { wrapper });
+
+    await waitFor(() => expect(refreshAccountSpy).toHaveBeenCalledWith(mockGitHubCloudAccount));
+  });
+
+  it('exposes a manual refetch that re-runs the refresh', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAccounts(), { wrapper });
+    await waitFor(() => expect(refreshAccountSpy).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.refetchAccounts();
+    });
+
+    await waitFor(() => expect(refreshAccountSpy).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/renderer/hooks/useAccounts.test.tsx
+++ b/src/renderer/hooks/useAccounts.test.tsx
@@ -3,9 +3,10 @@ import type { ReactNode } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import { mockGitHubCloudAccount } from '../__mocks__/account-mocks';
-
-import { Constants } from '../constants';
+import {
+  mockGitHubCloudAccount,
+  mockGitHubEnterpriseServerAccount,
+} from '../__mocks__/account-mocks';
 
 import { useAccountsStore } from '../stores';
 
@@ -62,14 +63,36 @@ describe('renderer/hooks/useAccounts.ts', () => {
     await waitFor(() => expect(refreshAccountSpy).toHaveBeenCalledTimes(2));
   });
 
-  it('sets an explicit staleTime aligned to the refresh interval', async () => {
-    const { queryClient, wrapper } = createWrapper();
+  it('serves a newly mounted observer from cache instead of refreshing again', async () => {
+    const { wrapper } = createWrapper();
 
     renderHook(() => useAccounts(), { wrapper });
     await waitFor(() => expect(refreshAccountSpy).toHaveBeenCalledTimes(1));
 
-    const [query] = queryClient.getQueryCache().getAll();
-    const options = query.options as { staleTime?: number };
-    expect(options.staleTime).toBe(Constants.REFRESH_ACCOUNTS_INTERVAL_MS);
+    // A second observer on the same key, well inside the refresh interval
+    renderHook(() => useAccounts(), { wrapper });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(refreshAccountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes again when the account list changes, despite the staleTime', async () => {
+    const { wrapper } = createWrapper();
+
+    renderHook(() => useAccounts(), { wrapper });
+    await waitFor(() => expect(refreshAccountSpy).toHaveBeenCalledTimes(1));
+
+    // A different account list is a different query key, so it has no cached
+    // data to be considered fresh
+    await act(async () => {
+      useAccountsStore.setState({
+        accounts: [mockGitHubCloudAccount, mockGitHubEnterpriseServerAccount],
+      });
+    });
+
+    await waitFor(() => expect(refreshAccountSpy.mock.calls.length).toBeGreaterThan(1));
   });
 });

--- a/src/renderer/hooks/useAccounts.test.tsx
+++ b/src/renderer/hooks/useAccounts.test.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { mockGitHubCloudAccount } from '../__mocks__/account-mocks';
 
+import { Constants } from '../constants';
+
 import { useAccountsStore } from '../stores';
 
 import * as authUtils from '../utils/auth/utils';
@@ -58,5 +60,16 @@ describe('renderer/hooks/useAccounts.ts', () => {
     });
 
     await waitFor(() => expect(refreshAccountSpy).toHaveBeenCalledTimes(2));
+  });
+
+  it('sets an explicit staleTime aligned to the refresh interval', async () => {
+    const { queryClient, wrapper } = createWrapper();
+
+    renderHook(() => useAccounts(), { wrapper });
+    await waitFor(() => expect(refreshAccountSpy).toHaveBeenCalledTimes(1));
+
+    const [query] = queryClient.getQueryCache().getAll();
+    const options = query.options as { staleTime?: number };
+    expect(options.staleTime).toBe(Constants.REFRESH_ACCOUNTS_INTERVAL_MS);
   });
 });

--- a/src/renderer/hooks/useAccounts.ts
+++ b/src/renderer/hooks/useAccounts.ts
@@ -42,6 +42,10 @@ export const useAccounts = (): AccountsState => {
 
     enabled: accounts.length > 0,
 
+    // Fresh for the whole refresh interval, so mounting a new observer (or
+    // this hook's own remount on account-list changes) doesn't trigger an
+    // immediate extra refetch on top of the hourly poll.
+    staleTime: Constants.REFRESH_ACCOUNTS_INTERVAL_MS,
     refetchInterval: Constants.REFRESH_ACCOUNTS_INTERVAL_MS,
     refetchOnWindowFocus: false,
   });

--- a/src/renderer/hooks/useAccounts.ts
+++ b/src/renderer/hooks/useAccounts.ts
@@ -42,9 +42,10 @@ export const useAccounts = (): AccountsState => {
 
     enabled: accounts.length > 0,
 
-    // Fresh for the whole refresh interval, so mounting a new observer (or
-    // this hook's own remount on account-list changes) doesn't trigger an
-    // immediate extra refetch on top of the hourly poll.
+    // Fresh for the whole refresh interval, so a newly mounted observer
+    // reuses the cached refresh rather than firing one on top of the hourly
+    // poll. Changing the account list does not go through this: it produces
+    // a new query key with no cached data, which always fetches.
     staleTime: Constants.REFRESH_ACCOUNTS_INTERVAL_MS,
     refetchInterval: Constants.REFRESH_ACCOUNTS_INTERVAL_MS,
     refetchOnWindowFocus: false,

--- a/src/renderer/hooks/useNotifications.test.tsx
+++ b/src/renderer/hooks/useNotifications.test.tsx
@@ -13,8 +13,6 @@ import {
   mockSingleAccountNotifications,
 } from '../__mocks__/notifications-mocks';
 
-import { Constants } from '../constants';
-
 import { useAccountsStore, useFiltersStore, useSettingsStore } from '../stores';
 
 import type { AccountNotifications, Percentage } from '../types';
@@ -289,7 +287,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
   });
 
   describe('query cache configuration', () => {
-    it('sets an explicit staleTime aligned to the minimum poll interval', async () => {
+    it('does not refetch on mount while the cached data is still fresh', async () => {
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
       const queryClient = new QueryClient({
@@ -308,9 +306,15 @@ describe('renderer/hooks/useNotifications.ts', () => {
       renderHook(() => useNotifications({ withSideEffects: true }), { wrapper });
       await waitFor(() => expect(getAllNotificationsMock).toHaveBeenCalledTimes(1));
 
-      const [query] = queryClient.getQueryCache().getAll();
-      const options = query.options as { staleTime?: number };
-      expect(options.staleTime).toBe(Constants.MIN_FETCH_NOTIFICATIONS_INTERVAL_MS);
+      // `refetchOnMount` is stale-gated, so a second host mounting inside the
+      // staleTime window shares the cached data rather than refetching.
+      renderHook(() => useNotifications({ withSideEffects: true }), { wrapper });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(getAllNotificationsMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/renderer/hooks/useNotifications.test.tsx
+++ b/src/renderer/hooks/useNotifications.test.tsx
@@ -13,6 +13,8 @@ import {
   mockSingleAccountNotifications,
 } from '../__mocks__/notifications-mocks';
 
+import { Constants } from '../constants';
+
 import { useAccountsStore, useFiltersStore, useSettingsStore } from '../stores';
 
 import type { AccountNotifications, Percentage } from '../types';
@@ -283,6 +285,32 @@ describe('renderer/hooks/useNotifications.ts', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe('query cache configuration', () => {
+    it('sets an explicit staleTime aligned to the minimum poll interval', async () => {
+      getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
+
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+            refetchOnWindowFocus: false,
+            refetchInterval: false,
+          },
+        },
+      });
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      );
+
+      renderHook(() => useNotifications({ withSideEffects: true }), { wrapper });
+      await waitFor(() => expect(getAllNotificationsMock).toHaveBeenCalledTimes(1));
+
+      const [query] = queryClient.getQueryCache().getAll();
+      const options = query.options as { staleTime?: number };
+      expect(options.staleTime).toBe(Constants.MIN_FETCH_NOTIFICATIONS_INTERVAL_MS);
     });
   });
 

--- a/src/renderer/hooks/useNotifications.ts
+++ b/src/renderer/hooks/useNotifications.ts
@@ -8,6 +8,8 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
+import { Constants } from '../constants';
+
 import { useAccountsStore, useFiltersStore, useSettingsStore } from '../stores';
 
 import {
@@ -164,6 +166,13 @@ export const useNotifications = ({
     select: selectFilteredNotifications,
 
     placeholderData: keepPreviousData,
+
+    // Fresh for at least one poll cycle at the fastest possible interval, so
+    // data isn't treated as stale before a refetch could realistically have
+    // occurred (see query-cache-timing-alignment design Decision 1 for why
+    // this uses the static floor rather than the live, possibly-stretched
+    // interval).
+    staleTime: Constants.MIN_FETCH_NOTIFICATIONS_INTERVAL_MS,
 
     // Only the singleton side-effects host polls. Other consumers share the
     // cached data and would otherwise each schedule their own refetch timer.

--- a/src/renderer/hooks/useNotifications.ts
+++ b/src/renderer/hooks/useNotifications.ts
@@ -169,9 +169,11 @@ export const useNotifications = ({
 
     // Fresh for at least one poll cycle at the fastest possible interval, so
     // data isn't treated as stale before a refetch could realistically have
-    // occurred (see query-cache-timing-alignment design Decision 1 for why
-    // this uses the static floor rather than the live, possibly-stretched
-    // interval).
+    // occurred. Uses the static floor rather than the live interval because
+    // the latter stretches with `X-Poll-Interval`; pinning staleTime to it
+    // would suppress mount/focus/reconnect refetches for as long as a forge
+    // asks Gitify to back off. Only those refetches are stale-gated - the
+    // poll itself fires on `refetchInterval` regardless.
     staleTime: Constants.MIN_FETCH_NOTIFICATIONS_INTERVAL_MS,
 
     // Only the singleton side-effects host polls. Other consumers share the

--- a/src/renderer/utils/api/queryClient.test.ts
+++ b/src/renderer/utils/api/queryClient.test.ts
@@ -1,6 +1,8 @@
 import { onlineManager } from '@tanstack/react-query';
 
-import { syncOnlineManagerWithBrowser } from './queryClient';
+import { Constants } from '../../constants';
+
+import { queryClient, syncOnlineManagerWithBrowser } from './queryClient';
 
 describe('renderer/utils/api/queryClient.ts', () => {
   afterEach(() => {
@@ -25,6 +27,30 @@ describe('renderer/utils/api/queryClient.ts', () => {
       syncOnlineManagerWithBrowser();
 
       expect(onlineManager.isOnline()).toBe(true);
+    });
+  });
+
+  describe('default options', () => {
+    const { queries } = queryClient.getDefaultOptions();
+
+    it('sets an explicit garbage-collection time', () => {
+      expect(queries?.gcTime).toBe(Constants.QUERY_GC_TIME_MS);
+    });
+
+    it('sets refetchIntervalInBackground at the client level', () => {
+      expect(queries?.refetchIntervalInBackground).toBe(true);
+    });
+
+    it('does not set staleTime at the client level', () => {
+      // Each query configures its own staleTime at the point of use, since a
+      // single global value would be wrong for at least one query (see
+      // useNotifications/useAccounts, which poll on different cadences).
+      expect(queries?.staleTime).toBeUndefined();
+    });
+
+    it('retries failed queries once after a cooldown', () => {
+      expect(queries?.retry).toBe(1);
+      expect(queries?.retryDelay).toBe(Constants.QUERY_RETRY_DELAY_MS);
     });
   });
 });

--- a/src/renderer/utils/api/queryClient.ts
+++ b/src/renderer/utils/api/queryClient.ts
@@ -25,6 +25,12 @@ syncOnlineManagerWithBrowser();
  * queries retry once after a cooldown instead of the default near-instant
  * backoff, so a struggling GitHub/GHES instance is not hammered with
  * back-to-back polls while it recovers.
+ *
+ * `staleTime` is intentionally not set here:
+ * each query has its own refetch cadence (notifications poll on a
+ * user-configurable interval, accounts poll hourly), so both are configured
+ * explicitly at each `useQuery` call site instead of a single value that
+ * would be wrong for at least one of them.
  */
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -32,7 +38,7 @@ export const queryClient = new QueryClient({
       retry: 1,
       retryDelay: Constants.QUERY_RETRY_DELAY_MS,
       refetchIntervalInBackground: true,
-      staleTime: Constants.QUERY_STALE_TIME_MS,
+      gcTime: Constants.QUERY_GC_TIME_MS,
       networkMode: 'online',
     },
     mutations: {


### PR DESCRIPTION
define staleTime to be at minimum poll-interval for each hook.

Explicitly define gcTime at client level