### PR TITLE
fix: keep the scroll fade ramping in packaged builds

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -553,9 +553,10 @@ body,
     transparent
   );
 
-  animation:
-    gitify-scroll-fade-top linear both,
-    gitify-scroll-fade-bottom linear both;
+  animation-name: gitify-scroll-fade-top, gitify-scroll-fade-bottom;
+  animation-duration: auto;
+  animation-timing-function: linear;
+  animation-fill-mode: both;
   animation-timeline: scroll(self block);
   animation-range:
     0px var(--gitify-scroll-fade-size),


### PR DESCRIPTION
## Summary

The scroll fade on `Contents` behaves differently in a packaged build than it does in `pnpm dev`: release builds render the top edge permanently faded, and neither edge eases in or out.

`.gitify-scroll-fade` declared its two scroll-driven animations with the `animation` shorthand and no duration, so the duration resolved to `auto` and each keyframe stretched across its `animation-range`. The production minifier cannot keep that shorthand alongside the `animation-timeline` and `animation-range` that follow it, so it expands the shorthand and fills the duration in with the CSS Animations 1 default of `0s`. The emitted bundle contained:

```css
animation-duration: 0s, 0s;
```

A `0s` duration on a scroll timeline snaps an animation straight to its end state the moment its range starts. `gitify-scroll-fade-top` starts at `0px`, so it was fully applied at scroll offset 0.

Measured in Chromium at a few scroll offsets:

| `scrollTop` | source (dev) | minified (release) |
| --- | --- | --- |
| 0 | `top=0px bottom=24px` | **`top=24px`** `bottom=24px` |
| 6 | `top=6px bottom=24px` | **`top=24px`** `bottom=24px` |
| 12 | `top=12px bottom=24px` | **`top=24px`** `bottom=24px` |
| 24 | `top=24px bottom=24px` | `top=24px bottom=24px` |

Spelling the longhands out with an explicit `animation-duration: auto` keeps `auto` in the emitted bundle.

## Verification

- Rebuilt and re-measured against the real `build/assets/index-*.css`. `animation-duration:auto` survives minification, and every offset now matches dev: `0→0px`, `6→6px`, `12→12px`, `24→24px`, with the bottom edge releasing over the last 24px.
- `vp check` and `tsc --noEmit` clean; unit suite passes; visual regression suite passes in the pinned Docker image with no baseline drift.

## Note

The visual regression suite cannot catch this class of bug. It renders unminified source CSS, so a minifier regression never reaches it, and `visual.setup.ts` forces `animation-duration: 0s !important` on everything, which is exactly the broken state. A guard would have to assert on the built CSS; not added here.
