### PR TITLE
chore(deps-core): update electron-menubar to v10.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "electron-log": "5.4.4",
-    "electron-menubar": "10.2.0",
+    "electron-menubar": "10.2.1",
     "electron-updater": "6.8.9",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 5.4.4
         version: 5.4.4
       electron-menubar:
-        specifier: 10.2.0
-        version: 10.2.0(electron@43.2.0(supports-color@10.2.2))
+        specifier: 10.2.1
+        version: 10.2.1(electron@43.2.0(supports-color@10.2.2))
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@10.2.2)
@@ -2548,8 +2548,8 @@ packages:
     resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
     engines: {node: '>= 14'}
 
-  electron-menubar@10.2.0:
-    resolution: {integrity: sha512-CMhVE91BZg5OQkViOHOknM2+HQMwwopxJjNR+Uuu7flc37I/MdujpeOgGPTAQJXgPnwYsPZ+VXo5K2kB+QrLpA==}
+  electron-menubar@10.2.1:
+    resolution: {integrity: sha512-JIpqGjVYUSloNJn/8hqotzFIRNmJ0jpGQJjXGs4GB/viy8cXIBlWj2G30w+SqJR7TKa+EBhXrMLSA73HdP/VgA==}
     peerDependencies:
       electron: 43.2.0
 
@@ -6837,7 +6837,7 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-menubar@10.2.0(electron@43.2.0(supports-color@10.2.2)):
+  electron-menubar@10.2.1(electron@43.2.0(supports-color@10.2.2)):
     dependencies:
       electron: 43.2.0(supports-color@10.2.2)
 


### PR DESCRIPTION
## Summary

Bumps `electron-menubar` 10.2.0 → **10.2.1**, which contains a single fix: [gitify-app/electron-menubar#155](https://github.com/gitify-app/electron-menubar/pull/155), passing `visibleOnFullScreen: true` to `setVisibleOnAllWorkspaces`.

That flag maps to `NSWindowCollectionBehaviorFullScreenAuxiliary`. Electron applies both workspace flags unconditionally from their argument values, so omitting it cleared the flag. A window without it cannot be displayed in fullscreen, so macOS switched to a different Space to show the popup. This seems to be the cause of the long-standing #563.

Attempts to close #563
