### PR TITLE
chore(deps-core): update electron to v43.5.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   react-is: 19.2.8
   cross-spawn: 7.0.6
   got: 11.8.6
-  electron: 43.2.0
+  electron: 43.5.1
 
 importers:
 
@@ -22,7 +22,7 @@ importers:
         version: 5.4.4
       electron-menubar:
         specifier: 10.2.1
-        version: 10.2.1(electron@43.2.0(supports-color@10.2.2))
+        version: 10.2.1(electron@43.5.1(supports-color@10.2.2))
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@10.2.2)
@@ -142,8 +142,8 @@ importers:
         specifier: 17.4.2
         version: 17.4.2
       electron:
-        specifier: 43.2.0
-        version: 43.2.0(supports-color@10.2.2)
+        specifier: 43.5.1
+        version: 43.5.1(supports-color@10.2.2)
       electron-builder:
         specifier: 26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
@@ -2563,7 +2563,7 @@ packages:
   electron-menubar@10.2.1:
     resolution: {integrity: sha512-JIpqGjVYUSloNJn/8hqotzFIRNmJ0jpGQJjXGs4GB/viy8cXIBlWj2G30w+SqJR7TKa+EBhXrMLSA73HdP/VgA==}
     peerDependencies:
-      electron: 43.2.0
+      electron: 43.5.1
 
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
@@ -2578,8 +2578,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.2.0:
-    resolution: {integrity: sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==}
+  electron@43.5.1:
+    resolution: {integrity: sha512-lRHSwzZimdWWeqcTHFRCpicWwxBE6kotKIyGTusums/jvmVVC27rLPFikUz8LsLwV7gVWlYaiEYQAWzitbN6nA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -6858,9 +6858,9 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-menubar@10.2.1(electron@43.2.0(supports-color@10.2.2)):
+  electron-menubar@10.2.1(electron@43.5.1(supports-color@10.2.2)):
     dependencies:
-      electron: 43.2.0(supports-color@10.2.2)
+      electron: 43.5.1(supports-color@10.2.2)
 
   electron-publish@26.15.3(supports-color@10.2.2):
     dependencies:
@@ -6903,7 +6903,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.2.0(supports-color@10.2.2):
+  electron@43.5.1(supports-color@10.2.2):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@10.2.2)
@@ -8087,7 +8087,7 @@ snapshots:
   react-devtools@7.0.1(supports-color@10.2.2):
     dependencies:
       cross-spawn: 7.0.6
-      electron: 43.2.0(supports-color@10.2.2)
+      electron: 43.5.1(supports-color@10.2.2)
       internal-ip: 6.2.0
       minimist: 1.2.8
       react-devtools-core: 7.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ allowBuilds:
   esbuild: true
   unrs-resolver: true
 catalog:
-  electron: '43.2.0'
+  electron: '43.5.1'
 minimumReleaseAgeExclude:
   - electron-menubar
 overrides:

--- a/renovate.json
+++ b/renovate.json
@@ -31,11 +31,6 @@
       "allowedVersions": "<12"
     },
     {
-      "description": "Hold electron below 43.3.0. The Chromium StatusNotifierItem multiplexer that arrived in 43.3.0 (electron#52416) collapses every tray icon onto a single /StatusNotifierItem object path, so desktops that address the item by its unique D-Bus name instead of its well-known name can no longer resolve the icon and render nothing. Gitify is a tray-first app, so this makes it unusable on those desktops. electron-menubar's visual tray matrix reproduces it on Budgie, Sway/Waybar and LXQt while KDE Plasma stays unaffected. 43.4.1 does NOT fix it despite its release note claiming a Linux tray fix; that change (electron#52952) is described upstream as a bad fix and coincided with LXQt breaking too. Remove this hold only once electron#52674 is closed AND electron-menubar's visual matrix is green on the candidate version.",
-      "matchPackageNames": ["electron"],
-      "allowedVersions": "<43.3.0"
-    },
-    {
       "description": "Group the playwright package with the Playwright container image that the visual regression job runs in. The image ships the browser build that exact release expects, so a mismatch fails to launch Chromium and would strand the committed screenshot baselines.",
       "matchPackageNames": ["playwright", "mcr.microsoft.com/playwright"],
       "groupName": "playwright"


### PR DESCRIPTION
## Summary

Bumps `electron` 43.2.0 → **43.5.1** via the pnpm catalog, and lifts the Renovate hold that was keeping Electron below 43.3.0.

## Why now

The hold existed because 43.3.0–43.4.1 broke Linux SNI tray icons ([electron#52674](https://github.com/electron/electron/issues/52674)), which shipped in 7.3.0–7.4.0 and was reported as #3206. Its description set two removal criteria: the upstream issue resolved, **and** electron-menubar's visual tray matrix green on the candidate.

The genuine upstream fix is [electron#53215](https://github.com/electron/electron/pull/53215) (43-x-y), merged 2026-08-26 and shipped in **43.5.0**. It re-exports the StatusNotifierItem at `/StatusNotifierItem` and registers only the well-known name, so `GDBusProxy`-based hosts (GNOME AppIndicator, xApp/Budgie, waybar, LXQt) can resolve it again. YUCLing, who did the root-cause analysis on 52674, confirmed on 2026-08-27 that this is the fix.

## Verified, not trusted

43.4.1's release note read just as convincingly and fixed nothing. So this bump rests on the matrix, which has now confirmed the fix **three times**:

| electron-menubar PR | Electron | Budgie | Sway/Waybar | LXQt | platforms |
| --- | --- | --- | --- | --- | --- |
| gitify-app/electron-menubar#169 | 43.5.1 | `exactTray=281`, attempt 1 | `484`, attempt 1 | `484`, attempt 1 | 14/14 |
| gitify-app/electron-menubar#170 | 44.1.1 | `281`, attempt 1 | `484`, attempt 1 | `484`, attempt 1 | 14/14 |
| gitify-app/electron-menubar#162 (Renovate) | 43.5.0 | pass | pass | pass | 26 checks |

Those pixel counts are **identical to the 43.2.0 baseline**, on the first capture with no retries. For contrast, 43.4.1 gave `exactTray=0` across 20–29 exhausted attempts on the same three jobs (gitify-app/electron-menubar#154).

## Changes

- `pnpm-workspace.yaml`: `catalog.electron` 43.2.0 → 43.5.1. This is now the single pin; `package.json` references `catalog:` and `overrides.electron: 'catalog:'` forces every transitive resolution to match.
- `renovate.json`: removes the `allowedVersions: "<43.3.0"` hold. Both of its removal criteria are met on the evidence above. Renovate proposes the latest in each major, so it cannot resurface the broken 43.3.x/43.4.x range, and 44.0.0 (which carries only the bad fix) is already superseded by 44.1.x.
- `pnpm-lock.yaml`: electron-only.

## Verification

- `pnpm test`: **1509 passed / 173 files**.
- `check` (format + lint, 455/405 files), `tsc --noEmit` and `build` clean.

## Note on 44

Renovate will now also propose Electron 44 for gitify. 44.1.x carries the same fix (#53214) and passed the matrix, but it is a major Chromium/Node bump and should be taken on its own merits, separately from this tray fix.

Refs #3206
