### PR TITLE
fix: correct online state on startup instead of waiting for a network event

### DIFF
--- a/src/renderer/hooks/useOnlineStatus.test.ts
+++ b/src/renderer/hooks/useOnlineStatus.test.ts
@@ -12,6 +12,7 @@ describe('renderer/hooks/useOnlineStatus.ts', () => {
     act(() => {
       onlineManager.setOnline(true);
     });
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
   });
 
   it('reflects the online manager status', () => {
@@ -48,5 +49,30 @@ describe('renderer/hooks/useOnlineStatus.ts', () => {
     });
 
     expect(onlineManager.isOnline()).toBe(true);
+  });
+
+  describe('startup bootstrap', () => {
+    it('corrects onlineManager to offline when the device starts offline', () => {
+      // onlineManager defaults to online: true regardless of the device's
+      // actual state; the hook should force-correct it on mount rather than
+      // waiting for a native browser online/offline event.
+      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+      onlineManager.setOnline(true);
+
+      const { result } = renderHook(() => useOnlineStatus());
+
+      expect(onlineManager.isOnline()).toBe(false);
+      expect(result.current).toBe(false);
+    });
+
+    it('confirms onlineManager as online when the device starts online', () => {
+      Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+      onlineManager.setOnline(true);
+
+      const { result } = renderHook(() => useOnlineStatus());
+
+      expect(onlineManager.isOnline()).toBe(true);
+      expect(result.current).toBe(true);
+    });
   });
 });

--- a/src/renderer/hooks/useOnlineStatus.test.ts
+++ b/src/renderer/hooks/useOnlineStatus.test.ts
@@ -50,29 +50,4 @@ describe('renderer/hooks/useOnlineStatus.ts', () => {
 
     expect(onlineManager.isOnline()).toBe(true);
   });
-
-  describe('startup bootstrap', () => {
-    it('corrects onlineManager to offline when the device starts offline', () => {
-      // onlineManager defaults to online: true regardless of the device's
-      // actual state; the hook should force-correct it on mount rather than
-      // waiting for a native browser online/offline event.
-      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
-      onlineManager.setOnline(true);
-
-      const { result } = renderHook(() => useOnlineStatus());
-
-      expect(onlineManager.isOnline()).toBe(false);
-      expect(result.current).toBe(false);
-    });
-
-    it('confirms onlineManager as online when the device starts online', () => {
-      Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
-      onlineManager.setOnline(true);
-
-      const { result } = renderHook(() => useOnlineStatus());
-
-      expect(onlineManager.isOnline()).toBe(true);
-      expect(result.current).toBe(true);
-    });
-  });
 });

--- a/src/renderer/hooks/useOnlineStatus.test.ts
+++ b/src/renderer/hooks/useOnlineStatus.test.ts
@@ -33,6 +33,16 @@ describe('renderer/hooks/useOnlineStatus.ts', () => {
     expect(result.current).toBe(true);
   });
 
+  it('reports offline on the very first render, before any effect runs', () => {
+    // `queryClient.ts` syncs onlineManager from the browser at import time,
+    // so a cold start while offline must not paint one frame as online.
+    onlineManager.setOnline(false);
+
+    const { result } = renderHook(() => useOnlineStatus());
+
+    expect(result.current).toBe(false);
+  });
+
   it('re-probes online state when the system wakes', () => {
     act(() => {
       onlineManager.setOnline(false);

--- a/src/renderer/hooks/useOnlineStatus.ts
+++ b/src/renderer/hooks/useOnlineStatus.ts
@@ -8,7 +8,7 @@ import { onlineManager } from '@tanstack/react-query';
  * pause/resume behaviour.
  */
 export function useOnlineStatus(): boolean {
-  const [isOnline, setIsOnline] = useState(true);
+  const [isOnline, setIsOnline] = useState(() => onlineManager.isOnline());
 
   useEffect(() => {
     const handle = () => {

--- a/src/renderer/hooks/useOnlineStatus.ts
+++ b/src/renderer/hooks/useOnlineStatus.ts
@@ -11,6 +11,14 @@ export function useOnlineStatus(): boolean {
   const [isOnline, setIsOnline] = useState(true);
 
   useEffect(() => {
+    // Force-correct TanStack Query's internal online state to match the
+    // browser's actual state on mount. `onlineManager` otherwise initializes
+    // to `online: true` regardless of reality, only self-correcting once the
+    // browser fires its first native online/offline event - which means an
+    // app cold-started while offline would fire (and fail/retry) a query
+    // before ever discovering it should be paused.
+    onlineManager.setOnline(navigator.onLine);
+
     const handle = () => {
       setIsOnline(onlineManager.isOnline());
     };

--- a/src/renderer/hooks/useOnlineStatus.ts
+++ b/src/renderer/hooks/useOnlineStatus.ts
@@ -11,14 +11,6 @@ export function useOnlineStatus(): boolean {
   const [isOnline, setIsOnline] = useState(true);
 
   useEffect(() => {
-    // Force-correct TanStack Query's internal online state to match the
-    // browser's actual state on mount. `onlineManager` otherwise initializes
-    // to `online: true` regardless of reality, only self-correcting once the
-    // browser fires its first native online/offline event - which means an
-    // app cold-started while offline would fire (and fail/retry) a query
-    // before ever discovering it should be paused.
-    onlineManager.setOnline(navigator.onLine);
-
     const handle = () => {
       setIsOnline(onlineManager.isOnline());
     };

--- a/src/renderer/utils/api/queryClient.test.ts
+++ b/src/renderer/utils/api/queryClient.test.ts
@@ -1,0 +1,30 @@
+import { onlineManager } from '@tanstack/react-query';
+
+import { syncOnlineManagerWithBrowser } from './queryClient';
+
+describe('renderer/utils/api/queryClient.ts', () => {
+  afterEach(() => {
+    onlineManager.setOnline(true);
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+  });
+
+  describe('syncOnlineManagerWithBrowser', () => {
+    it('corrects onlineManager to offline when the device is offline', () => {
+      onlineManager.setOnline(true);
+      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+
+      syncOnlineManagerWithBrowser();
+
+      expect(onlineManager.isOnline()).toBe(false);
+    });
+
+    it('corrects onlineManager to online when the device is online', () => {
+      onlineManager.setOnline(false);
+      Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+
+      syncOnlineManagerWithBrowser();
+
+      expect(onlineManager.isOnline()).toBe(true);
+    });
+  });
+});

--- a/src/renderer/utils/api/queryClient.ts
+++ b/src/renderer/utils/api/queryClient.ts
@@ -1,6 +1,22 @@
-import { QueryClient } from '@tanstack/react-query';
+import { onlineManager, QueryClient } from '@tanstack/react-query';
 
 import { Constants } from '../../constants';
+
+/**
+ * Set TanStack Query's online state from the browser's actual network state.
+ *
+ * `onlineManager` initializes to `online: true` regardless of reality, and
+ * self-corrects only once the browser fires a native online/offline event.
+ * Browsers emit those on transitions only, so a device already offline when
+ * Gitify launches never gets one.
+ */
+export function syncOnlineManagerWithBrowser(): void {
+  onlineManager.setOnline(navigator.onLine);
+}
+
+// Runs at import, before the client below exists and therefore before any
+// query can fire, so a cold start while offline pauses rather than fetches.
+syncOnlineManagerWithBrowser();
 
 /**
  * TanStack Query client for all API state.


### PR DESCRIPTION
**Problem**
TanStack Query's onlineManager initializes to online: true regardless of the device's actual network state, and only self-corrects when the browser fires a native online/offline event. Since browsers only emit events on transitions, a device that's already offline when Gitify launches (airplane mode, VPN down, etc.) never gets one — so the app incorrectly believes it's online from the first render, fires the notifications query, and only discovers it's offline after that query fails and retries.

**Fix**
Added a single onlineManager.setOnline(navigator.onLine) call at the start of useOnlineStatus's mount effect, before the existing subscription logic. This actively force-corrects onlineManager's state to match reality on startup, instead of passively waiting for a future browser event that may never come.

