### PR TITLE
fix(deps-core): pin electron to 43.2.0 to restore Linux tray icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "concurrently": "10.0.5",
     "date-fns": "4.4.0",
     "dotenv": "17.4.2",
-    "electron": "43.4.0",
+    "electron": "43.2.0",
     "electron-builder": "26.15.3",
     "final-form": "5.0.1",
     "graphql": "17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   react-is: 19.2.8
   cross-spawn: 7.0.6
   got: 11.8.6
-  electron: 43.4.0
+  electron: 43.2.0
 
 importers:
 
@@ -19,7 +19,7 @@ importers:
         version: 5.4.4
       electron-menubar:
         specifier: 10.2.0
-        version: 10.2.0(electron@43.4.0(supports-color@10.2.2))
+        version: 10.2.0(electron@43.2.0(supports-color@10.2.2))
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@10.2.2)
@@ -145,8 +145,8 @@ importers:
         specifier: 17.4.2
         version: 17.4.2
       electron:
-        specifier: 43.4.0
-        version: 43.4.0(supports-color@10.2.2)
+        specifier: 43.2.0
+        version: 43.2.0(supports-color@10.2.2)
       electron-builder:
         specifier: 26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
@@ -2551,7 +2551,7 @@ packages:
   electron-menubar@10.2.0:
     resolution: {integrity: sha512-CMhVE91BZg5OQkViOHOknM2+HQMwwopxJjNR+Uuu7flc37I/MdujpeOgGPTAQJXgPnwYsPZ+VXo5K2kB+QrLpA==}
     peerDependencies:
-      electron: 43.4.0
+      electron: 43.2.0
 
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
@@ -2566,8 +2566,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.4.0:
-    resolution: {integrity: sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==}
+  electron@43.2.0:
+    resolution: {integrity: sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -6837,9 +6837,9 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-menubar@10.2.0(electron@43.4.0(supports-color@10.2.2)):
+  electron-menubar@10.2.0(electron@43.2.0(supports-color@10.2.2)):
     dependencies:
-      electron: 43.4.0(supports-color@10.2.2)
+      electron: 43.2.0(supports-color@10.2.2)
 
   electron-publish@26.15.3(supports-color@10.2.2):
     dependencies:
@@ -6882,7 +6882,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.4.0(supports-color@10.2.2):
+  electron@43.2.0(supports-color@10.2.2):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@10.2.2)
@@ -8066,7 +8066,7 @@ snapshots:
   react-devtools@7.0.1(supports-color@10.2.2):
     dependencies:
       cross-spawn: 7.0.6
-      electron: 43.4.0(supports-color@10.2.2)
+      electron: 43.2.0(supports-color@10.2.2)
       internal-ip: 6.2.0
       minimist: 1.2.8
       react-devtools-core: 7.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ allowBuilds:
   esbuild: true
   unrs-resolver: true
 catalog:
-  electron: '43.4.0'
+  electron: '43.2.0'
 minimumReleaseAgeExclude:
   - electron-menubar
 overrides:

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,11 @@
       "allowedVersions": "<12"
     },
     {
+      "description": "Hold electron below 43.3.0. The Chromium StatusNotifierItem multiplexer that arrived in 43.3.0 (electron#52416) collapses every tray icon onto a single /StatusNotifierItem object path, so desktops that address the item by its unique D-Bus name instead of its well-known name can no longer resolve the icon and render nothing. Gitify is a tray-first app, so this makes it unusable on those desktops. electron-menubar's visual tray matrix reproduces it on Budgie, Sway/Waybar and LXQt while KDE Plasma stays unaffected. 43.4.1 does NOT fix it despite its release note claiming a Linux tray fix; that change (electron#52952) is described upstream as a bad fix and coincided with LXQt breaking too. Remove this hold only once electron#52674 is closed AND electron-menubar's visual matrix is green on the candidate version.",
+      "matchPackageNames": ["electron"],
+      "allowedVersions": "<43.3.0"
+    },
+    {
       "description": "Group vite-plus with vitest and @vitest/coverage-v8 so their versions always stay in sync. vite-plus bundles vitest as a direct dep; a mismatch causes SnapshotClient errors at runtime.",
       "matchPackageNames": ["vite-plus", "vitest", "@vitest/coverage-v8"],
       "groupName": "vite-plus / vitest"


### PR DESCRIPTION
## Summary

Pins `electron` back to **43.2.0** (from 43.4.0) and adds a Renovate hold so the broken range can't come back automatically.

Electron 43.3.0 pulled in a Chromium change ([electron#52416](https://github.com/electron/electron/pull/52416), Chromium 150.0.7871.181) that replaced per-icon D-Bus object paths with a *StatusNotifierItem multiplexer*. The multiplexer collapses every tray icon onto a single `/StatusNotifierItem` path, leaving the destination service name as the only discriminator. Desktops that address the item by its **unique** D-Bus connection name rather than its well-known name (anything built on `Gio.DBusProxy`) can no longer be routed to the right icon, so `Multiplexer::GetIcon(":1.x")` finds nothing and **no tray icon renders**.

Gitify is a tray-first app, so on affected desktops this makes it effectively unusable.

## Confirmed in the wild

#3206 is this bug, reported by a user running the **packaged AppImage** on Fedora 43 / GNOME (Wayland) with the AppIndicator extension. They independently bisected to v7.3.0, which lines up exactly with the Electron bump:

| Gitify | Electron | Tray |
| --- | --- | --- |
| v7.2.0 | 43.2.0 | works |
| v7.3.0 | 43.3.0 | **broken** |
| v7.3.1 / v7.3.3 | 43.3.0 | **broken** |
| v7.4.0 | 43.4.0 | **broken** |

Their symptom, a three-dots placeholder that appears at launch then vanishes, matches the upstream reporter in electron#52674 verbatim. This also settles a question that was otherwise open: packaged electron-builder builds are affected, not only directly-launched Electron.

Both currently-supported release lines (7.3.x and 7.4.x) are therefore shipping a broken tray on affected desktops, so a patch release should follow this merge.

## Evidence

Reproduced in [electron-menubar](https://github.com/gitify-app/electron-menubar)'s visual tray matrix, which boots a real menubar fixture on 14 platforms and asserts the tray icon and popover are actually painted. Three runs the same day, on the same runner image and harness, differing only in Electron version:

| Electron | Budgie | Sway/Waybar | LXQt | KDE / macOS / Windows |
| --- | --- | --- | --- | --- |
| 43.2.0 | pass | pass | pass | pass |
| 43.4.0 | **fail** | **fail** | pass | pass |
| 43.4.1 | **fail** | **fail** | **fail** | pass |

In every failing case the popover window renders with exactly the expected pixel counts and only the tray icon is missing, so this is specific to tray rendering. The harness re-captures and re-checks for 60s before failing, so a slow-painting panel is ruled out. Failures reproduced on re-run.

**43.4.1 does not fix this**, despite a release note that reads like it does. That change ([electron#52952](https://github.com/electron/electron/pull/52952)) is described upstream as a bad fix for the same problem; we measured it removing waybar's `Invalid Status Notifier Item` error without making the icon appear, and LXQt newly broke on it. That is why the hold is `<43.3.0` rather than "skip 43.4.0".

Upstream tracking: [electron#52674](https://github.com/electron/electron/issues/52674) (open, no fix PR yet). [electron#53024](https://github.com/electron/electron/issues/53024) was closed as a duplicate.

## Changes

- `package.json` and `pnpm-workspace.yaml` — Electron is pinned in both the `devDependencies` entry and the `catalog` that feeds `overrides.electron: 'catalog:'`, so both move together.
- `renovate.json` — adds an `allowedVersions: "<43.3.0"` hold, following the existing `got` pattern, with a description recording the removal criteria: electron#52674 closed **and** electron-menubar's visual matrix green on the candidate.

## Verification

- `pnpm run build` and `pnpm run check` (format + lint, 442 and 392 files) pass.
- Full CI is green, including all three `electron-builder` build jobs (Linux, Windows, macOS) and the test suite.
- Locally `pnpm test` showed 3 failures in `LoginWithOAuthApp.test.tsx` and `LoginWithPersonalAccessToken.test.tsx`; these are pre-existing load-induced timeouts (both files pass 19/19 in isolation, neither touches Electron) and they pass in CI.
- Lockfile diff is electron-only.

Closes #3206
