### PR TITLE
fix: restart to install update, and three update-flow bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "electron-log": "5.4.4",
-    "electron-menubar": "10.1.8",
+    "electron-menubar": "10.2.0",
     "electron-updater": "6.8.9",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 5.4.4
         version: 5.4.4
       electron-menubar:
-        specifier: 10.1.8
-        version: 10.1.8(electron@43.3.0(supports-color@10.2.2))
+        specifier: 10.2.0
+        version: 10.2.0(electron@43.3.0(supports-color@10.2.2))
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@10.2.2)
@@ -2538,8 +2538,8 @@ packages:
     resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
     engines: {node: '>= 14'}
 
-  electron-menubar@10.1.8:
-    resolution: {integrity: sha512-FD1Qku60xCbSgQTV4SXLaHh/NugT1Vp7PT9icb7A7lejzzCJj3e1LJLpt2aV+Nf3D/MqlqjcAcwwfbfEDJXu0w==}
+  electron-menubar@10.2.0:
+    resolution: {integrity: sha512-CMhVE91BZg5OQkViOHOknM2+HQMwwopxJjNR+Uuu7flc37I/MdujpeOgGPTAQJXgPnwYsPZ+VXo5K2kB+QrLpA==}
     peerDependencies:
       electron: 43.3.0
 
@@ -6809,7 +6809,7 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-menubar@10.1.8(electron@43.3.0(supports-color@10.2.2)):
+  electron-menubar@10.2.0(electron@43.3.0(supports-color@10.2.2)):
     dependencies:
       electron: 43.3.0(supports-color@10.2.2)
 

--- a/src/main/menu.test.ts
+++ b/src/main/menu.test.ts
@@ -94,6 +94,7 @@ describe('main/menu.ts', () => {
       app: { quit: vi.fn() },
       showWindow: vi.fn(),
       hideWindow: vi.fn(),
+      refreshContextMenu: vi.fn(),
       tray: {
         isDestroyed: vi.fn(() => false),
         setContextMenu: vi.fn(),
@@ -200,6 +201,12 @@ describe('main/menu.ts', () => {
 
       // oxlint-disable-next-line dot-notation -- This is a test
       expect(menuBuilder['updateReadyForInstallMenuItem'].visible).toBe(false);
+    });
+
+    it('republishes the menu so Linux picks up the visibility change', () => {
+      menuBuilder.setUpdateReadyForInstallMenuVisibility(true);
+
+      expect(menubar.refreshContextMenu).toHaveBeenCalled();
     });
   });
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -154,6 +154,17 @@ export default class MenuBuilder {
   }
 
   /**
+   * Publish in-place menu item changes to the tray.
+   *
+   * Linux serves libappindicator a cached serialization of the menu, so an
+   * item mutated after the menu was attached keeps rendering its old state
+   * until the menu is set again. A no-op on macOS and Windows.
+   */
+  private refreshMenu() {
+    this.menubar.refreshContextMenu();
+  }
+
+  /**
    * Enable or disable the "Check for updates" menu item.
    * Disabled while an update check is in progress.
    *
@@ -161,6 +172,7 @@ export default class MenuBuilder {
    */
   setCheckForUpdatesMenuEnabled(enabled: boolean) {
     this.checkForUpdatesMenuItem.enabled = enabled;
+    this.refreshMenu();
   }
 
   /**
@@ -170,6 +182,7 @@ export default class MenuBuilder {
    */
   setNoUpdateAvailableMenuVisibility(isVisible: boolean) {
     this.noUpdateAvailableMenuItem.visible = isVisible;
+    this.refreshMenu();
   }
 
   /**
@@ -179,6 +192,7 @@ export default class MenuBuilder {
    */
   setUpdateAvailableMenuVisibility(isVisible: boolean) {
     this.updateAvailableMenuItem.visible = isVisible;
+    this.refreshMenu();
   }
 
   /**
@@ -188,5 +202,6 @@ export default class MenuBuilder {
    */
   setUpdateReadyForInstallMenuVisibility(isVisible: boolean) {
     this.updateReadyForInstallMenuItem.visible = isVisible;
+    this.refreshMenu();
   }
 }

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -270,6 +270,27 @@ describe('main/updater.ts', () => {
       expect(menubar.tray.setToolTip).toHaveBeenCalledWith(APPLICATION.NAME);
     });
 
+    it('keeps checking on schedule after an error', async () => {
+      vi.useFakeTimers();
+      try {
+        await updater.start();
+
+        // Let the first scheduled check run, which registers the interval
+        await vi.advanceTimersByTimeAsync(APPLICATION.UPDATE_CHECK_INTERVAL_MS);
+        const callsBeforeError = vi.mocked(autoUpdater.checkForUpdatesAndNotify).mock.calls.length;
+
+        emit('error', new Error('offline'));
+
+        await vi.advanceTimersByTimeAsync(APPLICATION.UPDATE_CHECK_INTERVAL_MS);
+
+        expect(vi.mocked(autoUpdater.checkForUpdatesAndNotify).mock.calls.length).toBeGreaterThan(
+          callsBeforeError,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('performs initial check and schedules periodic checks', async () => {
       const originalSetInterval = globalThis.setInterval;
       const setIntervalSpy = vi.spyOn(globalThis, 'setInterval').mockImplementation(((

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -17,7 +17,7 @@ import MenuBuilder from './menu';
 import AppUpdater from './updater';
 
 // Mock electron-updater with an EventEmitter-like interface
-type UpdateDownloadedEvent = { releaseName: string };
+type UpdateDownloadedEvent = { releaseName?: string | null; version?: string };
 type ListenerArgs = UpdateDownloadedEvent | object | undefined;
 type Listener = (arg: ListenerArgs) => void;
 type ListenerMap = Record<string, Listener[]>;
@@ -122,6 +122,23 @@ describe('main/updater.ts', () => {
       expect(autoUpdater.quitAndInstall).not.toHaveBeenCalled();
       expect(menuBuilder.setUpdateAvailableMenuVisibility).toHaveBeenCalledWith(false);
       expect(menuBuilder.setUpdateReadyForInstallMenuVisibility).toHaveBeenCalledWith(true);
+    });
+
+    it('falls back to the version when the release has no name', async () => {
+      vi.mocked(dialog.showMessageBox).mockResolvedValue({
+        response: 1, // "Later" button index
+        checkboxChecked: false,
+      });
+
+      await updater.start();
+
+      emit('update-downloaded', { releaseName: null, version: '1.2.3' });
+
+      expect(dialog.showMessageBox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `${APPLICATION.NAME} 1.2.3 has been downloaded`,
+        }),
+      );
     });
 
     it('invokes quitAndInstall when user clicks Restart', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -21,7 +21,6 @@ export default class AppUpdater {
   private readonly menuBuilder: MenuBuilder;
   private started = false;
   private noUpdateMessageTimeout?: NodeJS.Timeout;
-  private periodicInterval?: NodeJS.Timeout;
 
   constructor(menubar: Menubar, menuBuilder: MenuBuilder) {
     this.menubar = menubar;
@@ -139,7 +138,7 @@ export default class AppUpdater {
     // This avoids an immediate duplicate check on startup.
     setTimeout(async () => {
       await runScheduledCheck();
-      this.periodicInterval = setInterval(runScheduledCheck, APPLICATION.UPDATE_CHECK_INTERVAL_MS);
+      setInterval(runScheduledCheck, APPLICATION.UPDATE_CHECK_INTERVAL_MS);
     }, APPLICATION.UPDATE_CHECK_INTERVAL_MS);
   }
 
@@ -164,6 +163,8 @@ export default class AppUpdater {
 
   /**
    * Reset tray tooltip and all update-related menu items to their default state.
+   * Leaves the periodic check schedule running so a cancelled or failed check
+   * does not stop the app looking for later updates.
    */
   private resetState() {
     this.menubar.tray.setToolTip(APPLICATION.NAME);
@@ -174,12 +175,6 @@ export default class AppUpdater {
 
     // Clear any pending timeout
     this.clearNoUpdateTimeout();
-
-    // Clear periodic interval if present
-    if (this.periodicInterval) {
-      clearInterval(this.periodicInterval);
-      this.periodicInterval = undefined;
-    }
   }
 
   /**

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -81,7 +81,7 @@ export default class AppUpdater {
       this.setTooltipWithStatus('A new update is ready to install');
       this.menuBuilder.setUpdateAvailableMenuVisibility(false);
       this.menuBuilder.setUpdateReadyForInstallMenuVisibility(true);
-      this.showUpdateReadyDialog(event.releaseName ?? undefined);
+      this.showUpdateReadyDialog(event.releaseName ?? event.version);
     });
 
     autoUpdater.on('update-not-available', () => {
@@ -181,14 +181,14 @@ export default class AppUpdater {
    * Show a dialog informing the user that an update is ready to install.
    * If the user chooses to restart, quitAndInstall is called immediately.
    *
-   * @param releaseName - The version string shown in the dialog message.
+   * @param release - The release name shown in the dialog message.
    */
-  private showUpdateReadyDialog(releaseName?: string) {
+  private showUpdateReadyDialog(release: string) {
     const dialogOpts: MessageBoxOptions = {
       type: 'info',
       buttons: ['Restart', 'Later'],
       title: 'Application Update',
-      message: `${APPLICATION.NAME} ${releaseName} has been downloaded`,
+      message: `${APPLICATION.NAME} ${release} has been downloaded`,
       detail: 'Restart to apply the update. You can also restart later from the tray menu.',
     };
 


### PR DESCRIPTION
## Summary

The "Restart to install update" button and the post-download **Restart** dialog button both did nothing. Root cause turned out to be in `electron-menubar`, fixed there and released as [v10.2.0](https://github.com/gitify-app/electron-menubar/releases/tag/v10.2.0). Three smaller update-flow bugs found along the way are fixed here.

## Why restart-to-update was a silent no-op

Applying an update never goes through `app.quit()`. Electron's `autoUpdater.quitAndInstall()` does this:

```cpp
Emit("before-quit-for-update");
if (WindowList::IsEmpty()) { QuitAndInstall(); return; }
WindowList::AddObserver(this);
WindowList::CloseAllWindows();   // quits only once the list empties
```

`before-quit` is emitted *after* the windows close, not before. `electron-menubar`'s `hideOnClose` only let a close through once `before-quit` had fired, so it vetoed the close, the window list never emptied, `OnWindowAllClosed` never fired, and the install stalled with no error and no log.

macOS only in practice: on Windows and Linux, `electron-updater`'s `BaseUpdater.quitAndInstall` calls `app.quit()` itself, which emits `before-quit` first. Long-standing, not a regression from the v10 migration, the pre-#2880 hand-rolled `close` handler had the same `isQuitting` gate.

Fixed in electron-menubar (gitify-app/electron-menubar#139) by binding its `before-quit` handler to `autoUpdater`'s `before-quit-for-update` as well. No Gitify code change needed, just the bump.

## Also fixed here

| Bug | Fix |
| --- | --- |
| One transient network error permanently stopped periodic update checks for the session: the `error` handler called `resetState()`, which cleared the interval. | `resetState()` is now UI-only and leaves the schedule running. Dropped the write-only `periodicInterval` field. |
| The dialog read "Gitify **undefined** has been downloaded" when the release had no name (`UpdateInfo.releaseName` is `string \| null`). | Falls back to `event.version`. |
| On Linux, toggling a tray item's visibility did nothing until the next window show/hide, because libappindicator serves a cached serialization of the menu. | The update-item setters call `menubar.refreshContextMenu()`, a new v10.2.0 API. No-op on macOS and Windows. |

## Testing

Every fix has a test that was verified to fail against the unfixed code and pass after, by reverting only the source and re-running:

| Bug | Failure without the fix |
| --- | --- |
| Restart-to-update | `expected undefined to be type of 'function'` (electron-menubar suite) |
| Periodic checks die on error | zero further checks after one `error` event |
| `undefined` in dialog | `"Gitify undefined has been downloaded"` |
| Linux menu never refreshes | `refreshContextMenu` never called |

1317 tests across 166 files pass, `tsc --noEmit` clean, `vp check` clean. Visual regression tests are Linux-only by design and were not run locally; CI covers them.