### PR TITLE
feat(linux): add opt-in X11 backend for tray-anchored positioning

### DIFF
--- a/src/main/handlers/system.test.ts
+++ b/src/main/handlers/system.test.ts
@@ -4,7 +4,12 @@ import type { Menubar } from 'electron-menubar';
 import { EVENTS } from '../../shared/events';
 
 import { applyKeepWindowOnBlur } from '../lifecycle/window';
+import { setX11Backend } from '../ozone';
 import { registerSystemHandlers } from './system';
+
+vi.mock('../ozone', () => ({
+  setX11Backend: vi.fn(),
+}));
 
 vi.mock('../lifecycle/window', () => ({
   applyKeepWindowOnBlur: vi.fn(),
@@ -157,6 +162,19 @@ describe('main/handlers/system.ts', () => {
       handler?.({}, true);
 
       expect(applyKeepWindowOnBlur).toHaveBeenCalledWith(menubar, true);
+    });
+  });
+
+  describe('UPDATE_USE_X11_BACKEND', () => {
+    it('forwards the value to setX11Backend', () => {
+      registerSystemHandlers(menubar);
+
+      const handler = onMock.mock.calls.find(
+        (call: unknown[]) => call[0] === EVENTS.UPDATE_USE_X11_BACKEND,
+      )?.[1];
+      handler?.({}, true);
+
+      expect(setX11Backend).toHaveBeenCalledWith(true);
     });
   });
 

--- a/src/main/handlers/system.ts
+++ b/src/main/handlers/system.ts
@@ -6,6 +6,7 @@ import { logInfo } from '../../shared/logger';
 
 import { handleMainEvent, onMainEvent, sendRendererEvent } from '../events';
 import { applyKeepWindowOnBlur, applyWindowVibrancy } from '../lifecycle/window';
+import { setX11Backend } from '../ozone';
 import { isDevMode } from '../utils';
 
 /**
@@ -90,6 +91,14 @@ export function registerSystemHandlers(mb: Menubar): void {
    */
   onMainEvent(EVENTS.UPDATE_KEEP_WINDOW_ON_BLUR, (_, value: boolean) => {
     applyKeepWindowOnBlur(mb, value);
+  });
+
+  /**
+   * Persist the Linux X11 backend preference. Only read during startup, so the
+   * change applies on the next launch.
+   */
+  onMainEvent(EVENTS.UPDATE_USE_X11_BACKEND, (_, value: boolean) => {
+    setX11Backend(value);
   });
 
   /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,8 +17,13 @@ import {
   onFirstRunMaybe,
 } from './lifecycle';
 import MenuBuilder from './menu';
+import { applyOzonePlatform } from './ozone';
 import AppUpdater from './updater';
 import { isDevMode } from './utils';
+
+// Runs at module load: the Ozone platform is read during app startup, so this
+// has to happen before `app.whenReady()` below.
+applyOzonePlatform();
 
 log.initialize();
 

--- a/src/main/ozone.test.ts
+++ b/src/main/ozone.test.ts
@@ -106,11 +106,24 @@ describe('main/ozone.ts', () => {
       expect(appendSwitchMock).toHaveBeenCalledWith('ozone-platform', 'x11');
     });
 
+    it('disables Vulkan alongside x11', () => {
+      setPlatform('linux');
+      setX11Backend(true);
+
+      applyOzonePlatform();
+
+      // Vulkan on X11 segfaults the GPU process on the NVIDIA proprietary
+      // driver, so the popup never paints. Both switches have to travel
+      // together or the setting trades a misplaced window for no window.
+      expect(appendSwitchMock).toHaveBeenCalledWith('disable-features', 'Vulkan');
+    });
+
     it('leaves the platform alone on Linux when disabled', () => {
       setPlatform('linux');
 
       applyOzonePlatform();
 
+      // Wayland users keep Vulkan; the switch is only a companion to X11.
       expect(appendSwitchMock).not.toHaveBeenCalled();
     });
 

--- a/src/main/ozone.test.ts
+++ b/src/main/ozone.test.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { applyOzonePlatform, isX11BackendEnabled, setX11Backend } from './ozone';
+
+const USER_DATA = '/tmp/gitify-test-userdata';
+const MARKER = path.join(USER_DATA, 'UseX11Backend');
+
+const appendSwitchMock = vi.fn();
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => (name === 'userData' ? '/tmp/gitify-test-userdata' : ''),
+    commandLine: {
+      appendSwitch: (...a: unknown[]) => appendSwitchMock(...a),
+    },
+  },
+}));
+
+const logErrorMock = vi.fn();
+vi.mock('../shared/logger', () => ({
+  logError: (...a: unknown[]) => logErrorMock(...a),
+  logInfo: vi.fn(),
+  toError: (e: unknown) => e,
+}));
+
+/** Swap `process.platform`, which is read-only on the real process object. */
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+describe('main/ozone.ts', () => {
+  const realPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Electron creates userData for a real app; the stubbed path needs it too.
+    fs.mkdirSync(USER_DATA, { recursive: true });
+    fs.rmSync(MARKER, { force: true });
+  });
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+    fs.rmSync(MARKER, { force: true });
+  });
+
+  describe('setX11Backend / isX11BackendEnabled', () => {
+    it('reports disabled when no marker exists', () => {
+      expect(isX11BackendEnabled()).toBe(false);
+    });
+
+    it('round-trips the preference through the marker file', () => {
+      setX11Backend(true);
+      expect(fs.existsSync(MARKER)).toBe(true);
+      expect(isX11BackendEnabled()).toBe(true);
+
+      setX11Backend(false);
+      expect(fs.existsSync(MARKER)).toBe(false);
+      expect(isX11BackendEnabled()).toBe(false);
+    });
+
+    it('is idempotent when disabling with no marker present', () => {
+      expect(() => setX11Backend(false)).not.toThrow();
+      expect(logErrorMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('applyOzonePlatform', () => {
+    it('forces x11 on Linux when enabled', () => {
+      setPlatform('linux');
+      setX11Backend(true);
+
+      applyOzonePlatform();
+
+      expect(appendSwitchMock).toHaveBeenCalledWith('ozone-platform', 'x11');
+    });
+
+    it('leaves the platform alone on Linux when disabled', () => {
+      setPlatform('linux');
+
+      applyOzonePlatform();
+
+      expect(appendSwitchMock).not.toHaveBeenCalled();
+    });
+
+    it('never forces x11 off Linux, even with a stale marker', () => {
+      // A marker copied between machines, or left by a previous Linux install
+      // sharing a synced profile, must not affect macOS or Windows.
+      setPlatform('darwin');
+      setX11Backend(true);
+
+      applyOzonePlatform();
+
+      expect(appendSwitchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/ozone.test.ts
+++ b/src/main/ozone.test.ts
@@ -63,6 +63,37 @@ describe('main/ozone.ts', () => {
       expect(() => setX11Backend(false)).not.toThrow();
       expect(logErrorMock).not.toHaveBeenCalled();
     });
+
+    it('logs and swallows a failure to write the marker', () => {
+      const writeSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+        throw new Error('EACCES');
+      });
+
+      expect(() => setX11Backend(true)).not.toThrow();
+      expect(logErrorMock).toHaveBeenCalledWith(
+        'setX11Backend',
+        expect.stringContaining('Unable to persist'),
+        expect.anything(),
+      );
+
+      writeSpy.mockRestore();
+    });
+
+    it('reports disabled when the marker cannot be read', () => {
+      const existsSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
+        throw new Error('EIO');
+      });
+
+      // Defaulting to "off" keeps a broken read from silently forcing X11.
+      expect(isX11BackendEnabled()).toBe(false);
+      expect(logErrorMock).toHaveBeenCalledWith(
+        'isX11BackendEnabled',
+        expect.stringContaining('Unable to read'),
+        expect.anything(),
+      );
+
+      existsSpy.mockRestore();
+    });
   });
 
   describe('applyOzonePlatform', () => {

--- a/src/main/ozone.ts
+++ b/src/main/ozone.ts
@@ -64,5 +64,14 @@ export function applyOzonePlatform(): void {
   }
 
   app.commandLine.appendSwitch('ozone-platform', 'x11');
-  logInfo('applyOzonePlatform', 'X11 backend enabled, forcing --ozone-platform=x11');
+  // Chromium skips Vulkan under Wayland because the two are incompatible, then
+  // initialises it once X11 is in play. On the NVIDIA proprietary driver that
+  // segfaults the GPU process, leaving the tray icon clickable but no window
+  // painted. Disabling Vulkan keeps the rest of GPU acceleration intact, which
+  // `--disable-gpu` would not.
+  app.commandLine.appendSwitch('disable-features', 'Vulkan');
+  logInfo(
+    'applyOzonePlatform',
+    'X11 backend enabled, forcing --ozone-platform=x11 --disable-features=Vulkan',
+  );
 }

--- a/src/main/ozone.ts
+++ b/src/main/ozone.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { app } from 'electron';
+
+import { logError, logInfo, toError } from '../shared/logger';
+
+/**
+ * Marker file in the user data directory whose presence selects the X11
+ * backend. The renderer owns every other setting via `localStorage`, which the
+ * main process cannot read, and the Ozone platform has to be chosen before the
+ * app is ready — long before a renderer exists. A file on disk is the only
+ * state available that early, so this setting is mirrored here rather than
+ * read from the settings store.
+ */
+const X11_MARKER_FILE = 'UseX11Backend';
+
+const markerPath = (): string => path.join(app.getPath('userData'), X11_MARKER_FILE);
+
+/**
+ * Whether the user has opted into the X11 backend.
+ */
+export function isX11BackendEnabled(): boolean {
+  try {
+    return fs.existsSync(markerPath());
+  } catch (err) {
+    logError('isX11BackendEnabled', 'Unable to read X11 backend marker', toError(err));
+    return false;
+  }
+}
+
+/**
+ * Persist the X11 backend preference. Takes effect on the next launch, since
+ * the Ozone platform is fixed once the app has started.
+ *
+ * @param enabled - `true` to run under X11/XWayland, `false` to let Electron pick.
+ */
+export function setX11Backend(enabled: boolean): void {
+  try {
+    if (enabled) {
+      fs.writeFileSync(markerPath(), '');
+      return;
+    }
+
+    fs.rmSync(markerPath(), { force: true });
+  } catch (err) {
+    logError('setX11Backend', 'Unable to persist X11 backend preference', toError(err));
+  }
+}
+
+/**
+ * Force the X11 Ozone backend when the user has opted in.
+ *
+ * Must run before the app is ready. Electron 38+ defaults the platform hint to
+ * `auto`, so a Wayland session gets a native Wayland client, where the
+ * compositor owns window placement and the tray reports no coordinates. The
+ * popup then opens centre-screen instead of under the tray icon. Running under
+ * XWayland restores tray-anchored positioning at the cost of native Wayland
+ * scaling, so it stays opt-in.
+ */
+export function applyOzonePlatform(): void {
+  if (process.platform !== 'linux' || !isX11BackendEnabled()) {
+    return;
+  }
+
+  app.commandLine.appendSwitch('ozone-platform', 'x11');
+  logInfo('applyOzonePlatform', 'X11 backend enabled, forcing --ozone-platform=x11');
+}

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -63,6 +63,7 @@ class MockNotification {
 interface TestApi {
   tray: { updateColor: (n?: number, isOnline?: boolean) => void };
   openExternalLink: (u: string, f: boolean) => void;
+  setUseX11Backend: (value: boolean) => void;
   app: { version: () => Promise<string>; show?: () => void; hide?: () => void };
   raiseNativeNotification: (t: string, b: string, u?: string) => unknown;
 }
@@ -97,6 +98,14 @@ describe('preload/index', () => {
       isOnline: true,
       notificationsCount: -1,
     });
+  });
+
+  it('setUseX11Backend sends the preference to main', async () => {
+    const api = getExposedApi();
+
+    api.setUseX11Backend(true);
+
+    expect(sendMainEventMock).toHaveBeenCalledWith(EVENTS.UPDATE_USE_X11_BACKEND, true);
   });
 
   it('openExternalLink sends event with payload', async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -64,6 +64,14 @@ export const api = {
   setKeepWindowOnBlur: (value: boolean) => sendMainEvent(EVENTS.UPDATE_KEEP_WINDOW_ON_BLUR, value),
 
   /**
+   * Persist whether Linux should run under the X11 backend. Applied at startup,
+   * so the change only takes effect after the app is restarted.
+   *
+   * @param value - `true` to force X11/XWayland, `false` to let Electron pick.
+   */
+  setUseX11Backend: (value: boolean) => sendMainEvent(EVENTS.UPDATE_USE_X11_BACKEND, value),
+
+  /**
    * Enable or disable the macOS window vibrancy material for Glass. Resolves once
    * the material has been applied so the renderer can order the visual switch.
    */

--- a/src/renderer/__helpers__/visual.setup.ts
+++ b/src/renderer/__helpers__/visual.setup.ts
@@ -109,6 +109,7 @@ function createGitifyBridgeApi(): Window['gitify'] {
     onSystemWake: vi.fn(() => vi.fn()),
     setAutoLaunch: vi.fn(),
     setKeepWindowOnBlur: vi.fn(),
+    setUseX11Backend: vi.fn(),
     applyKeyboardShortcut: vi.fn().mockResolvedValue({ success: true }),
     raiseNativeNotification: vi.fn(),
   };

--- a/src/renderer/__helpers__/vitest.setup.ts
+++ b/src/renderer/__helpers__/vitest.setup.ts
@@ -107,6 +107,7 @@ function createGitifyBridgeApi(): Window['gitify'] {
     onSystemWake: vi.fn(() => vi.fn()),
     setAutoLaunch: vi.fn(),
     setKeepWindowOnBlur: vi.fn(),
+    setUseX11Backend: vi.fn(),
     applyKeyboardShortcut: vi.fn().mockResolvedValue({ success: true }),
     raiseNativeNotification: vi.fn(),
   };

--- a/src/renderer/__mocks__/state-mocks.ts
+++ b/src/renderer/__mocks__/state-mocks.ts
@@ -63,6 +63,7 @@ const mockSystemSettings: SystemSettingsState = {
   notificationVolume: 20 as Percentage,
   openAtStartup: false,
   keepWindowOnBlur: false,
+  useX11Backend: false,
 };
 
 export const mockSettings: SettingsState = {

--- a/src/renderer/components/settings/SystemSettings.test.tsx
+++ b/src/renderer/components/settings/SystemSettings.test.tsx
@@ -46,6 +46,34 @@ describe('renderer/components/settings/SystemSettings.tsx', () => {
     expect(toggleSettingSpy).toHaveBeenCalledWith(setting);
   });
 
+  describe('X11 backend checkbox', () => {
+    // `window.gitify` is rebuilt in a global `beforeEach`, so the mock has to
+    // be read inside each test rather than captured at describe scope.
+    const isLinuxMock = () => window.gitify.platform.isLinux as unknown as ReturnType<typeof vi.fn>;
+
+    it('is hidden off Linux', async () => {
+      isLinuxMock().mockReturnValue(false);
+
+      await act(async () => {
+        renderWithProviders(<SystemSettings />);
+      });
+
+      expect(screen.queryByTestId('checkbox-useX11Backend')).not.toBeInTheDocument();
+    });
+
+    it('is shown and toggles on Linux', async () => {
+      isLinuxMock().mockReturnValue(true);
+
+      await act(async () => {
+        renderWithProviders(<SystemSettings />);
+      });
+
+      await userEvent.click(screen.getByTestId('checkbox-useX11Backend'));
+
+      expect(toggleSettingSpy).toHaveBeenCalledWith('useX11Backend');
+    });
+  });
+
   it('should reset global shortcut to default when customized', async () => {
     renderWithProviders(<SystemSettings />, {
       settings: {

--- a/src/renderer/components/settings/SystemSettings.tsx
+++ b/src/renderer/components/settings/SystemSettings.tsx
@@ -51,6 +51,7 @@ export const SystemSettings: FC = () => {
   const notificationVolume = useSettingsStore((s) => s.notificationVolume);
   const keepWindowOnBlur = useSettingsStore((s) => s.keepWindowOnBlur);
   const openAtStartup = useSettingsStore((s) => s.openAtStartup);
+  const useX11Backend = useSettingsStore((s) => s.useX11Backend);
 
   const [recordingShortcut, setRecordingShortcut] = useState(false);
   const [liveModifierAccelerator, setLiveModifierAccelerator] = useState('');
@@ -342,6 +343,22 @@ export const SystemSettings: FC = () => {
           onChange={() => toggleSetting('openAtStartup')}
           tooltip={<Text>Launch {APPLICATION.NAME} automatically at startup.</Text>}
           visible={!window.gitify.platform.isLinux()}
+        />
+
+        <Checkbox
+          checked={useX11Backend}
+          label="Use X11 backend (restart required)"
+          name="useX11Backend"
+          onChange={() => toggleSetting('useX11Backend')}
+          tooltip={
+            <Text>
+              Run under X11/XWayland so the window opens next to the tray icon. On Wayland the
+              compositor decides where windows appear, so {APPLICATION.NAME} opens in the middle of
+              the screen. Enabling this may soften text on displays using fractional scaling. Takes
+              effect after restarting {APPLICATION.NAME}.
+            </Text>
+          }
+          visible={window.gitify.platform.isLinux()}
         />
       </Stack>
     </fieldset>

--- a/src/renderer/components/settings/SystemSettings.tsx
+++ b/src/renderer/components/settings/SystemSettings.tsx
@@ -354,8 +354,9 @@ export const SystemSettings: FC = () => {
             <Text>
               Run under X11/XWayland so the window opens next to the tray icon. On Wayland the
               compositor decides where windows appear, so {APPLICATION.NAME} opens in the middle of
-              the screen. Enabling this may soften text on displays using fractional scaling. Takes
-              effect after restarting {APPLICATION.NAME}.
+              the screen. Enabling this also disables Vulkan, which crashes under X11 on some
+              drivers, and may soften text on displays using fractional scaling. Takes effect after
+              restarting {APPLICATION.NAME}.
             </Text>
           }
           visible={window.gitify.platform.isLinux()}

--- a/src/renderer/stores/defaults.ts
+++ b/src/renderer/stores/defaults.ts
@@ -87,6 +87,7 @@ const DEFAULT_SYSTEM_SETTINGS: SystemSettingsState = {
   notificationVolume: 20 as Percentage,
   openAtStartup: false,
   keepWindowOnBlur: false,
+  useX11Backend: false,
 };
 
 /**

--- a/src/renderer/stores/subscriptions.test.ts
+++ b/src/renderer/stores/subscriptions.test.ts
@@ -14,6 +14,7 @@ describe('renderer/stores/subscriptions.ts', () => {
   const setUseAlternateIdleIconSpy = vi
     .spyOn(comms, 'setUseAlternateIdleIcon')
     .mockImplementation(vi.fn());
+  const setUseX11BackendSpy = vi.spyOn(comms, 'setUseX11Backend').mockImplementation(vi.fn());
 
   let cleanup: (() => void) | null = null;
 
@@ -53,6 +54,9 @@ describe('renderer/stores/subscriptions.ts', () => {
 
     useSettingsStore.getState().updateSetting('useAlternateIdleIcon', true);
     expect(setUseAlternateIdleIconSpy).toHaveBeenCalledWith(true);
+
+    useSettingsStore.getState().updateSetting('useX11Backend', true);
+    expect(setUseX11BackendSpy).toHaveBeenCalledWith(true);
   });
 
   it('applies zoom level when zoom percentage changes', () => {

--- a/src/renderer/stores/subscriptions.ts
+++ b/src/renderer/stores/subscriptions.ts
@@ -10,6 +10,7 @@ import {
   setKeepWindowOnBlur,
   setUseAlternateIdleIcon,
   setUseUnreadActiveIcon,
+  setUseX11Backend,
 } from '../utils/system/comms';
 import { zoomLevelToPercentage, zoomPercentageToLevel } from '../utils/ui/zoom';
 import { useSettingsStore } from './';
@@ -55,6 +56,17 @@ export function initializeStoreSubscriptions(): () => void {
     },
   );
   unsubscribers.push(unsubKeepWindowOnBlur);
+
+  // Linux X11 backend. Not applied on startup: the main process reads its own
+  // marker file before the renderer exists, so mirroring it here would be
+  // redundant. Only the change needs forwarding.
+  const unsubUseX11Backend = useSettingsStore.subscribe(
+    (state) => state.useX11Backend,
+    (useX11Backend) => {
+      setUseX11Backend(useX11Backend);
+    },
+  );
+  unsubscribers.push(unsubUseX11Backend);
 
   // Tray icon settings (unread active icon)
   const unsubUnreadActive = useSettingsStore.subscribe(

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -140,6 +140,8 @@ export interface SystemSettingsState {
   notificationVolume: Percentage;
   openAtStartup: boolean;
   keepWindowOnBlur: boolean;
+  /** Linux only. Runs under X11/XWayland so the popup can be anchored to the tray icon. */
+  useX11Backend: boolean;
 }
 
 /** Values are lower-cased because they double as the root `data-theme` attribute. */

--- a/src/renderer/utils/system/comms.test.ts
+++ b/src/renderer/utils/system/comms.test.ts
@@ -14,6 +14,7 @@ import {
   setAutoLaunch,
   setKeepWindowOnBlur,
   setUseAlternateIdleIcon,
+  setUseX11Backend,
   showWindow,
   updateTrayColor,
   updateTrayTitle,
@@ -118,6 +119,13 @@ describe('renderer/utils/comms.ts', () => {
 
       expect(window.gitify.setKeepWindowOnBlur).toHaveBeenCalledTimes(1);
       expect(window.gitify.setKeepWindowOnBlur).toHaveBeenCalledWith(true);
+    });
+
+    it('sets the X11 backend preference', () => {
+      setUseX11Backend(true);
+
+      expect(window.gitify.setUseX11Backend).toHaveBeenCalledTimes(1);
+      expect(window.gitify.setUseX11Backend).toHaveBeenCalledWith(true);
     });
 
     it('applies keyboard shortcut', async () => {

--- a/src/renderer/utils/system/comms.ts
+++ b/src/renderer/utils/system/comms.ts
@@ -92,6 +92,18 @@ export function setKeepWindowOnBlur(value: boolean): void {
 }
 
 /**
+ * Persist whether Linux should run under the X11 backend.
+ *
+ * The Ozone platform is fixed while the app starts, so this only takes effect
+ * on the next launch.
+ *
+ * @param value - `true` to force X11/XWayland, `false` to let Electron pick.
+ */
+export function setUseX11Backend(value: boolean): void {
+  window.gitify.setUseX11Backend(value);
+}
+
+/**
  * Switch the tray icon to an alternate idle icon variant.
  *
  * @param value - `true` to use the alternate idle icon, `false` for the default.

--- a/src/shared/events.ts
+++ b/src/shared/events.ts
@@ -17,6 +17,7 @@ export const EVENTS = {
   UPDATE_KEYBOARD_SHORTCUT: `${P}update-keyboard-shortcut`,
   UPDATE_AUTO_LAUNCH: `${P}update-auto-launch`,
   UPDATE_KEEP_WINDOW_ON_BLUR: `${P}update-keep-window-on-blur`,
+  UPDATE_USE_X11_BACKEND: `${P}update-use-x11-backend`,
   SET_WINDOW_VIBRANCY: `${P}set-window-vibrancy`,
   SET_NATIVE_THEME: `${P}set-native-theme`,
   SAFE_STORAGE_ENCRYPT: `${P}safe-storage-encrypt`,
@@ -108,6 +109,10 @@ export type EventContracts = AssertEventCoverage<{
   };
   [EVENTS.UPDATE_AUTO_LAUNCH]: { request: IAutoLaunch; response: undefined };
   [EVENTS.UPDATE_KEEP_WINDOW_ON_BLUR]: {
+    request: boolean;
+    response: undefined;
+  };
+  [EVENTS.UPDATE_USE_X11_BACKEND]: {
     request: boolean;
     response: undefined;
   };


### PR DESCRIPTION
## Summary

Adds a Linux-only **"Use X11 backend (restart required)"** setting under System settings. When enabled, Gitify starts with `--ozone-platform=x11`, which restores tray-anchored window positioning.

## Why

Electron 38 changed the default `--ozone-platform-hint` to `auto` ([electron#35630](https://github.com/electron/electron/pull/35630)), so on Electron 43 a Wayland session gets a **native Wayland client**. Under Wayland an app cannot position its own window (`setPosition` is a no-op, `getPosition` reads back `[0, 0]`) and the tray icon reports no coordinates over StatusNotifierItem, so the compositor decides placement and the popup lands centre-screen. That is #2341.

This is a protocol design decision rather than an Electron bug, so no future release fixes it. Running under XWayland is the only way to get anchored positioning back.

## Why opt-in rather than forced

Forcing X11 would fix placement for everyone but degrade every Wayland user: XWayland means blurrier fractional scaling, no per-monitor DPI, and it breaks on Wayland-only setups without XWayland installed. It would also override a session choice the user already made. Notably [teams-for-linux is moving the other way](https://github.com/IsmaelMartinez/teams-for-linux/issues/2508), removing its forced `--ozone-platform=x11` now that Wayland has matured.

The tradeoff is genuinely user-specific (a HiDPI laptop user may prefer crisp text; a multi-monitor desktop user probably wants anchoring), so it belongs in the user's hands. Defaulting to `false` keeps current behaviour unchanged. If feedback shows most Linux users want anchoring, flipping the default later is a one-line change.

## Why it needs a restart, and why a file

The Ozone platform is read during startup, so the switch must be appended **before `app.whenReady()`** — earlier than any renderer exists.

Every other setting lives in the renderer (Zustand → `localStorage`), which the main process cannot read at that point. So this one setting is mirrored to a marker file in `userData`, following the existing `FirstRun` marker precedent:

- `src/main/ozone.ts` owns the marker: `isX11BackendEnabled()`, `setX11Backend()`, `applyOzonePlatform()`.
- `src/main/index.ts` calls `applyOzonePlatform()` at module load, before `app.whenReady()`.
- Toggling the setting sends `UPDATE_USE_X11_BACKEND` to main, which writes/removes the marker. The label says "restart required" and the tooltip repeats it.

`applyOzonePlatform()` is a no-op off Linux even if a marker exists, so a profile synced from a Linux machine can't affect macOS or Windows.

Refs #2341

---

## Update: verified on hardware, plus a required companion switch

@alexey-anufriev tested a build of this branch on Kubuntu 25.10 / Plasma 6 Wayland (gitify-app/gitify#2341) and confirmed two things.

**The mechanism works.** The log line proves the full chain on a real packaged Linux build:

```
[applyOzonePlatform] X11 backend enabled, forcing --ozone-platform=x11
```

**But X11 alone was not enough.** With only the ozone switch, the GPU process segfaulted repeatedly and no window ever painted:

```
GPU process exited unexpectedly: exit_code=139   (x3)   # 128 + 11 = SIGSEGV
XGetWindowAttributes failed for window 1
```

The tray icon appeared and responded to clicks, but the popup never rendered, which is worse than the centre-screen placement this setting exists to fix.

The cause was Vulkan, and the reporter's own Wayland log named it:

> `'--ozone-platform=wayland' is not compatible with Vulkan. Consider switching to '--ozone-platform=x11' or disabling Vulkan`

Chromium skips Vulkan under Wayland because the two are incompatible, then initialises it once X11 is in play. On the NVIDIA proprietary driver (RTX 3080 Ti, `nvidia` kernel driver) that initialisation segfaults the GPU process.

Two candidates were tested on the affected machine:

| | flags | result |
| --- | --- | --- |
| A | `--ozone-platform=x11 --disable-features=Vulkan` | **window correctly placed, no errors** |
| B | `--ozone-platform=x11 --disable-gpu` | window correctly placed, no errors |

Both work, so **A** was chosen: it keeps hardware acceleration, where `--disable-gpu` would throw all of it away to solve one broken code path.

`applyOzonePlatform()` now appends both switches together, and a test asserts they travel as a pair, since shipping the ozone switch alone reintroduces the no-window failure. Wayland users are unaffected: neither switch is applied unless the setting is on. The tooltip now mentions the Vulkan tradeoff.

Verified as exactly the flag combination that was tested on the affected hardware, rather than an equivalent-looking one.