### PR TITLE
refactor(theme): source the base colour tokens from Primer

### DIFF
--- a/tailwind.config.mts
+++ b/tailwind.config.mts
@@ -100,9 +100,6 @@ const config: Config = {
           '@apply rounded-md bg-gitify-accounts': {},
         },
       });
-      // Primer tokens resolve per colour scheme on the wrapper (including the
-      // accessibility and high-contrast palettes), so only the two tokens with an
-      // intentional light/dark asymmetry need `light-dark()`.
       addBase({
         '[data-color-mode]': {
           '--gitify-background': 'light-dark(var(--bgColor-default), var(--bgColor-muted))',

--- a/tailwind.config.mts
+++ b/tailwind.config.mts
@@ -100,20 +100,22 @@ const config: Config = {
           '@apply rounded-md bg-gitify-accounts': {},
         },
       });
-      // TODO - ideally we would use GitHub Primer Design Tokens instead of TailwindCSS
+      // Primer tokens resolve per colour scheme on the wrapper (including the
+      // accessibility and high-contrast palettes), so only the two tokens with an
+      // intentional light/dark asymmetry need `light-dark()`.
       addBase({
         '[data-color-mode]': {
           '--gitify-background': 'light-dark(var(--bgColor-default), var(--bgColor-muted))',
           '--gitify-account-error-bg':
             'light-dark(var(--bgColor-danger-muted), var(--bgColor-danger-emphasis))',
 
-          '--gitify-scrollbar-track': `light-dark(${colors.gray[100]}, ${colors.gray[900]})`,
-          '--gitify-scrollbar-thumb': `light-dark(${colors.gray[300]}, ${colors.gray[700]})`,
-          '--gitify-scrollbar-thumb-hover': `light-dark(${colors.gray[400]}, ${colors.gray[600]})`,
+          '--gitify-scrollbar-track': 'var(--bgColor-muted)',
+          '--gitify-scrollbar-thumb': 'var(--borderColor-default)',
+          '--gitify-scrollbar-thumb-hover': 'var(--borderColor-emphasis)',
 
-          '--gitify-counter-primary': `light-dark(${colors.blue[300]}, ${colors.blue[400]})`,
-          '--gitify-counter-secondary': `light-dark(${colors.gray[200]}, ${colors.gray[600]})`,
-          '--gitify-counter-text': `light-dark(${colors.gray[800]}, ${colors.gray[100]})`,
+          '--gitify-counter-primary': 'var(--bgColor-accent-muted)',
+          '--gitify-counter-secondary': 'var(--bgColor-neutral-muted)',
+          '--gitify-counter-text': 'var(--fgColor-default)',
         },
       });
     }),


### PR DESCRIPTION
## Summary

Stacked on #3130. Resolves the long-standing `TODO` in `tailwind.config.mts` by replacing the six Tailwind palette literals (scrollbar track/thumb/thumb-hover, counter primary/secondary/text) with Primer design tokens.

- Primer tokens resolve per colour scheme on the `[data-color-mode]` wrapper, so these now follow the colorblind / Tritanopia / Soft dark / high-contrast palettes — the literals stayed frozen at generic gray/blue regardless of scheme.
- The `light-dark()` shims become unnecessary for them; only `--gitify-background` and `--gitify-account-error-bg` keep it, as their light/dark asymmetry is an intentional design choice rather than scheme resolution.
- Counter pills move from saturated `blue.300`/`gray.200` to the `--bgColor-accent-muted` / `--bgColor-neutral-muted` fills GitHub itself uses, softer and scheme-aware. Glass is unaffected (it overrides pill fills with its own glass tokens).

Mappings (light-scheme values for comparison):

| Token | Before | After |
|---|---|---|
| scrollbar-track | `gray.100` | `--bgColor-muted` (`#f6f8fa`) |
| scrollbar-thumb | `gray.300` (`#d1d5db`) | `--borderColor-default` (`#d1d9e0`) |
| scrollbar-thumb-hover | `gray.400` | `--borderColor-emphasis` (`#818b98`) |
| counter-primary | `blue.300` | `--bgColor-accent-muted` (`#ddf4ff`) |
| counter-secondary | `gray.200` | `--bgColor-neutral-muted` |
| counter-text | `gray.800` | `--fgColor-default` |

Verified token resolution in the built app across Classic light / dark / System / Soft dark — under Soft dark the pills and background now pick up the dimmed palette (`#4184e41a`, `#262c36`) instead of the frozen literals.