### PR TITLE
feat(theme): add a Glass option to show status icon colors

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -85,6 +85,16 @@
   --gitify-link: color-mix(in oklab, var(--fgColor-link), var(--fgColor-muted) 30%);
 }
 
+/* Opt-in status icon colours under Glass (`.gitify-colored-icons`, set from the
+ * appearance setting): a restrained palette that blends the vivid Primer state
+ * colours toward the muted foreground. */
+.gitify-colored-icons [data-color-mode] {
+  --gitify-icon-open: color-mix(in oklab, var(--fgColor-open), var(--fgColor-muted) 45%);
+  --gitify-icon-closed: color-mix(in oklab, var(--fgColor-closed), var(--fgColor-muted) 45%);
+  --gitify-icon-done: color-mix(in oklab, var(--fgColor-done), var(--fgColor-muted) 45%);
+  --gitify-icon-attention: color-mix(in oklab, var(--fgColor-attention), var(--fgColor-muted) 45%);
+}
+
 [data-theme='glass'] {
   /* Sidebar stays dark in both modes so its forced-white icons stay legible. */
   --gitify-sidebar: rgb(22 27 34 / 0.55);

--- a/src/renderer/__mocks__/state-mocks.ts
+++ b/src/renderer/__mocks__/state-mocks.ts
@@ -28,6 +28,7 @@ const mockAppearanceSettings: AppearanceSettingsState = {
   designLanguage: DesignLanguage.CLASSIC,
   theme: Theme.SYSTEM,
   increaseContrast: false,
+  showStatusIconColors: false,
   zoomPercentage: 100 as Percentage,
   showAccountHeader: false,
   wrapNotificationTitle: false,

--- a/src/renderer/components/settings/AppearanceSettings.test.tsx
+++ b/src/renderer/components/settings/AppearanceSettings.test.tsx
@@ -107,4 +107,25 @@ describe('renderer/components/settings/AppearanceSettings.tsx', () => {
 
     expect(screen.queryByTestId('checkbox-increaseContrast')).not.toBeInTheDocument();
   });
+
+  it('should toggle the status icon colors checkbox for Glass', async () => {
+    await act(async () => {
+      renderWithProviders(<AppearanceSettings />, {
+        settings: { designLanguage: DesignLanguage.GLASS },
+      });
+    });
+
+    await userEvent.click(screen.getByTestId('checkbox-showStatusIconColors'));
+
+    expect(toggleSettingSpy).toHaveBeenCalledTimes(1);
+    expect(toggleSettingSpy).toHaveBeenCalledWith('showStatusIconColors');
+  });
+
+  it('hides the status icon colors checkbox for Classic', async () => {
+    await act(async () => {
+      renderWithProviders(<AppearanceSettings />);
+    });
+
+    expect(screen.queryByTestId('checkbox-showStatusIconColors')).not.toBeInTheDocument();
+  });
 });

--- a/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/src/renderer/components/settings/AppearanceSettings.tsx
@@ -32,6 +32,7 @@ export const AppearanceSettings: FC = () => {
   const designLanguage = useSettingsStore((s) => s.designLanguage);
   const theme = useSettingsStore((s) => s.theme);
   const increaseContrast = useSettingsStore((s) => s.increaseContrast);
+  const showStatusIconColors = useSettingsStore((s) => s.showStatusIconColors);
 
   const colorModeSupported = (mode: Theme) => supportedColorModes(designLanguage).includes(mode);
   const showAccountHeader = useSettingsStore((s) => s.showAccountHeader);
@@ -101,6 +102,20 @@ export const AppearanceSettings: FC = () => {
             </Text>
           }
           visible={designLanguage === DesignLanguage.CLASSIC}
+        />
+
+        <Checkbox
+          checked={showStatusIconColors}
+          label="Show status icon colors"
+          name="showStatusIconColors"
+          onChange={() => toggleSetting('showStatusIconColors')}
+          tooltip={
+            <Text>
+              Color the notification type icons by their state (open, closed, done, attention).
+              Glass renders them monochrome by default.
+            </Text>
+          }
+          visible={designLanguage === DesignLanguage.GLASS}
         />
 
         <Stack align="center" className="text-sm" direction="horizontal" gap="condensed">

--- a/src/renderer/hooks/useAppearance.test.ts
+++ b/src/renderer/hooks/useAppearance.test.ts
@@ -33,7 +33,11 @@ describe('renderer/hooks/useAppearance.ts', () => {
   afterEach(() => {
     document.documentElement.removeAttribute('data-theme');
     document.documentElement.removeAttribute('data-glass-material');
-    document.documentElement.classList.remove('gitify-vibrant', 'gitify-translucent');
+    document.documentElement.classList.remove(
+      'gitify-vibrant',
+      'gitify-translucent',
+      'gitify-colored-icons',
+    );
   });
 
   it('marks the root with the Classic design language by default', () => {
@@ -176,5 +180,35 @@ describe('renderer/hooks/useAppearance.ts', () => {
 
     expect(window.gitify.setWindowVibrancy).toHaveBeenCalledWith(false);
     spy.mockRestore();
+  });
+
+  it('marks the root for colored status icons under Glass when enabled', () => {
+    useSettingsStore.setState({
+      designLanguage: DesignLanguage.GLASS,
+      showStatusIconColors: true,
+    });
+
+    renderHook(() => useAppearance());
+
+    expect(document.documentElement.classList.contains('gitify-colored-icons')).toBe(true);
+  });
+
+  it('keeps Glass status icons monochrome by default', () => {
+    useSettingsStore.setState({ designLanguage: DesignLanguage.GLASS });
+
+    renderHook(() => useAppearance());
+
+    expect(document.documentElement.classList.contains('gitify-colored-icons')).toBe(false);
+  });
+
+  it('ignores the status icon colors setting under Classic', () => {
+    useSettingsStore.setState({
+      designLanguage: DesignLanguage.CLASSIC,
+      showStatusIconColors: true,
+    });
+
+    renderHook(() => useAppearance());
+
+    expect(document.documentElement.classList.contains('gitify-colored-icons')).toBe(false);
   });
 });

--- a/src/renderer/hooks/useAppearance.ts
+++ b/src/renderer/hooks/useAppearance.ts
@@ -31,6 +31,7 @@ export function useAppearance(): void {
   const designLanguage = useSettingsStore((s) => s.designLanguage);
   const theme = useSettingsStore((s) => s.theme);
   const increaseContrast = useSettingsStore((s) => s.increaseContrast);
+  const showStatusIconColors = useSettingsStore((s) => s.showStatusIconColors);
   const prefersReducedTransparency = usePrefersReducedTransparency();
   const prefersContrast = usePrefersContrast();
 
@@ -94,6 +95,13 @@ export function useAppearance(): void {
       ? 'vibrancy'
       : 'backdrop-filter';
   }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle(
+      'gitify-colored-icons',
+      designLanguage === DesignLanguage.GLASS && showStatusIconColors,
+    );
+  }, [designLanguage, showStatusIconColors]);
 
   useEffect(() => {
     const root = document.documentElement;

--- a/src/renderer/stores/defaults.ts
+++ b/src/renderer/stores/defaults.ts
@@ -43,6 +43,7 @@ const DEFAULT_APPEARANCE_SETTINGS: AppearanceSettingsState = {
   designLanguage: DesignLanguage.CLASSIC,
   theme: Theme.SYSTEM,
   increaseContrast: false,
+  showStatusIconColors: false,
   zoomPercentage: 100 as Percentage,
   showAccountHeader: false,
   wrapNotificationTitle: false,

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -94,6 +94,8 @@ export interface AppearanceSettingsState {
   theme: Theme;
   /** High-contrast Primer schemes for Classic; also honours the OS setting. */
   increaseContrast: boolean;
+  /** Colours the status icons under Glass, which renders them monochrome by default. */
+  showStatusIconColors: boolean;
   zoomPercentage: Percentage;
   showAccountHeader: boolean;
   wrapNotificationTitle: boolean;


### PR DESCRIPTION
## Summary

Glass renders the notification type icons monochrome (they follow the surrounding text). This adds a Glass-only **"Show status icon colors"** appearance setting that opts back into colour, using the restrained palette that blends Primer's state colours 45% toward the muted foreground — the same desaturated look designed for Glass, rather than Classic's vivid colours.

- New `showStatusIconColors` appearance setting (defaults to off, so existing Glass behaviour is unchanged; zustand's shallow merge covers persisted settings).
- The checkbox only shows while Glass is the active design language, mirroring how "Increase contrast" is Classic-only.
- `useAppearance` toggles a `gitify-colored-icons` root class only under Glass; Classic ignores the setting entirely.
- The accessibility degradation block still restores full vivid colour coding under OS Reduce Transparency / Increase Contrast, regardless of this setting.

Verified in the built app: Glass default stays monochrome (icon colour equals row text), Glass with the setting renders the desaturated state colours, and Classic is untouched in both cases.