### PR TITLE
refactor(forges): bind account-scoped adapter operations via getAccountAdapter

### DIFF
--- a/src/renderer/components/notifications/NotificationFooter.tsx
+++ b/src/renderer/components/notifications/NotificationFooter.tsx
@@ -6,7 +6,7 @@ import { cn } from 'cn';
 
 import { type GitifyNotification, Opacity, Size } from '../../types';
 
-import { getAdapter } from '../../utils/forges/registry';
+import { forAccount } from '../../utils/forges/registry';
 import { openUserProfile } from '../../utils/system/links';
 import { AvatarWithFallback } from '../avatars/AvatarWithFallback';
 import { MetricGroup } from '../metrics/MetricGroup';
@@ -20,7 +20,7 @@ export const NotificationFooter: FC<NotificationFooterProps> = ({
 }: NotificationFooterProps) => {
   const user = notification.subject.user;
   const userLabel = user
-    ? getAdapter(notification.account).formatNotificationUser(notification.account, user)
+    ? forAccount(notification.account).formatNotificationUser(user)
     : undefined;
 
   return (

--- a/src/renderer/components/notifications/NotificationFooter.tsx
+++ b/src/renderer/components/notifications/NotificationFooter.tsx
@@ -6,7 +6,7 @@ import { cn } from 'cn';
 
 import { type GitifyNotification, Opacity, Size } from '../../types';
 
-import { forAccount } from '../../utils/forges/registry';
+import { getAccountAdapter } from '../../utils/forges/registry';
 import { openUserProfile } from '../../utils/system/links';
 import { AvatarWithFallback } from '../avatars/AvatarWithFallback';
 import { MetricGroup } from '../metrics/MetricGroup';
@@ -20,7 +20,7 @@ export const NotificationFooter: FC<NotificationFooterProps> = ({
 }: NotificationFooterProps) => {
   const user = notification.subject.user;
   const userLabel = user
-    ? forAccount(notification.account).formatNotificationUser(user)
+    ? getAccountAdapter(notification.account).formatNotificationUser(user)
     : undefined;
 
   return (

--- a/src/renderer/hooks/useLogins.test.tsx
+++ b/src/renderer/hooks/useLogins.test.tsx
@@ -161,7 +161,7 @@ describe('renderer/hooks/useLogins.ts', () => {
   });
 
   it('loginWithPersonalAccessToken forwards username for Bitbucket accounts', async () => {
-    vi.spyOn(getAdapter('bitbucket'), 'fetchAuthenticatedUser').mockResolvedValue({
+    vi.spyOn(getAdapter('bitbucket').accountOps, 'fetchAuthenticatedUser').mockResolvedValue({
       user: {
         id: mockBitbucketAccount.user!.id,
         login: mockBitbucketAccount.user!.login,

--- a/src/renderer/hooks/useLogins.ts
+++ b/src/renderer/hooks/useLogins.ts
@@ -12,7 +12,7 @@ import type {
 } from '../utils/auth/types';
 
 import { notificationsKeys } from '../utils/api/queryKeys';
-import { forAccount, getAdapter } from '../utils/forges/registry';
+import { getAccountAdapter, getAdapter } from '../utils/forges/registry';
 import { encryptValue } from '../utils/system/comms';
 import { useNotifications } from './useNotifications';
 
@@ -136,7 +136,7 @@ export const useLogins = (): LoginsState => {
     async ({ token, hostname, forge, username }: LoginPersonalAccessTokenOptions) => {
       const resolvedForge: Forge = forge ?? 'github';
       const encryptedToken = (await encryptValue(token)) as Token;
-      await forAccount({
+      await getAccountAdapter({
         forge: resolvedForge,
         hostname,
         token: encryptedToken,

--- a/src/renderer/hooks/useLogins.ts
+++ b/src/renderer/hooks/useLogins.ts
@@ -12,7 +12,7 @@ import type {
 } from '../utils/auth/types';
 
 import { notificationsKeys } from '../utils/api/queryKeys';
-import { getAdapter } from '../utils/forges/registry';
+import { forAccount, getAdapter } from '../utils/forges/registry';
 import { encryptValue } from '../utils/system/comms';
 import { useNotifications } from './useNotifications';
 
@@ -136,12 +136,12 @@ export const useLogins = (): LoginsState => {
     async ({ token, hostname, forge, username }: LoginPersonalAccessTokenOptions) => {
       const resolvedForge: Forge = forge ?? 'github';
       const encryptedToken = (await encryptValue(token)) as Token;
-      await getAdapter(resolvedForge).fetchAuthenticatedUser({
+      await forAccount({
         forge: resolvedForge,
         hostname,
         token: encryptedToken,
         username,
-      } as Account);
+      } as Account).fetchAuthenticatedUser();
 
       const existingAccount = accounts.find(
         (a) =>

--- a/src/renderer/hooks/useNotifications.test.tsx
+++ b/src/renderer/hooks/useNotifications.test.tsx
@@ -529,7 +529,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
   describe('markNotificationsAsRead', () => {
     it('marks notifications as read via the forge adapter and removes them', async () => {
       const markThreadAsReadSpy = vi
-        .spyOn(githubAdapter, 'markThreadAsRead')
+        .spyOn(githubAdapter.accountOps, 'markThreadAsRead')
         .mockResolvedValue(undefined);
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
@@ -549,7 +549,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
     });
 
     it('logs an error when marking as read fails', async () => {
-      vi.spyOn(githubAdapter, 'markThreadAsRead').mockRejectedValue(new Error('boom'));
+      vi.spyOn(githubAdapter.accountOps, 'markThreadAsRead').mockRejectedValue(new Error('boom'));
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
       const { result } = renderNotificationsHook();
@@ -563,7 +563,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
     });
 
     it('rolls back the cache for a failed notification while a failed request does not affect it', async () => {
-      vi.spyOn(githubAdapter, 'markThreadAsRead').mockRejectedValue(new Error('boom'));
+      vi.spyOn(githubAdapter.accountOps, 'markThreadAsRead').mockRejectedValue(new Error('boom'));
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
       const { result } = renderNotificationsHook();
@@ -593,11 +593,13 @@ describe('renderer/hooks/useNotifications.ts', () => {
         },
       ]);
 
-      vi.spyOn(githubAdapter, 'markThreadAsRead').mockImplementation(async (_account, id) => {
-        if (id === failsNotification.id) {
-          throw new Error('boom');
-        }
-      });
+      vi.spyOn(githubAdapter.accountOps, 'markThreadAsRead').mockImplementation(
+        async (_account, id) => {
+          if (id === failsNotification.id) {
+            throw new Error('boom');
+          }
+        },
+      );
 
       const { result } = renderNotificationsHook();
       await waitFor(() => expect(result.current.notificationCount).toBe(2));
@@ -627,7 +629,7 @@ describe('renderer/hooks/useNotifications.ts', () => {
   describe('markNotificationsAsDone', () => {
     it('marks notifications as done via the forge adapter', async () => {
       const markThreadAsDoneSpy = vi
-        .spyOn(githubAdapter, 'markThreadAsDone')
+        .spyOn(githubAdapter.accountOps, 'markThreadAsDone')
         .mockResolvedValue(undefined);
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
@@ -648,13 +650,13 @@ describe('renderer/hooks/useNotifications.ts', () => {
 
     it('falls back to mark as read when the forge does not support done', async () => {
       const markAsDoneCapabilitySpy = vi
-        .spyOn(githubAdapter.capabilities, 'markAsDone')
+        .spyOn(githubAdapter.accountOps.capabilities, 'markAsDone')
         .mockReturnValue(false);
       const markThreadAsDoneSpy = vi
-        .spyOn(githubAdapter, 'markThreadAsDone')
+        .spyOn(githubAdapter.accountOps, 'markThreadAsDone')
         .mockResolvedValue(undefined);
       const markThreadAsReadSpy = vi
-        .spyOn(githubAdapter, 'markThreadAsRead')
+        .spyOn(githubAdapter.accountOps, 'markThreadAsRead')
         .mockResolvedValue(undefined);
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
@@ -674,9 +676,9 @@ describe('renderer/hooks/useNotifications.ts', () => {
 
     it('reconciles a failed mark-as-read fallback only once', async () => {
       const markAsDoneCapabilitySpy = vi
-        .spyOn(githubAdapter.capabilities, 'markAsDone')
+        .spyOn(githubAdapter.accountOps.capabilities, 'markAsDone')
         .mockReturnValue(false);
-      vi.spyOn(githubAdapter, 'markThreadAsRead').mockRejectedValue(new Error('boom'));
+      vi.spyOn(githubAdapter.accountOps, 'markThreadAsRead').mockRejectedValue(new Error('boom'));
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
       const { result } = renderNotificationsHook();
@@ -702,13 +704,13 @@ describe('renderer/hooks/useNotifications.ts', () => {
   describe('unsubscribeNotification', () => {
     it('unsubscribes and marks as read by default', async () => {
       const unsubscribeThreadSpy = vi
-        .spyOn(githubAdapter, 'unsubscribeThread')
+        .spyOn(githubAdapter.accountOps, 'unsubscribeThread')
         .mockResolvedValue(undefined);
       const markThreadAsReadSpy = vi
-        .spyOn(githubAdapter, 'markThreadAsRead')
+        .spyOn(githubAdapter.accountOps, 'markThreadAsRead')
         .mockResolvedValue(undefined);
       const markThreadAsDoneSpy = vi
-        .spyOn(githubAdapter, 'markThreadAsDone')
+        .spyOn(githubAdapter.accountOps, 'markThreadAsDone')
         .mockResolvedValue(undefined);
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
@@ -731,13 +733,13 @@ describe('renderer/hooks/useNotifications.ts', () => {
       useSettingsStore.setState({ markAsDoneOnUnsubscribe: true });
 
       const unsubscribeThreadSpy = vi
-        .spyOn(githubAdapter, 'unsubscribeThread')
+        .spyOn(githubAdapter.accountOps, 'unsubscribeThread')
         .mockResolvedValue(undefined);
       const markThreadAsReadSpy = vi
-        .spyOn(githubAdapter, 'markThreadAsRead')
+        .spyOn(githubAdapter.accountOps, 'markThreadAsRead')
         .mockResolvedValue(undefined);
       const markThreadAsDoneSpy = vi
-        .spyOn(githubAdapter, 'markThreadAsDone')
+        .spyOn(githubAdapter.accountOps, 'markThreadAsDone')
         .mockResolvedValue(undefined);
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
@@ -754,8 +756,8 @@ describe('renderer/hooks/useNotifications.ts', () => {
     });
 
     it('keeps a failed follow-up action recorded after unsubscribe succeeds', async () => {
-      vi.spyOn(githubAdapter, 'unsubscribeThread').mockResolvedValue(undefined);
-      vi.spyOn(githubAdapter, 'markThreadAsRead').mockRejectedValue(new Error('boom'));
+      vi.spyOn(githubAdapter.accountOps, 'unsubscribeThread').mockResolvedValue(undefined);
+      vi.spyOn(githubAdapter.accountOps, 'markThreadAsRead').mockRejectedValue(new Error('boom'));
       getAllNotificationsMock.mockResolvedValue(mockSingleAccountNotifications);
 
       const { result } = renderNotificationsHook();

--- a/src/renderer/hooks/useNotifications.ts
+++ b/src/renderer/hooks/useNotifications.ts
@@ -32,7 +32,7 @@ import { notificationsKeys } from '../utils/api/queryKeys';
 import { getAccountUUID } from '../utils/auth/utils';
 import { areAllAccountErrorsSame, doesAllAccountsHaveErrors, Errors } from '../utils/core/errors';
 import { rendererLogError, toError } from '../utils/core/logger';
-import { getAdapter } from '../utils/forges/registry';
+import { forAccount } from '../utils/forges/registry';
 import {
   filterBaseNotifications,
   filterDetailedNotifications,
@@ -472,7 +472,7 @@ export const useNotifications = ({
   const markNotificationsAsReadMutation = useMutation({
     mutationFn: async ({ readNotifications }: { readNotifications: GitifyNotification[] }) => {
       return await settleNotificationActions(readNotifications, (notification) =>
-        getAdapter(notification.account).markThreadAsRead(notification.account, notification.id),
+        forAccount(notification.account).markThreadAsRead(notification.id),
       );
     },
 
@@ -524,7 +524,7 @@ export const useNotifications = ({
       }
 
       return await settleNotificationActions(doneNotifications, (notification) =>
-        getAdapter(notification.account).markThreadAsDone(notification.account, notification.id),
+        forAccount(notification.account).markThreadAsDone(notification.id),
       );
     },
 
@@ -572,7 +572,7 @@ export const useNotifications = ({
       }
 
       const result = await settleNotificationActions([notification], (n) =>
-        getAdapter(n.account).unsubscribeThread(n.account, n.id),
+        forAccount(n.account).unsubscribeThread(n.id),
       );
 
       if (result.failed.length > 0) {

--- a/src/renderer/hooks/useNotifications.ts
+++ b/src/renderer/hooks/useNotifications.ts
@@ -32,7 +32,7 @@ import { notificationsKeys } from '../utils/api/queryKeys';
 import { getAccountUUID } from '../utils/auth/utils';
 import { areAllAccountErrorsSame, doesAllAccountsHaveErrors, Errors } from '../utils/core/errors';
 import { rendererLogError, toError } from '../utils/core/logger';
-import { forAccount } from '../utils/forges/registry';
+import { getAccountAdapter } from '../utils/forges/registry';
 import {
   filterBaseNotifications,
   filterDetailedNotifications,
@@ -472,7 +472,7 @@ export const useNotifications = ({
   const markNotificationsAsReadMutation = useMutation({
     mutationFn: async ({ readNotifications }: { readNotifications: GitifyNotification[] }) => {
       return await settleNotificationActions(readNotifications, (notification) =>
-        forAccount(notification.account).markThreadAsRead(notification.id),
+        getAccountAdapter(notification.account).markThreadAsRead(notification.id),
       );
     },
 
@@ -524,7 +524,7 @@ export const useNotifications = ({
       }
 
       return await settleNotificationActions(doneNotifications, (notification) =>
-        forAccount(notification.account).markThreadAsDone(notification.id),
+        getAccountAdapter(notification.account).markThreadAsDone(notification.id),
       );
     },
 
@@ -572,7 +572,7 @@ export const useNotifications = ({
       }
 
       const result = await settleNotificationActions([notification], (n) =>
-        forAccount(n.account).unsubscribeThread(n.id),
+        getAccountAdapter(n.account).unsubscribeThread(n.id),
       );
 
       if (result.failed.length > 0) {

--- a/src/renderer/routes/Accounts.tsx
+++ b/src/renderer/routes/Accounts.tsx
@@ -228,7 +228,7 @@ export const AccountsRoute: FC = () => {
                       variant={i === 0 ? 'primary' : 'default'}
                     />
 
-                    {!hasBadCredentials && adapter.oauthScopes && (
+                    {!hasBadCredentials && adapter.accountOps.oauthScopes && (
                       <IconButton
                         aria-label={`View scopes for ${account.user?.login}`}
                         data-testid="account-view-scopes"

--- a/src/renderer/stores/useAccountsStore.test.ts
+++ b/src/renderer/stores/useAccountsStore.test.ts
@@ -274,7 +274,7 @@ describe('renderer/stores/useAccountsStore.ts', () => {
 
     test('should drop forge client state for every account', () => {
       const onAccountTokenChangeSpy = vi
-        .spyOn(getAdapter(mockGitHubCloudAccount), 'onAccountTokenChange')
+        .spyOn(getAdapter(mockGitHubCloudAccount).accountOps, 'onAccountTokenChange')
         .mockImplementation(vi.fn());
 
       useAccountsStore.setState({

--- a/src/renderer/stores/useAccountsStore.ts
+++ b/src/renderer/stores/useAccountsStore.ts
@@ -9,7 +9,7 @@ import type { AccountsState, AccountsStore } from './types';
 
 import { getAccountUUID, isValidHostname, refreshAccount } from '../utils/auth/utils';
 import { rendererLogInfo, rendererLogWarn } from '../utils/core/logger';
-import { forAccount, getAdapter, isKnownForge } from '../utils/forges/registry';
+import { getAccountAdapter, getAdapter, isKnownForge } from '../utils/forges/registry';
 import { decryptValue, encryptValue } from '../utils/system/comms';
 import { DEFAULT_ACCOUNTS_STATE } from './defaults';
 
@@ -79,7 +79,7 @@ const useAccountsStore = create<AccountsStore>()(
 
         if (existingAccount) {
           // Drop any forge-specific HTTP client cache so the new token is used.
-          forAccount(existingAccount).onAccountTokenChange?.();
+          getAccountAdapter(existingAccount).onAccountTokenChange?.();
 
           // Replace the existing account (e.g. re-authentication with a new token)
           rendererLogInfo(
@@ -113,7 +113,7 @@ const useAccountsStore = create<AccountsStore>()(
 
       removeAccount: (account) => {
         // Drop any forge-specific HTTP client state for the removed account.
-        forAccount(account).onAccountTokenChange?.();
+        getAccountAdapter(account).onAccountTokenChange?.();
 
         set((state) => ({
           accounts: state.accounts.filter((a) => a.token !== account.token),
@@ -168,7 +168,7 @@ const useAccountsStore = create<AccountsStore>()(
         // Drop forge-specific HTTP client state (e.g. cached authenticated
         // Octokit clients) for every account being wiped.
         for (const account of get().accounts) {
-          forAccount(account).onAccountTokenChange?.();
+          getAccountAdapter(account).onAccountTokenChange?.();
         }
 
         set({ ...DEFAULT_ACCOUNTS_STATE });

--- a/src/renderer/stores/useAccountsStore.ts
+++ b/src/renderer/stores/useAccountsStore.ts
@@ -9,7 +9,7 @@ import type { AccountsState, AccountsStore } from './types';
 
 import { getAccountUUID, isValidHostname, refreshAccount } from '../utils/auth/utils';
 import { rendererLogInfo, rendererLogWarn } from '../utils/core/logger';
-import { getAdapter, isKnownForge } from '../utils/forges/registry';
+import { forAccount, getAdapter, isKnownForge } from '../utils/forges/registry';
 import { decryptValue, encryptValue } from '../utils/system/comms';
 import { DEFAULT_ACCOUNTS_STATE } from './defaults';
 
@@ -79,7 +79,7 @@ const useAccountsStore = create<AccountsStore>()(
 
         if (existingAccount) {
           // Drop any forge-specific HTTP client cache so the new token is used.
-          getAdapter(existingAccount).onAccountTokenChange?.(existingAccount);
+          forAccount(existingAccount).onAccountTokenChange?.();
 
           // Replace the existing account (e.g. re-authentication with a new token)
           rendererLogInfo(
@@ -113,7 +113,7 @@ const useAccountsStore = create<AccountsStore>()(
 
       removeAccount: (account) => {
         // Drop any forge-specific HTTP client state for the removed account.
-        getAdapter(account).onAccountTokenChange?.(account);
+        forAccount(account).onAccountTokenChange?.();
 
         set((state) => ({
           accounts: state.accounts.filter((a) => a.token !== account.token),
@@ -168,7 +168,7 @@ const useAccountsStore = create<AccountsStore>()(
         // Drop forge-specific HTTP client state (e.g. cached authenticated
         // Octokit clients) for every account being wiped.
         for (const account of get().accounts) {
-          getAdapter(account).onAccountTokenChange?.(account);
+          forAccount(account).onAccountTokenChange?.();
         }
 
         set({ ...DEFAULT_ACCOUNTS_STATE });

--- a/src/renderer/utils/api/features.ts
+++ b/src/renderer/utils/api/features.ts
@@ -1,6 +1,6 @@
 import type { Account } from '../../types';
 
-import { getAdapter } from '../forges/registry';
+import { forAccount } from '../forges/registry';
 
 /**
  * Whether the account's forge supports a distinct "mark as done" action.
@@ -10,12 +10,12 @@ import { getAdapter } from '../forges/registry';
  * equivalent and always reports false.
  */
 export function isMarkAsDoneFeatureSupported(account: Account): boolean {
-  return getAdapter(account).capabilities.markAsDone(account);
+  return forAccount(account).capabilities.markAsDone();
 }
 
 /**
  * Whether the account's forge supports ignoring a thread subscription.
  */
 export function isUnsubscribeThreadSupported(account: Account): boolean {
-  return getAdapter(account).capabilities.unsubscribeThread(account);
+  return forAccount(account).capabilities.unsubscribeThread();
 }

--- a/src/renderer/utils/api/features.ts
+++ b/src/renderer/utils/api/features.ts
@@ -1,6 +1,6 @@
 import type { Account } from '../../types';
 
-import { forAccount } from '../forges/registry';
+import { getAccountAdapter } from '../forges/registry';
 
 /**
  * Whether the account's forge supports a distinct "mark as done" action.
@@ -10,12 +10,12 @@ import { forAccount } from '../forges/registry';
  * equivalent and always reports false.
  */
 export function isMarkAsDoneFeatureSupported(account: Account): boolean {
-  return forAccount(account).capabilities.markAsDone();
+  return getAccountAdapter(account).capabilities.markAsDone();
 }
 
 /**
  * Whether the account's forge supports ignoring a thread subscription.
  */
 export function isUnsubscribeThreadSupported(account: Account): boolean {
-  return forAccount(account).capabilities.unsubscribeThread();
+  return getAccountAdapter(account).capabilities.unsubscribeThread();
 }

--- a/src/renderer/utils/auth/scopes.ts
+++ b/src/renderer/utils/auth/scopes.ts
@@ -2,7 +2,7 @@ import { Constants } from '../../constants';
 
 import type { Account } from '../../types';
 
-import { forAccount } from '../forges/registry';
+import { getAccountAdapter } from '../forges/registry';
 
 /**
  * Return true if the account has all required OAuth scopes.
@@ -13,7 +13,7 @@ import { forAccount } from '../forges/registry';
  * @param account - The account whose scopes to check.
  */
 export function hasRequiredScopes(account: Account): boolean {
-  return forAccount(account).oauthScopes?.hasRequired() ?? true;
+  return getAccountAdapter(account).oauthScopes?.hasRequired() ?? true;
 }
 
 /**
@@ -22,7 +22,7 @@ export function hasRequiredScopes(account: Account): boolean {
  * @param account - The account whose scopes to check.
  */
 export function hasRecommendedScopes(account: Account): boolean {
-  return forAccount(account).oauthScopes?.hasRecommended() ?? true;
+  return getAccountAdapter(account).oauthScopes?.hasRecommended() ?? true;
 }
 
 /**
@@ -31,7 +31,7 @@ export function hasRecommendedScopes(account: Account): boolean {
  * @param account - The account whose scopes to check.
  */
 export function hasAlternateScopes(account: Account): boolean {
-  return forAccount(account).oauthScopes?.hasAlternate() ?? true;
+  return getAccountAdapter(account).oauthScopes?.hasAlternate() ?? true;
 }
 
 /**

--- a/src/renderer/utils/auth/scopes.ts
+++ b/src/renderer/utils/auth/scopes.ts
@@ -2,7 +2,7 @@ import { Constants } from '../../constants';
 
 import type { Account } from '../../types';
 
-import { getAdapter } from '../forges/registry';
+import { forAccount } from '../forges/registry';
 
 /**
  * Return true if the account has all required OAuth scopes.
@@ -13,7 +13,7 @@ import { getAdapter } from '../forges/registry';
  * @param account - The account whose scopes to check.
  */
 export function hasRequiredScopes(account: Account): boolean {
-  return getAdapter(account).oauthScopes?.hasRequired(account) ?? true;
+  return forAccount(account).oauthScopes?.hasRequired() ?? true;
 }
 
 /**
@@ -22,7 +22,7 @@ export function hasRequiredScopes(account: Account): boolean {
  * @param account - The account whose scopes to check.
  */
 export function hasRecommendedScopes(account: Account): boolean {
-  return getAdapter(account).oauthScopes?.hasRecommended(account) ?? true;
+  return forAccount(account).oauthScopes?.hasRecommended() ?? true;
 }
 
 /**
@@ -31,7 +31,7 @@ export function hasRecommendedScopes(account: Account): boolean {
  * @param account - The account whose scopes to check.
  */
 export function hasAlternateScopes(account: Account): boolean {
-  return getAdapter(account).oauthScopes?.hasAlternate(account) ?? true;
+  return forAccount(account).oauthScopes?.hasAlternate() ?? true;
 }
 
 /**

--- a/src/renderer/utils/auth/utils.ts
+++ b/src/renderer/utils/auth/utils.ts
@@ -1,7 +1,7 @@
 import type { Account, AccountUUID, Hostname, Link } from '../../types';
 
 import { rendererLogError, rendererLogWarn, toError } from '../core/logger';
-import { forAccount } from '../forges/registry';
+import { getAccountAdapter } from '../forges/registry';
 import { hasRequiredScopes } from './scopes';
 
 /**
@@ -16,7 +16,7 @@ import { hasRequiredScopes } from './scopes';
  */
 export async function refreshAccount(account: Account): Promise<Account> {
   try {
-    const refreshed = await forAccount(account).fetchAuthenticatedUser();
+    const refreshed = await getAccountAdapter(account).fetchAuthenticatedUser();
 
     account.user = {
       id: refreshed.user.id,

--- a/src/renderer/utils/auth/utils.ts
+++ b/src/renderer/utils/auth/utils.ts
@@ -1,7 +1,7 @@
 import type { Account, AccountUUID, Hostname, Link } from '../../types';
 
 import { rendererLogError, rendererLogWarn, toError } from '../core/logger';
-import { getAdapter } from '../forges/registry';
+import { forAccount } from '../forges/registry';
 import { hasRequiredScopes } from './scopes';
 
 /**
@@ -16,7 +16,7 @@ import { hasRequiredScopes } from './scopes';
  */
 export async function refreshAccount(account: Account): Promise<Account> {
   try {
-    const refreshed = await getAdapter(account).fetchAuthenticatedUser(account);
+    const refreshed = await forAccount(account).fetchAuthenticatedUser();
 
     account.user = {
       id: refreshed.user.id,

--- a/src/renderer/utils/forges/bitbucket/adapter.test.ts
+++ b/src/renderer/utils/forges/bitbucket/adapter.test.ts
@@ -59,8 +59,10 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
     });
 
     it('reports unsupported capabilities', () => {
-      expect(bitbucketAdapter.capabilities.markAsDone(mockBitbucketAccount)).toBe(false);
-      expect(bitbucketAdapter.capabilities.unsubscribeThread(mockBitbucketAccount)).toBe(false);
+      expect(bitbucketAdapter.accountOps.capabilities.markAsDone(mockBitbucketAccount)).toBe(false);
+      expect(bitbucketAdapter.accountOps.capabilities.unsubscribeThread(mockBitbucketAccount)).toBe(
+        false,
+      );
     });
 
     it('exposes a single PAT login method', () => {
@@ -78,7 +80,7 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
 
     it('uses the native login as a notification actor label', () => {
       expect(
-        bitbucketAdapter.formatNotificationUser(mockBitbucketAccount, {
+        bitbucketAdapter.accountOps.formatNotificationUser(mockBitbucketAccount, {
           login: 'user@example.com',
           avatarUrl: '' as Link,
           htmlUrl: '' as Link,
@@ -94,17 +96,19 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
     });
 
     it('returns the Atlassian token settings URL for account settings', () => {
-      expect(bitbucketAdapter.getAccountSettingsUrl(mockBitbucketAccount)).toBe(
+      expect(bitbucketAdapter.accountOps.getAccountSettingsUrl(mockBitbucketAccount)).toBe(
         'https://id.atlassian.com/manage-profile/security/api-tokens',
       );
     });
 
     it('links pull requests to the Your work dashboard and the rest to the host root', () => {
-      expect(bitbucketAdapter.getIssuesUrl(mockBitbucketAccount)).toBe('https://bitbucket.org');
-      expect(bitbucketAdapter.getPullRequestsUrl(mockBitbucketAccount)).toBe(
+      expect(bitbucketAdapter.accountOps.getIssuesUrl(mockBitbucketAccount)).toBe(
+        'https://bitbucket.org',
+      );
+      expect(bitbucketAdapter.accountOps.getPullRequestsUrl(mockBitbucketAccount)).toBe(
         'https://bitbucket.org/dashboard/overview',
       );
-      expect(bitbucketAdapter.getNotificationsUrl(mockBitbucketAccount)).toBe(
+      expect(bitbucketAdapter.accountOps.getNotificationsUrl(mockBitbucketAccount)).toBe(
         'https://bitbucket.org',
       );
     });
@@ -142,7 +146,7 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
         },
       });
 
-      const result = await bitbucketAdapter.fetchAuthenticatedUser(mockBitbucketAccount);
+      const result = await bitbucketAdapter.accountOps.fetchAuthenticatedUser(mockBitbucketAccount);
 
       expect(result).toEqual({
         user: {
@@ -166,7 +170,8 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
       });
 
       const accountWithoutUsername = { ...mockBitbucketAccount, username: undefined };
-      const result = await bitbucketAdapter.fetchAuthenticatedUser(accountWithoutUsername);
+      const result =
+        await bitbucketAdapter.accountOps.fetchAuthenticatedUser(accountWithoutUsername);
 
       expect(result.user.login).toBe('atlas-456');
     });
@@ -182,7 +187,7 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
         },
       });
 
-      const result = await bitbucketAdapter.fetchAuthenticatedUser(mockBitbucketAccount);
+      const result = await bitbucketAdapter.accountOps.fetchAuthenticatedUser(mockBitbucketAccount);
 
       expect(result.user.name).toBeNull();
       expect(result.user.avatar).toBe('');
@@ -193,9 +198,9 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
         me: { user: null },
       });
 
-      await expect(bitbucketAdapter.fetchAuthenticatedUser(mockBitbucketAccount)).rejects.toThrow(
-        'Failed to retrieve Bitbucket authenticated user.',
-      );
+      await expect(
+        bitbucketAdapter.accountOps.fetchAuthenticatedUser(mockBitbucketAccount),
+      ).rejects.toThrow('Failed to retrieve Bitbucket authenticated user.');
     });
   });
 
@@ -207,7 +212,7 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
 
       useSettingsStore.setState({ fetchReadNotifications: false });
 
-      const result = await bitbucketAdapter.listNotifications(mockBitbucketAccount);
+      const result = await bitbucketAdapter.accountOps.listNotifications(mockBitbucketAccount);
 
       expect(listSpy).toHaveBeenCalledWith(mockBitbucketAccount, true);
       expect(result).toHaveLength(1);
@@ -219,7 +224,7 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
 
       useSettingsStore.setState({ fetchReadNotifications: true });
 
-      await bitbucketAdapter.listNotifications(mockBitbucketAccount);
+      await bitbucketAdapter.accountOps.listNotifications(mockBitbucketAccount);
 
       expect(listSpy).toHaveBeenCalledWith(mockBitbucketAccount, false);
     });
@@ -231,21 +236,21 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
         .spyOn(client, 'markBitbucketNotificationsAsRead')
         .mockResolvedValue(undefined);
 
-      await bitbucketAdapter.markThreadAsRead(mockBitbucketAccount, 'notif-abc');
+      await bitbucketAdapter.accountOps.markThreadAsRead(mockBitbucketAccount, 'notif-abc');
 
       expect(markSpy).toHaveBeenCalledWith(mockBitbucketAccount, ['notif-abc']);
     });
 
     it('markThreadAsDone throws — check capabilities before calling', () => {
-      expect(() => bitbucketAdapter.markThreadAsDone(mockBitbucketAccount, 'notif-abc')).toThrow(
-        /check capabilities.markAsDone/,
-      );
+      expect(() =>
+        bitbucketAdapter.accountOps.markThreadAsDone(mockBitbucketAccount, 'notif-abc'),
+      ).toThrow(/check capabilities.markAsDone/);
     });
 
     it('unsubscribeThread throws — check capabilities before calling', () => {
-      expect(() => bitbucketAdapter.unsubscribeThread(mockBitbucketAccount, 'notif-abc')).toThrow(
-        /not supported for Bitbucket/,
-      );
+      expect(() =>
+        bitbucketAdapter.accountOps.unsubscribeThread(mockBitbucketAccount, 'notif-abc'),
+      ).toThrow(/not supported for Bitbucket/);
     });
   });
 
@@ -261,7 +266,7 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
         json: async () => payload,
       } as Response);
 
-      const result = await bitbucketAdapter.followUrl<{ key: string }>(
+      const result = await bitbucketAdapter.accountOps.followUrl(
         mockBitbucketAccount,
         'https://bitbucket.org/api/resource' as Link,
       );
@@ -280,7 +285,10 @@ describe('renderer/utils/forges/bitbucket/adapter.ts', () => {
       } as Response);
 
       await expect(
-        bitbucketAdapter.followUrl(mockBitbucketAccount, 'https://bitbucket.org/missing' as Link),
+        bitbucketAdapter.accountOps.followUrl(
+          mockBitbucketAccount,
+          'https://bitbucket.org/missing' as Link,
+        ),
       ).rejects.toThrow('Bitbucket fetch error: 404');
     });
   });

--- a/src/renderer/utils/forges/bitbucket/adapter.ts
+++ b/src/renderer/utils/forges/bitbucket/adapter.ts
@@ -89,30 +89,10 @@ export const bitbucketAdapter: ForgeAdapter = {
   displayName: 'Bitbucket',
   tagline: 'Bitbucket Cloud',
   icon: BitbucketIcon,
-  capabilities,
 
   getPlatform: () => 'Bitbucket Cloud',
   formatUserLogin: (login) => login,
-  formatNotificationUser: (_account, user) => user.login,
 
-  fetchAuthenticatedUser,
-  listNotifications,
-
-  markThreadAsRead: async (account, threadId) => {
-    await markBitbucketNotificationsAsRead(account, [threadId]);
-  },
-  markThreadAsDone: () => {
-    throw new Error(
-      'Mark-as-done is not supported for Bitbucket; check capabilities.markAsDone before calling.',
-    );
-  },
-  unsubscribeThread: () => {
-    throw new Error(
-      'Unsubscribing threads is not supported for Bitbucket; check capabilities.unsubscribeThread before calling.',
-    );
-  },
-
-  followUrl,
   getDisplayHelpers,
 
   defaultHostname: 'bitbucket.org' as Hostname,
@@ -120,16 +100,6 @@ export const bitbucketAdapter: ForgeAdapter = {
   validateToken: (token) => token.length > 0,
 
   getPersonalAccessTokenSettingsUrl: (_hostname: Hostname) => ATLASSIAN_TOKEN_SETTINGS_URL,
-
-  getAccountSettingsUrl: (_account: Account) => ATLASSIAN_TOKEN_SETTINGS_URL,
-
-  // Bitbucket does not capture a workspace slug, so shortcut links cannot use
-  // workspace-scoped ("/workspace/{slug}/...") URLs. Pull requests go to the
-  // account-wide "Your work" dashboard; issues and notifications have no
-  // account-wide page and fall back to the host root.
-  getIssuesUrl: (account) => `https://${account.hostname}` as Link,
-  getPullRequestsUrl: (account) => `https://${account.hostname}/dashboard/overview` as Link,
-  getNotificationsUrl: (account) => `https://${account.hostname}` as Link,
 
   documentationUrl: BITBUCKET_DOCS_URL,
 
@@ -144,4 +114,33 @@ export const bitbucketAdapter: ForgeAdapter = {
       authMethod: 'Personal Access Token',
     },
   ],
+
+  accountOps: {
+    capabilities,
+    formatNotificationUser: (_account, user) => user.login,
+    fetchAuthenticatedUser,
+    listNotifications,
+    markThreadAsRead: async (account, threadId) => {
+      await markBitbucketNotificationsAsRead(account, [threadId]);
+    },
+    markThreadAsDone: () => {
+      throw new Error(
+        'Mark-as-done is not supported for Bitbucket; check capabilities.markAsDone before calling.',
+      );
+    },
+    unsubscribeThread: () => {
+      throw new Error(
+        'Unsubscribing threads is not supported for Bitbucket; check capabilities.unsubscribeThread before calling.',
+      );
+    },
+    followUrl,
+    getAccountSettingsUrl: (_account: Account) => ATLASSIAN_TOKEN_SETTINGS_URL,
+    // Bitbucket does not capture a workspace slug, so shortcut links cannot use
+    // workspace-scoped ("/workspace/{slug}/...") URLs. Pull requests go to the
+    // account-wide "Your work" dashboard; issues and notifications have no
+    // account-wide page and fall back to the host root.
+    getIssuesUrl: (account) => `https://${account.hostname}` as Link,
+    getPullRequestsUrl: (account) => `https://${account.hostname}/dashboard/overview` as Link,
+    getNotificationsUrl: (account) => `https://${account.hostname}` as Link,
+  },
 };

--- a/src/renderer/utils/forges/gitea/adapter.test.ts
+++ b/src/renderer/utils/forges/gitea/adapter.test.ts
@@ -18,8 +18,8 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
     });
 
     it('reports unsupported capabilities', () => {
-      expect(giteaAdapter.capabilities.markAsDone(mockGiteaAccount)).toBe(false);
-      expect(giteaAdapter.capabilities.unsubscribeThread(mockGiteaAccount)).toBe(false);
+      expect(giteaAdapter.accountOps.capabilities.markAsDone(mockGiteaAccount)).toBe(false);
+      expect(giteaAdapter.accountOps.capabilities.unsubscribeThread(mockGiteaAccount)).toBe(false);
     });
 
     it('does not implement detailed enrichment', () => {
@@ -28,7 +28,7 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
 
     it('uses the formatted login as a notification actor label', () => {
       expect(
-        giteaAdapter.formatNotificationUser(mockGiteaAccount, {
+        giteaAdapter.accountOps.formatNotificationUser(mockGiteaAccount, {
           login: 'octocat',
           avatarUrl: '' as Link,
           htmlUrl: '' as Link,
@@ -55,17 +55,19 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
         'https://gitea.example.com/user/settings/applications',
       );
 
-      expect(giteaAdapter.getAccountSettingsUrl(mockGiteaAccount)).toBe(
+      expect(giteaAdapter.accountOps.getAccountSettingsUrl(mockGiteaAccount)).toBe(
         'https://gitea.example.com/user/settings/applications',
       );
     });
 
     it('builds issues, pull requests and notifications shortcut URLs', () => {
-      expect(giteaAdapter.getIssuesUrl(mockGiteaAccount)).toBe('https://gitea.example.com/issues');
-      expect(giteaAdapter.getPullRequestsUrl(mockGiteaAccount)).toBe(
+      expect(giteaAdapter.accountOps.getIssuesUrl(mockGiteaAccount)).toBe(
+        'https://gitea.example.com/issues',
+      );
+      expect(giteaAdapter.accountOps.getPullRequestsUrl(mockGiteaAccount)).toBe(
         'https://gitea.example.com/pulls',
       );
-      expect(giteaAdapter.getNotificationsUrl(mockGiteaAccount)).toBe(
+      expect(giteaAdapter.accountOps.getNotificationsUrl(mockGiteaAccount)).toBe(
         'https://gitea.example.com/notifications',
       );
     });
@@ -114,7 +116,7 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
         avatar_url: 'https://example.com/a.png',
       });
 
-      const result = await giteaAdapter.fetchAuthenticatedUser(mockGiteaAccount);
+      const result = await giteaAdapter.accountOps.fetchAuthenticatedUser(mockGiteaAccount);
 
       expect(result).toEqual({
         user: {
@@ -132,7 +134,7 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
         login: 'octocat',
       });
 
-      const result = await giteaAdapter.fetchAuthenticatedUser(mockGiteaAccount);
+      const result = await giteaAdapter.accountOps.fetchAuthenticatedUser(mockGiteaAccount);
 
       expect(result.user.name).toBeNull();
       expect(result.user.avatar).toBe('');
@@ -158,7 +160,7 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
 
       useSettingsStore.setState({ fetchAllNotifications: false, fetchReadNotifications: false });
 
-      const result = await giteaAdapter.listNotifications(mockGiteaAccount);
+      const result = await giteaAdapter.accountOps.listNotifications(mockGiteaAccount);
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('99');
@@ -172,7 +174,7 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
         .spyOn(client, 'patchGiteaNotificationThread')
         .mockResolvedValue(undefined);
 
-      await giteaAdapter.markThreadAsRead(mockGiteaAccount, '12');
+      await giteaAdapter.accountOps.markThreadAsRead(mockGiteaAccount, '12');
 
       expect(patchSpy).toHaveBeenCalledWith(mockGiteaAccount, '12', 'read');
     });
@@ -182,13 +184,13 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
       // back to mark-as-read before reaching here. Throwing surfaces any
       // caller that bypasses the capability check rather than silently
       // doing the wrong thing.
-      expect(() => giteaAdapter.markThreadAsDone(mockGiteaAccount, '13')).toThrow(
+      expect(() => giteaAdapter.accountOps.markThreadAsDone(mockGiteaAccount, '13')).toThrow(
         /check capabilities.markAsDone/,
       );
     });
 
     it('unsubscribeThread throws because Gitea has no equivalent', () => {
-      expect(() => giteaAdapter.unsubscribeThread(mockGiteaAccount, '14')).toThrow(
+      expect(() => giteaAdapter.accountOps.unsubscribeThread(mockGiteaAccount, '14')).toThrow(
         /not supported for Gitea/,
       );
     });
@@ -196,7 +198,7 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
 
   describe('oauthScopes capability bundle', () => {
     it('is omitted because Gitea has no OAuth scope concept', () => {
-      expect(giteaAdapter.oauthScopes).toBeUndefined();
+      expect(giteaAdapter.accountOps.oauthScopes).toBeUndefined();
     });
   });
 
@@ -204,7 +206,7 @@ describe('renderer/utils/forges/gitea/adapter.ts', () => {
     it('delegates to giteaGetJson', async () => {
       const getJsonSpy = vi.spyOn(client, 'giteaGetJson').mockResolvedValue({ html_url: 'x' });
 
-      const result = await giteaAdapter.followUrl<{ html_url: string }>(
+      const result = await giteaAdapter.accountOps.followUrl(
         mockGiteaAccount,
         'https://gitea.example.com/api/v1/x' as Link,
       );

--- a/src/renderer/utils/forges/gitea/adapter.ts
+++ b/src/renderer/utils/forges/gitea/adapter.ts
@@ -61,44 +61,16 @@ export const giteaAdapter: ForgeAdapter = {
   displayName: 'Gitea',
   tagline: 'Gitea, Forgejo & Codeberg',
   icon: ServerIcon,
-  capabilities,
 
   getPlatform: () => 'Gitea',
   formatUserLogin: (login) => login,
-  formatNotificationUser: (_account, user) => user.login,
 
-  fetchAuthenticatedUser,
-  listNotifications,
-
-  markThreadAsRead: (account, threadId) => patchGiteaNotificationThread(account, threadId, 'read'),
-  // Gitea has no "done" state — capability `markAsDone(account)` returns
-  // false so the UI gates this off. Throwing rather than silently aliasing to
-  // markThreadAsRead surfaces any caller that bypasses the capability check.
-  markThreadAsDone: () => {
-    throw new Error(
-      'Mark-as-done is not supported for Gitea accounts; check capabilities.markAsDone before calling.',
-    );
-  },
-  unsubscribeThread: () => {
-    throw new Error(
-      'Ignoring thread subscriptions is not supported for Gitea accounts; check capabilities.unsubscribeThread before calling.',
-    );
-  },
-
-  followUrl<T>(account: Account, url: Link): Promise<T> {
-    return giteaGetJson<T>(account, url);
-  },
   getDisplayHelpers,
 
   // Gitea PATs from /user/settings/applications are 40-char lowercase hex.
   validateToken: (token: Token) => /^[a-f0-9]{40}$/.test(token),
   getPersonalAccessTokenSettingsUrl: (hostname: Hostname) =>
     `https://${hostname}/user/settings/applications` as Link,
-  getAccountSettingsUrl: (account: Account) =>
-    `https://${account.hostname}/user/settings/applications` as Link,
-  getIssuesUrl: (account) => `https://${account.hostname}/issues` as Link,
-  getPullRequestsUrl: (account) => `https://${account.hostname}/pulls` as Link,
-  getNotificationsUrl: (account) => `https://${account.hostname}/notifications` as Link,
   documentationUrl: GITEA_DOCS_URL,
   // Gitea only supports PAT today, so every method falls through to the key
   // icon. Adding device-flow/OAuth support later means returning their icons
@@ -115,6 +87,35 @@ export const giteaAdapter: ForgeAdapter = {
     },
   ],
 
-  // Gitea has no GitHub-style OAuth scope concept, so `oauthScopes` is
-  // omitted. Callers skip scopes UI when this is undefined.
+  accountOps: {
+    capabilities,
+    formatNotificationUser: (_account, user) => user.login,
+    fetchAuthenticatedUser,
+    listNotifications,
+    markThreadAsRead: (account, threadId) =>
+      patchGiteaNotificationThread(account, threadId, 'read'),
+    // Gitea has no "done" state — capability `markAsDone(account)` returns
+    // false so the UI gates this off. Throwing rather than silently aliasing to
+    // markThreadAsRead surfaces any caller that bypasses the capability check.
+    markThreadAsDone: () => {
+      throw new Error(
+        'Mark-as-done is not supported for Gitea accounts; check capabilities.markAsDone before calling.',
+      );
+    },
+    unsubscribeThread: () => {
+      throw new Error(
+        'Ignoring thread subscriptions is not supported for Gitea accounts; check capabilities.unsubscribeThread before calling.',
+      );
+    },
+    followUrl<T>(account: Account, url: Link): Promise<T> {
+      return giteaGetJson<T>(account, url);
+    },
+    getAccountSettingsUrl: (account: Account) =>
+      `https://${account.hostname}/user/settings/applications` as Link,
+    getIssuesUrl: (account) => `https://${account.hostname}/issues` as Link,
+    getPullRequestsUrl: (account) => `https://${account.hostname}/pulls` as Link,
+    getNotificationsUrl: (account) => `https://${account.hostname}/notifications` as Link,
+    // Gitea has no GitHub-style OAuth scope concept, so `oauthScopes` is
+    // omitted. Callers skip scopes UI when this is undefined.
+  },
 };

--- a/src/renderer/utils/forges/github/adapter.test.ts
+++ b/src/renderer/utils/forges/github/adapter.test.ts
@@ -35,17 +35,19 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
     });
 
     it('routes getAccountSettingsUrl through the auth-method helper', () => {
-      expect(githubAdapter.getAccountSettingsUrl(mockGitHubCloudAccount)).toBe(
+      expect(githubAdapter.accountOps.getAccountSettingsUrl(mockGitHubCloudAccount)).toBe(
         'https://github.com/settings/tokens',
       );
     });
 
     it('builds the issues, pull requests and notifications shortcut URLs', () => {
-      expect(githubAdapter.getIssuesUrl(mockGitHubCloudAccount)).toBe('https://github.com/issues');
-      expect(githubAdapter.getPullRequestsUrl(mockGitHubCloudAccount)).toBe(
+      expect(githubAdapter.accountOps.getIssuesUrl(mockGitHubCloudAccount)).toBe(
+        'https://github.com/issues',
+      );
+      expect(githubAdapter.accountOps.getPullRequestsUrl(mockGitHubCloudAccount)).toBe(
         'https://github.com/pulls',
       );
-      expect(githubAdapter.getNotificationsUrl(mockGitHubCloudAccount)).toBe(
+      expect(githubAdapter.accountOps.getNotificationsUrl(mockGitHubCloudAccount)).toBe(
         'https://github.com/notifications',
       );
     });
@@ -79,7 +81,7 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
 
     it('uses a trimmed profile name for an enterprise managed user', () => {
       expect(
-        githubAdapter.formatNotificationUser(mockGitHubCloudAccount, {
+        githubAdapter.accountOps.formatNotificationUser(mockGitHubCloudAccount, {
           ...user,
           name: '  Notification Author  ',
         }),
@@ -90,14 +92,17 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
       'falls back to the formatted login when the EMU name is %s',
       (name) => {
         expect(
-          githubAdapter.formatNotificationUser(mockGitHubCloudAccount, { ...user, name }),
+          githubAdapter.accountOps.formatNotificationUser(mockGitHubCloudAccount, {
+            ...user,
+            name,
+          }),
         ).toBe('notification-author_gitify');
       },
     );
 
     it('keeps the formatted login for a regular user with a profile name', () => {
       expect(
-        githubAdapter.formatNotificationUser(mockGitHubCloudAccount, {
+        githubAdapter.accountOps.formatNotificationUser(mockGitHubCloudAccount, {
           ...user,
           login: 'notification-author',
           type: 'User',
@@ -111,9 +116,9 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
         user: { ...mockGitHubCloudAccount.user!, login: 'octocat_gitify' },
       };
 
-      expect(githubAdapter.formatNotificationUser(managedAccount, { ...user, type: 'User' })).toBe(
-        'Notification Author (notification-author_gitify)',
-      );
+      expect(
+        githubAdapter.accountOps.formatNotificationUser(managedAccount, { ...user, type: 'User' }),
+      ).toBe('Notification Author (notification-author_gitify)');
     });
   });
 
@@ -132,7 +137,7 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
         },
       } as unknown as Awaited<ReturnType<typeof client.fetchAuthenticatedUserDetails>>);
 
-      const result = await githubAdapter.fetchAuthenticatedUser(mockGitHubCloudAccount);
+      const result = await githubAdapter.accountOps.fetchAuthenticatedUser(mockGitHubCloudAccount);
 
       expect(result).toEqual({
         user: {
@@ -152,7 +157,7 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
         headers: {},
       } as unknown as Awaited<ReturnType<typeof client.fetchAuthenticatedUserDetails>>);
 
-      const result = await githubAdapter.fetchAuthenticatedUser(mockGitHubCloudAccount);
+      const result = await githubAdapter.accountOps.fetchAuthenticatedUser(mockGitHubCloudAccount);
 
       expect(result.version).toBe('latest');
       expect(result.scopes).toBeUndefined();
@@ -186,7 +191,7 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
         },
       ] as unknown as Awaited<ReturnType<typeof client.listNotificationsForAuthenticatedUser>>);
 
-      const result = await githubAdapter.listNotifications(mockGitHubCloudAccount);
+      const result = await githubAdapter.accountOps.listNotifications(mockGitHubCloudAccount);
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('1');
@@ -199,7 +204,7 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
     it('markThreadAsRead delegates to the GitHub client', async () => {
       const spy = vi.spyOn(client, 'markNotificationThreadAsRead').mockResolvedValue(undefined);
 
-      await githubAdapter.markThreadAsRead(mockGitHubCloudAccount, '7');
+      await githubAdapter.accountOps.markThreadAsRead(mockGitHubCloudAccount, '7');
 
       expect(spy).toHaveBeenCalledWith(mockGitHubCloudAccount, '7');
     });
@@ -207,7 +212,7 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
     it('markThreadAsDone delegates to the GitHub client', async () => {
       const spy = vi.spyOn(client, 'markNotificationThreadAsDone').mockResolvedValue(undefined);
 
-      await githubAdapter.markThreadAsDone(mockGitHubCloudAccount, '8');
+      await githubAdapter.accountOps.markThreadAsDone(mockGitHubCloudAccount, '8');
 
       expect(spy).toHaveBeenCalledWith(mockGitHubCloudAccount, '8');
     });
@@ -221,7 +226,7 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
           >,
         );
 
-      await githubAdapter.unsubscribeThread(mockGitHubCloudAccount, '9');
+      await githubAdapter.accountOps.unsubscribeThread(mockGitHubCloudAccount, '9');
 
       expect(spy).toHaveBeenCalledWith(mockGitHubCloudAccount, '9');
     });
@@ -233,33 +238,39 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
     }
 
     it('exposes the bundle (GitHub has an OAuth scope concept)', () => {
-      expect(githubAdapter.oauthScopes).toBeDefined();
+      expect(githubAdapter.accountOps.oauthScopes).toBeDefined();
     });
 
     it('hasRequired is true when notifications + read:user are present', () => {
       expect(
-        githubAdapter.oauthScopes!.hasRequired(withScopes(['notifications', 'read:user'])),
+        githubAdapter.accountOps.oauthScopes!.hasRequired(
+          withScopes(['notifications', 'read:user']),
+        ),
       ).toBe(true);
     });
 
     it('hasRequired is false when a required scope is missing', () => {
-      expect(githubAdapter.oauthScopes!.hasRequired(withScopes(['notifications']))).toBe(false);
+      expect(githubAdapter.accountOps.oauthScopes!.hasRequired(withScopes(['notifications']))).toBe(
+        false,
+      );
     });
 
     it('hasRecommended requires the full repo scope set', () => {
       expect(
-        githubAdapter.oauthScopes!.hasRecommended(
+        githubAdapter.accountOps.oauthScopes!.hasRecommended(
           withScopes(['notifications', 'read:user', 'repo']),
         ),
       ).toBe(true);
       expect(
-        githubAdapter.oauthScopes!.hasRecommended(withScopes(['notifications', 'read:user'])),
+        githubAdapter.accountOps.oauthScopes!.hasRecommended(
+          withScopes(['notifications', 'read:user']),
+        ),
       ).toBe(false);
     });
 
     it('hasAlternate accepts public_repo as the legacy substitute', () => {
       expect(
-        githubAdapter.oauthScopes!.hasAlternate(
+        githubAdapter.accountOps.oauthScopes!.hasAlternate(
           withScopes(['notifications', 'read:user', 'public_repo']),
         ),
       ).toBe(true);
@@ -275,7 +286,7 @@ describe('renderer/utils/forges/github/adapter.ts', () => {
         request: requestMock,
       } as unknown as Awaited<ReturnType<typeof octokit.createOctokitClient>>);
 
-      const result = await githubAdapter.followUrl<{ html_url: string }>(
+      const result = await githubAdapter.accountOps.followUrl(
         mockGitHubCloudAccount,
         'https://api.github.com/repos/o/r/issues/1' as Link,
       );

--- a/src/renderer/utils/forges/github/adapter.ts
+++ b/src/renderer/utils/forges/github/adapter.ts
@@ -80,38 +80,16 @@ export const githubAdapter: ForgeAdapter = {
   displayName: 'GitHub',
   tagline: 'GitHub Cloud & GitHub Enterprise Server',
   icon: MarkGithubIcon,
-  capabilities: githubCapabilities,
 
   getPlatform: getGitHubPlatform,
   formatUserLogin: (login) => login,
-  formatNotificationUser: formatGitHubNotificationUser,
-
-  fetchAuthenticatedUser,
-  listNotifications,
-
-  markThreadAsRead: async (account, threadId) => {
-    await markNotificationThreadAsRead(account, threadId);
-  },
-  markThreadAsDone: async (account, threadId) => {
-    await markNotificationThreadAsDone(account, threadId);
-  },
-  unsubscribeThread: async (account, threadId) => {
-    await ignoreNotificationThreadSubscription(account, threadId);
-  },
 
   enrichNotifications: enrichGitHubNotifications,
-  onAccountTokenChange: clearOctokitClientCacheForAccount,
-
-  followUrl,
   getDisplayHelpers,
 
   defaultHostname: Constants.GITHUB_HOSTNAME,
   validateToken: isValidToken,
   getPersonalAccessTokenSettingsUrl: getNewTokenURL,
-  getAccountSettingsUrl: getDeveloperSettingsURL,
-  getIssuesUrl: (account) => `https://${account.hostname}/issues` as Link,
-  getPullRequestsUrl: (account) => `https://${account.hostname}/pulls` as Link,
-  getNotificationsUrl: (account) => `https://${account.hostname}/notifications` as Link,
   documentationUrl: Constants.GITHUB_DOCS.PAT_URL as Link,
   getAuthMethodIcon: githubAuthMethodIcon,
 
@@ -155,10 +133,31 @@ export const githubAdapter: ForgeAdapter = {
     getNewOAuthAppUrl: getNewOAuthAppURL,
   },
 
-  oauthScopes: {
-    hasRequired: (account) => accountHasScopes(account, 'REQUIRED'),
-    hasRecommended: (account) => accountHasScopes(account, 'RECOMMENDED'),
-    hasAlternate: (account) => accountHasScopes(account, 'ALTERNATE'),
+  accountOps: {
+    capabilities: githubCapabilities,
+    formatNotificationUser: formatGitHubNotificationUser,
+    fetchAuthenticatedUser,
+    onAccountTokenChange: clearOctokitClientCacheForAccount,
+    listNotifications,
+    markThreadAsRead: async (account, threadId) => {
+      await markNotificationThreadAsRead(account, threadId);
+    },
+    markThreadAsDone: async (account, threadId) => {
+      await markNotificationThreadAsDone(account, threadId);
+    },
+    unsubscribeThread: async (account, threadId) => {
+      await ignoreNotificationThreadSubscription(account, threadId);
+    },
+    followUrl,
+    getAccountSettingsUrl: getDeveloperSettingsURL,
+    getIssuesUrl: (account) => `https://${account.hostname}/issues` as Link,
+    getPullRequestsUrl: (account) => `https://${account.hostname}/pulls` as Link,
+    getNotificationsUrl: (account) => `https://${account.hostname}/notifications` as Link,
+    oauthScopes: {
+      hasRequired: (account) => accountHasScopes(account, 'REQUIRED'),
+      hasRecommended: (account) => accountHasScopes(account, 'RECOMMENDED'),
+      hasAlternate: (account) => accountHasScopes(account, 'ALTERNATE'),
+    },
   },
 };
 

--- a/src/renderer/utils/forges/gitlab/adapter.test.ts
+++ b/src/renderer/utils/forges/gitlab/adapter.test.ts
@@ -25,8 +25,10 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
     });
 
     it('reports no distinct done state — GitLab has one transition', () => {
-      expect(gitlabAdapter.capabilities.markAsDone(mockGitLabAccount)).toBe(false);
-      expect(gitlabAdapter.capabilities.unsubscribeThread(mockGitLabAccount)).toBe(false);
+      expect(gitlabAdapter.accountOps.capabilities.markAsDone(mockGitLabAccount)).toBe(false);
+      expect(gitlabAdapter.accountOps.capabilities.unsubscribeThread(mockGitLabAccount)).toBe(
+        false,
+      );
     });
 
     it('does not implement detailed enrichment', () => {
@@ -37,7 +39,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
     it('uses plain logins for account identity surfaces', () => {
       expect(gitlabAdapter.formatUserLogin('octocat')).toBe('octocat');
       expect(
-        gitlabAdapter.formatNotificationUser(mockGitLabAccount, {
+        gitlabAdapter.accountOps.formatNotificationUser(mockGitLabAccount, {
           login: 'octocat',
           avatarUrl: '' as Link,
           htmlUrl: '' as Link,
@@ -63,19 +65,19 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
       expect(gitlabAdapter.getPersonalAccessTokenSettingsUrl('gitlab.com' as Hostname)).toBe(
         'https://gitlab.com/-/user_settings/personal_access_tokens',
       );
-      expect(gitlabAdapter.getAccountSettingsUrl(mockGitLabAccount)).toBe(
+      expect(gitlabAdapter.accountOps.getAccountSettingsUrl(mockGitLabAccount)).toBe(
         'https://gitlab.com/-/user_settings/personal_access_tokens',
       );
     });
 
     it('builds issues, merge requests and notifications shortcut URLs using GitLab paths', () => {
-      expect(gitlabAdapter.getIssuesUrl(mockGitLabAccount)).toBe(
+      expect(gitlabAdapter.accountOps.getIssuesUrl(mockGitLabAccount)).toBe(
         'https://gitlab.com/dashboard/issues?assignee_username=octocat',
       );
-      expect(gitlabAdapter.getPullRequestsUrl(mockGitLabAccount)).toBe(
+      expect(gitlabAdapter.accountOps.getPullRequestsUrl(mockGitLabAccount)).toBe(
         'https://gitlab.com/dashboard/merge_requests',
       );
-      expect(gitlabAdapter.getNotificationsUrl(mockGitLabAccount)).toBe(
+      expect(gitlabAdapter.accountOps.getNotificationsUrl(mockGitLabAccount)).toBe(
         'https://gitlab.com/dashboard/todos',
       );
     });
@@ -86,7 +88,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
     });
 
     it('omits the oauthScopes bundle', () => {
-      expect(gitlabAdapter.oauthScopes).toBeUndefined();
+      expect(gitlabAdapter.accountOps.oauthScopes).toBeUndefined();
     });
   });
 
@@ -148,7 +150,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
         expires_at: null,
       });
 
-      const result = await gitlabAdapter.fetchAuthenticatedUser(mockGitLabAccount);
+      const result = await gitlabAdapter.accountOps.fetchAuthenticatedUser(mockGitLabAccount);
 
       expect(result).toEqual({
         user: {
@@ -173,7 +175,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
       });
       vi.spyOn(client, 'fetchGitLabTokenMetadata').mockRejectedValue(new Error('nope'));
 
-      const result = await gitlabAdapter.fetchAuthenticatedUser(mockGitLabAccount);
+      const result = await gitlabAdapter.accountOps.fetchAuthenticatedUser(mockGitLabAccount);
 
       expect(result.user.name).toBeNull();
       expect(result.user.avatar).toBe('');
@@ -188,7 +190,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
       vi.spyOn(client, 'fetchGitLabVersion').mockRejectedValue(new Error('403'));
       vi.spyOn(client, 'fetchGitLabTokenMetadata').mockRejectedValue(new Error('403'));
 
-      const result = await gitlabAdapter.fetchAuthenticatedUser(mockGitLabAccount);
+      const result = await gitlabAdapter.accountOps.fetchAuthenticatedUser(mockGitLabAccount);
 
       expect(result.user.login).toBe('octocat');
       expect(result.version).toBeUndefined();
@@ -200,9 +202,9 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
         new Error('GitLab API 401 Unauthorized'),
       );
 
-      await expect(gitlabAdapter.fetchAuthenticatedUser(mockGitLabAccount)).rejects.toThrow(
-        /401 Unauthorized/,
-      );
+      await expect(
+        gitlabAdapter.accountOps.fetchAuthenticatedUser(mockGitLabAccount),
+      ).rejects.toThrow(/401 Unauthorized/);
     });
   });
 
@@ -224,7 +226,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
 
       useSettingsStore.setState({ fetchAllNotifications: false, fetchReadNotifications: false });
 
-      const result = await gitlabAdapter.listNotifications(mockGitLabAccount);
+      const result = await gitlabAdapter.accountOps.listNotifications(mockGitLabAccount);
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('99');
@@ -236,7 +238,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
     it('markThreadAsRead marks the to-do item done', async () => {
       const spy = vi.spyOn(client, 'markGitLabTodoAsDone').mockResolvedValue(undefined);
 
-      await gitlabAdapter.markThreadAsRead(mockGitLabAccount, '12');
+      await gitlabAdapter.accountOps.markThreadAsRead(mockGitLabAccount, '12');
 
       expect(spy).toHaveBeenCalledWith(mockGitLabAccount, '12');
     });
@@ -244,13 +246,13 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
     it('markThreadAsDone throws — the capability gate is the contract', () => {
       // The orchestrator falls back to mark-as-read for forges reporting
       // markAsDone: false, which lands on the same GitLab endpoint anyway.
-      expect(() => gitlabAdapter.markThreadAsDone(mockGitLabAccount, '13')).toThrow(
+      expect(() => gitlabAdapter.accountOps.markThreadAsDone(mockGitLabAccount, '13')).toThrow(
         /check capabilities.markAsDone/,
       );
     });
 
     it('unsubscribeThread throws because the capability is off', () => {
-      expect(() => gitlabAdapter.unsubscribeThread(mockGitLabAccount, '14')).toThrow(
+      expect(() => gitlabAdapter.accountOps.unsubscribeThread(mockGitLabAccount, '14')).toThrow(
         /not supported for GitLab/,
       );
     });
@@ -260,7 +262,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
     it('delegates to gitlabGetJson', async () => {
       const spy = vi.spyOn(client, 'gitlabGetJson').mockResolvedValue({ web_url: 'x' });
 
-      const result = await gitlabAdapter.followUrl<{ web_url: string }>(
+      const result = await gitlabAdapter.accountOps.followUrl(
         mockGitLabAccount,
         'https://gitlab.com/api/v4/x' as Link,
       );
@@ -316,7 +318,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
 
   describe('onAccountTokenChange', () => {
     it('is omitted because the client holds no cache', () => {
-      expect(gitlabAdapter.onAccountTokenChange).toBeUndefined();
+      expect(gitlabAdapter.accountOps.onAccountTokenChange).toBeUndefined();
     });
   });
 
@@ -327,7 +329,7 @@ describe('renderer/utils/forges/gitlab/adapter.ts', () => {
         hostname: 'gitlab.example.com' as Hostname,
       } satisfies Account;
 
-      expect(gitlabAdapter.getAccountSettingsUrl(selfManaged)).toBe(
+      expect(gitlabAdapter.accountOps.getAccountSettingsUrl(selfManaged)).toBe(
         'https://gitlab.example.com/-/user_settings/personal_access_tokens',
       );
     });

--- a/src/renderer/utils/forges/gitlab/adapter.ts
+++ b/src/renderer/utils/forges/gitlab/adapter.ts
@@ -128,33 +128,10 @@ export const gitlabAdapter: ForgeAdapter = {
   displayName: 'GitLab',
   tagline: 'GitLab.com & Self-Managed',
   icon: GitLabIcon,
-  capabilities,
 
   getPlatform,
   formatUserLogin: (login) => login,
-  formatNotificationUser: (_account, user) => user.login,
 
-  fetchAuthenticatedUser,
-  listNotifications,
-
-  markThreadAsRead: (account, threadId) => markGitLabTodoAsDone(account, threadId),
-  // Capability `markAsDone(account)` returns false, so the orchestrator falls
-  // back to mark-as-read before reaching here. Throwing surfaces any caller
-  // that bypasses the capability check.
-  markThreadAsDone: () => {
-    throw new Error(
-      'Mark-as-done is not supported for GitLab accounts; check capabilities.markAsDone before calling.',
-    );
-  },
-  unsubscribeThread: () => {
-    throw new Error(
-      'Ignoring thread subscriptions is not supported for GitLab accounts; check capabilities.unsubscribeThread before calling.',
-    );
-  },
-
-  followUrl<T>(account: Account, url: Link): Promise<T> {
-    return gitlabGetJson<T>(account, url);
-  },
   getDisplayHelpers,
 
   defaultHostname: GITLAB_CLOUD_HOSTNAME,
@@ -166,19 +143,6 @@ export const gitlabAdapter: ForgeAdapter = {
 
   getPersonalAccessTokenSettingsUrl: (hostname: Hostname) =>
     `https://${hostname}/-/user_settings/personal_access_tokens` as Link,
-  getAccountSettingsUrl: (account: Account) =>
-    `https://${account.hostname}/-/user_settings/personal_access_tokens` as Link,
-  getIssuesUrl: (account) => {
-    const url = new URL(`https://${account.hostname}/dashboard/issues`);
-    if (account.user) {
-      url.searchParams.set('assignee_username', account.user.login);
-    }
-    return url.toString() as Link;
-  },
-  getPullRequestsUrl: (account) => `https://${account.hostname}/dashboard/merge_requests` as Link,
-  // GitLab's "notification feed" for the current user is the To-Do List
-  // (bell icon). Gitify reads to-dos for GitLab, so link there.
-  getNotificationsUrl: (account) => `https://${account.hostname}/dashboard/todos` as Link,
 
   documentationUrl: GITLAB_DOCS_URL,
 
@@ -195,4 +159,41 @@ export const gitlabAdapter: ForgeAdapter = {
       authMethod: 'Personal Access Token',
     },
   ],
+
+  accountOps: {
+    capabilities,
+    formatNotificationUser: (_account, user) => user.login,
+    fetchAuthenticatedUser,
+    listNotifications,
+    markThreadAsRead: (account, threadId) => markGitLabTodoAsDone(account, threadId),
+    // Capability `markAsDone(account)` returns false, so the orchestrator falls
+    // back to mark-as-read before reaching here. Throwing surfaces any caller
+    // that bypasses the capability check.
+    markThreadAsDone: () => {
+      throw new Error(
+        'Mark-as-done is not supported for GitLab accounts; check capabilities.markAsDone before calling.',
+      );
+    },
+    unsubscribeThread: () => {
+      throw new Error(
+        'Ignoring thread subscriptions is not supported for GitLab accounts; check capabilities.unsubscribeThread before calling.',
+      );
+    },
+    followUrl<T>(account: Account, url: Link): Promise<T> {
+      return gitlabGetJson<T>(account, url);
+    },
+    getAccountSettingsUrl: (account: Account) =>
+      `https://${account.hostname}/-/user_settings/personal_access_tokens` as Link,
+    getIssuesUrl: (account) => {
+      const url = new URL(`https://${account.hostname}/dashboard/issues`);
+      if (account.user) {
+        url.searchParams.set('assignee_username', account.user.login);
+      }
+      return url.toString() as Link;
+    },
+    getPullRequestsUrl: (account) => `https://${account.hostname}/dashboard/merge_requests` as Link,
+    // GitLab's "notification feed" for the current user is the To-Do List
+    // (bell icon). Gitify reads to-dos for GitLab, so link there.
+    getNotificationsUrl: (account) => `https://${account.hostname}/dashboard/todos` as Link,
+  },
 };

--- a/src/renderer/utils/forges/registry.test.ts
+++ b/src/renderer/utils/forges/registry.test.ts
@@ -7,7 +7,13 @@ import {
 
 import type { Account, Forge, Link } from '../../types';
 
-import { forAccount, getAdapter, isKnownForge, KNOWN_FORGES, listAdapters } from './registry';
+import {
+  getAccountAdapter,
+  getAdapter,
+  isKnownForge,
+  KNOWN_FORGES,
+  listAdapters,
+} from './registry';
 
 describe('renderer/utils/forges/registry.ts', () => {
   describe('getAdapter', () => {
@@ -47,7 +53,7 @@ describe('renderer/utils/forges/registry.ts', () => {
     });
   });
 
-  describe('forAccount', () => {
+  describe('getAccountAdapter', () => {
     afterEach(() => {
       vi.restoreAllMocks();
     });
@@ -57,7 +63,7 @@ describe('renderer/utils/forges/registry.ts', () => {
         .spyOn(getAdapter('github').accountOps, 'listNotifications')
         .mockResolvedValue([]);
 
-      await forAccount(mockGitHubCloudAccount).listNotifications();
+      await getAccountAdapter(mockGitHubCloudAccount).listNotifications();
 
       expect(listSpy).toHaveBeenCalledWith(mockGitHubCloudAccount);
     });
@@ -67,7 +73,7 @@ describe('renderer/utils/forges/registry.ts', () => {
         .spyOn(getAdapter('github').accountOps, 'markThreadAsRead')
         .mockResolvedValue(undefined);
 
-      await forAccount(mockGitHubCloudAccount).markThreadAsRead('thread-1');
+      await getAccountAdapter(mockGitHubCloudAccount).markThreadAsRead('thread-1');
 
       expect(markSpy).toHaveBeenCalledWith(mockGitHubCloudAccount, 'thread-1');
     });
@@ -77,18 +83,18 @@ describe('renderer/utils/forges/registry.ts', () => {
         .spyOn(getAdapter('github').accountOps.capabilities, 'markAsDone')
         .mockReturnValue(true);
 
-      expect(forAccount(mockGitHubCloudAccount).capabilities.markAsDone()).toBe(true);
+      expect(getAccountAdapter(mockGitHubCloudAccount).capabilities.markAsDone()).toBe(true);
       expect(capabilitySpy).toHaveBeenCalledWith(mockGitHubCloudAccount);
     });
 
     it('omits optional bundles the forge does not provide', () => {
-      expect(forAccount(mockGiteaAccount).oauthScopes).toBeUndefined();
-      expect(forAccount(mockGiteaAccount).onAccountTokenChange).toBeUndefined();
-      expect(forAccount(mockGitHubCloudAccount).oauthScopes).toBeDefined();
+      expect(getAccountAdapter(mockGiteaAccount).oauthScopes).toBeUndefined();
+      expect(getAccountAdapter(mockGiteaAccount).onAccountTokenChange).toBeUndefined();
+      expect(getAccountAdapter(mockGitHubCloudAccount).oauthScopes).toBeDefined();
     });
 
     it('resolves members at call time so later replacements are honoured', () => {
-      const view = forAccount(mockGitHubCloudAccount);
+      const view = getAccountAdapter(mockGitHubCloudAccount);
       const urlSpy = vi
         .spyOn(getAdapter('github').accountOps, 'getIssuesUrl')
         .mockReturnValue('https://example.test/issues' as Link);
@@ -99,7 +105,7 @@ describe('renderer/utils/forges/registry.ts', () => {
 
     it('throws for an unknown forge', () => {
       const unknown = { ...mockGitHubCloudAccount, forge: 'mystery' as Forge } as Account;
-      expect(() => forAccount(unknown)).toThrow(/No forge adapter registered/);
+      expect(() => getAccountAdapter(unknown)).toThrow(/No forge adapter registered/);
     });
   });
 

--- a/src/renderer/utils/forges/registry.test.ts
+++ b/src/renderer/utils/forges/registry.test.ts
@@ -5,9 +5,9 @@ import {
   mockGitLabAccount,
 } from '../../__mocks__/account-mocks';
 
-import type { Account, Forge } from '../../types';
+import type { Account, Forge, Link } from '../../types';
 
-import { getAdapter, isKnownForge, KNOWN_FORGES, listAdapters } from './registry';
+import { forAccount, getAdapter, isKnownForge, KNOWN_FORGES, listAdapters } from './registry';
 
 describe('renderer/utils/forges/registry.ts', () => {
   describe('getAdapter', () => {
@@ -44,6 +44,62 @@ describe('renderer/utils/forges/registry.ts', () => {
 
     it('throws for an unknown forge id', () => {
       expect(() => getAdapter('mystery' as Forge)).toThrow(/No forge adapter registered/);
+    });
+  });
+
+  describe('forAccount', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('supplies the account to account-scoped operations', async () => {
+      const listSpy = vi
+        .spyOn(getAdapter('github').accountOps, 'listNotifications')
+        .mockResolvedValue([]);
+
+      await forAccount(mockGitHubCloudAccount).listNotifications();
+
+      expect(listSpy).toHaveBeenCalledWith(mockGitHubCloudAccount);
+    });
+
+    it('passes remaining arguments after the account', async () => {
+      const markSpy = vi
+        .spyOn(getAdapter('github').accountOps, 'markThreadAsRead')
+        .mockResolvedValue(undefined);
+
+      await forAccount(mockGitHubCloudAccount).markThreadAsRead('thread-1');
+
+      expect(markSpy).toHaveBeenCalledWith(mockGitHubCloudAccount, 'thread-1');
+    });
+
+    it('binds nested bundles such as capabilities', () => {
+      const capabilitySpy = vi
+        .spyOn(getAdapter('github').accountOps.capabilities, 'markAsDone')
+        .mockReturnValue(true);
+
+      expect(forAccount(mockGitHubCloudAccount).capabilities.markAsDone()).toBe(true);
+      expect(capabilitySpy).toHaveBeenCalledWith(mockGitHubCloudAccount);
+    });
+
+    it('omits optional bundles the forge does not provide', () => {
+      expect(forAccount(mockGiteaAccount).oauthScopes).toBeUndefined();
+      expect(forAccount(mockGiteaAccount).onAccountTokenChange).toBeUndefined();
+      expect(forAccount(mockGitHubCloudAccount).oauthScopes).toBeDefined();
+    });
+
+    it('resolves members at call time so later replacements are honoured', () => {
+      const view = forAccount(mockGitHubCloudAccount);
+      const urlSpy = vi
+        .spyOn(getAdapter('github').accountOps, 'getIssuesUrl')
+        .mockReturnValue('https://example.test/issues' as Link);
+
+      expect(view.getIssuesUrl()).toBe('https://example.test/issues');
+      expect(urlSpy).toHaveBeenCalledWith(mockGitHubCloudAccount);
+    });
+
+    it('throws for an unknown forge', () => {
+      const unknown = { ...mockGitHubCloudAccount, forge: 'mystery' as Forge } as Account;
+      expect(() => forAccount(unknown)).toThrow(/No forge adapter registered/);
     });
   });
 

--- a/src/renderer/utils/forges/registry.test.ts
+++ b/src/renderer/utils/forges/registry.test.ts
@@ -1,12 +1,17 @@
+import { expectTypeOf } from 'vite-plus/test';
+
 import {
   mockBitbucketAccount,
   mockGiteaAccount,
   mockGitHubCloudAccount,
+  mockGitHubEnterpriseServerAccount,
   mockGitLabAccount,
 } from '../../__mocks__/account-mocks';
 
 import type { Account, Forge, Link } from '../../types';
+import type { ForgeAccountAdapter, ForgeAccountOperations } from './types';
 
+import * as giteaClient from './gitea/client';
 import {
   getAccountAdapter,
   getAdapter,
@@ -93,14 +98,63 @@ describe('renderer/utils/forges/registry.ts', () => {
       expect(getAccountAdapter(mockGitHubCloudAccount).oauthScopes).toBeDefined();
     });
 
-    it('resolves members at call time so later replacements are honoured', () => {
-      const view = getAccountAdapter(mockGitHubCloudAccount);
-      const urlSpy = vi
-        .spyOn(getAdapter('github').accountOps, 'getIssuesUrl')
-        .mockReturnValue('https://example.test/issues' as Link);
+    it('keeps interleaved operations isolated between accounts on the same forge', async () => {
+      const markSpy = vi
+        .spyOn(getAdapter('github').accountOps, 'markThreadAsRead')
+        .mockResolvedValue(undefined);
+      const cloud = getAccountAdapter(mockGitHubCloudAccount);
+      const enterprise = getAccountAdapter(mockGitHubEnterpriseServerAccount);
 
-      expect(view.getIssuesUrl()).toBe('https://example.test/issues');
-      expect(urlSpy).toHaveBeenCalledWith(mockGitHubCloudAccount);
+      await cloud.markThreadAsRead('cloud-1');
+      await enterprise.markThreadAsRead('enterprise-1');
+      await cloud.markThreadAsRead('cloud-2');
+
+      expect(markSpy.mock.calls).toEqual([
+        [mockGitHubCloudAccount, 'cloud-1'],
+        [mockGitHubEnterpriseServerAccount, 'enterprise-1'],
+        [mockGitHubCloudAccount, 'cloud-2'],
+      ]);
+      expect(cloud.getIssuesUrl()).toBe('https://github.com/issues');
+      expect(enterprise.getIssuesUrl()).toBe('https://github.gitify.io/issues');
+    });
+
+    it('routes bound Gitea requests through its provider and preserves the response', async () => {
+      const url = 'https://gitea.example.com/api/v1/repos/owner/repo/issues/1' as Link;
+      const response = { html_url: 'https://gitea.example.com/owner/repo/issues/1' };
+      const getJsonSpy = vi.spyOn(giteaClient, 'giteaGetJson').mockResolvedValue(response);
+      const markSpy = vi
+        .spyOn(giteaClient, 'patchGiteaNotificationThread')
+        .mockResolvedValue(undefined);
+      const view = getAccountAdapter(mockGiteaAccount);
+
+      const result = await view.followUrl<{ html_url: string }>(url);
+      await view.markThreadAsRead('gitea-1');
+
+      expect(result).toBe(response);
+      expect(getJsonSpy).toHaveBeenCalledWith(mockGiteaAccount, url);
+      expect(markSpy).toHaveBeenCalledWith(mockGiteaAccount, 'gitea-1', 'read');
+      expect(view.capabilities.markAsDone()).toBe(false);
+      expect(view.getNotificationsUrl()).toBe('https://gitea.example.com/notifications');
+    });
+
+    it('propagates a bound provider request failure', async () => {
+      const error = new Error('Gitea request failed');
+      vi.spyOn(giteaClient, 'giteaGetJson').mockRejectedValue(error);
+
+      await expect(
+        getAccountAdapter(mockGiteaAccount).followUrl(
+          'https://gitea.example.com/api/v1/user' as Link,
+        ),
+      ).rejects.toBe(error);
+    });
+
+    it('preserves generic response types on both operation contracts', () => {
+      expectTypeOf<ForgeAccountOperations['followUrl']>().toEqualTypeOf<
+        <T>(account: Account, url: Link) => Promise<T>
+      >();
+      expectTypeOf<ForgeAccountAdapter['followUrl']>().toEqualTypeOf<
+        <T>(url: Link) => Promise<T>
+      >();
     });
 
     it('throws for an unknown forge', () => {

--- a/src/renderer/utils/forges/registry.ts
+++ b/src/renderer/utils/forges/registry.ts
@@ -1,5 +1,5 @@
 import type { Account, Forge } from '../../types';
-import type { ForgeAdapter } from './types';
+import type { ForgeAccountAdapter, ForgeAdapter, WithAccount } from './types';
 
 import { bitbucketAdapter } from './bitbucket/adapter';
 import { giteaAdapter } from './gitea/adapter';
@@ -10,7 +10,9 @@ import { gitlabAdapter } from './gitlab/adapter';
  * Central forge adapter registry.
  *
  * Adding a new forge is one entry in this map. Shared code routes through
- * `getAdapter(account)` and never imports forge-specific modules directly.
+ * `getAdapter(forge)` for forge-wide members and `forAccount(account)` for
+ * account-scoped operations, and never imports forge-specific modules
+ * directly.
  */
 const ADAPTERS: Record<Forge, ForgeAdapter> = {
   github: githubAdapter,
@@ -41,6 +43,36 @@ export function getAdapter(forgeOrAccount: Forge | Account): ForgeAdapter {
     throw new Error(`No forge adapter registered for "${id}"`);
   }
   return adapter;
+}
+
+/**
+ * Resolve the account-bound view of an account's forge adapter.
+ *
+ * Every function under the adapter's `accountOps` is wrapped to receive the
+ * account as its first argument, and nested bundles (capabilities, OAuth
+ * scopes) are wrapped the same way. Members are looked up on the adapter at
+ * call time, so replacing one on the adapter (e.g. a test spy) is honoured by
+ * views created earlier.
+ */
+export function forAccount(account: Account): ForgeAccountAdapter {
+  return bindAccount(getAdapter(account).accountOps, account);
+}
+
+function bindAccount<T extends object>(operations: WithAccount<T>, account: Account): T {
+  const source = operations as Record<string, unknown>;
+  const bound: Record<string, unknown> = {};
+  for (const key of Object.keys(source)) {
+    const member = source[key];
+    if (typeof member === 'function') {
+      bound[key] = (...args: unknown[]) =>
+        (source[key] as (account: Account, ...rest: unknown[]) => unknown)(account, ...args);
+    } else if (member !== null && typeof member === 'object') {
+      bound[key] = bindAccount(member as WithAccount<object>, account);
+    } else {
+      bound[key] = member;
+    }
+  }
+  return bound as T;
 }
 
 export function listAdapters(): ForgeAdapter[] {

--- a/src/renderer/utils/forges/registry.ts
+++ b/src/renderer/utils/forges/registry.ts
@@ -10,7 +10,7 @@ import { gitlabAdapter } from './gitlab/adapter';
  * Central forge adapter registry.
  *
  * Adding a new forge is one entry in this map. Shared code routes through
- * `getAdapter(forge)` for forge-wide members and `forAccount(account)` for
+ * `getAdapter(forge)` for forge-wide members and `getAccountAdapter(account)` for
  * account-scoped operations, and never imports forge-specific modules
  * directly.
  */
@@ -54,7 +54,7 @@ export function getAdapter(forgeOrAccount: Forge | Account): ForgeAdapter {
  * call time, so replacing one on the adapter (e.g. a test spy) is honoured by
  * views created earlier.
  */
-export function forAccount(account: Account): ForgeAccountAdapter {
+export function getAccountAdapter(account: Account): ForgeAccountAdapter {
   return bindAccount(getAdapter(account).accountOps, account);
 }
 

--- a/src/renderer/utils/forges/registry.ts
+++ b/src/renderer/utils/forges/registry.ts
@@ -1,5 +1,5 @@
-import type { Account, Forge } from '../../types';
-import type { ForgeAccountAdapter, ForgeAdapter, WithAccount } from './types';
+import type { Account, Forge, Link } from '../../types';
+import type { ForgeAccountAdapter, ForgeAdapter } from './types';
 
 import { bitbucketAdapter } from './bitbucket/adapter';
 import { giteaAdapter } from './gitea/adapter';
@@ -45,34 +45,50 @@ export function getAdapter(forgeOrAccount: Forge | Account): ForgeAdapter {
   return adapter;
 }
 
-/**
- * Resolve the account-bound view of an account's forge adapter.
- *
- * Every function under the adapter's `accountOps` is wrapped to receive the
- * account as its first argument, and nested bundles (capabilities, OAuth
- * scopes) are wrapped the same way. Members are looked up on the adapter at
- * call time, so replacing one on the adapter (e.g. a test spy) is honoured by
- * views created earlier.
- */
+/** Create a view for this account snapshot; resolve a new view when the account changes. */
 export function getAccountAdapter(account: Account): ForgeAccountAdapter {
-  return bindAccount(getAdapter(account).accountOps, account);
-}
+  const {
+    capabilities,
+    formatNotificationUser,
+    fetchAuthenticatedUser,
+    onAccountTokenChange,
+    listNotifications,
+    markThreadAsRead,
+    markThreadAsDone,
+    unsubscribeThread,
+    followUrl,
+    getAccountSettingsUrl,
+    getIssuesUrl,
+    getPullRequestsUrl,
+    getNotificationsUrl,
+    oauthScopes,
+  } = getAdapter(account).accountOps;
 
-function bindAccount<T extends object>(operations: WithAccount<T>, account: Account): T {
-  const source = operations as Record<string, unknown>;
-  const bound: Record<string, unknown> = {};
-  for (const key of Object.keys(source)) {
-    const member = source[key];
-    if (typeof member === 'function') {
-      bound[key] = (...args: unknown[]) =>
-        (source[key] as (account: Account, ...rest: unknown[]) => unknown)(account, ...args);
-    } else if (member !== null && typeof member === 'object') {
-      bound[key] = bindAccount(member as WithAccount<object>, account);
-    } else {
-      bound[key] = member;
-    }
-  }
-  return bound as T;
+  return {
+    capabilities: {
+      markAsDone: () => capabilities.markAsDone(account),
+      unsubscribeThread: () => capabilities.unsubscribeThread(account),
+    },
+    formatNotificationUser: (user) => formatNotificationUser(account, user),
+    fetchAuthenticatedUser: () => fetchAuthenticatedUser(account),
+    onAccountTokenChange: onAccountTokenChange ? () => onAccountTokenChange(account) : undefined,
+    listNotifications: () => listNotifications(account),
+    markThreadAsRead: (threadId) => markThreadAsRead(account, threadId),
+    markThreadAsDone: (threadId) => markThreadAsDone(account, threadId),
+    unsubscribeThread: (threadId) => unsubscribeThread(account, threadId),
+    followUrl: <T>(url: Link) => followUrl<T>(account, url),
+    getAccountSettingsUrl: () => getAccountSettingsUrl(account),
+    getIssuesUrl: () => getIssuesUrl(account),
+    getPullRequestsUrl: () => getPullRequestsUrl(account),
+    getNotificationsUrl: () => getNotificationsUrl(account),
+    oauthScopes: oauthScopes
+      ? {
+          hasRequired: () => oauthScopes.hasRequired(account),
+          hasRecommended: () => oauthScopes.hasRecommended(account),
+          hasAlternate: () => oauthScopes.hasAlternate(account),
+        }
+      : undefined,
+  };
 }
 
 export function listAdapters(): ForgeAdapter[] {

--- a/src/renderer/utils/forges/types.ts
+++ b/src/renderer/utils/forges/types.ts
@@ -28,12 +28,7 @@ import type {
  * Each capability is a function over the account because for some forges (e.g.
  * GitHub Enterprise Server) capabilities depend on the hostname and version.
  */
-export interface ForgeCapabilities {
-  /** Whether the forge supports a "mark as done" action distinct from "mark as read". */
-  markAsDone(account: Account): boolean;
-  /** Whether the forge supports ignoring a thread's subscription (unsubscribe). */
-  unsubscribeThread(account: Account): boolean;
-}
+export type ForgeCapabilities = ForgeAccountOperations['capabilities'];
 
 /**
  * Normalised account data returned by `fetchAuthenticatedUser`.
@@ -88,7 +83,9 @@ export interface LoginMethodDescriptor {
  * The contract every forge adapter must implement.
  *
  * Goal: shared code (notifications orchestrator, hooks, UI) routes through
- * `getAdapter(account)` and never imports forge-specific modules directly.
+ * `getAdapter(forge)` for forge-wide members and `forAccount(account)` for
+ * account-scoped operations, and never imports forge-specific modules
+ * directly.
  *
  * @see ./github/adapter.ts — full reference implementation (REST + GraphQL,
  *      enrichment, Octokit cache lifecycle).
@@ -103,8 +100,13 @@ export interface ForgeAdapter {
   readonly tagline?: string;
   /** Icon used for the platform in the UI. */
   readonly icon: FC<OcticonProps>;
-  /** Static or computed capability matrix for this forge. */
-  readonly capabilities: ForgeCapabilities;
+
+  /**
+   * Operations that act on behalf of one account. Shared code never calls
+   * these directly: it obtains an account-bound view via `forAccount(account)`
+   * from the registry, which supplies the account to every call.
+   */
+  readonly accountOps: ForgeAccountOperations;
 
   /**
    * Resolve the platform label (e.g. "GitHub Cloud") for a given hostname.
@@ -116,29 +118,6 @@ export interface ForgeAdapter {
    * Format an authenticated user login according to the forge's display convention.
    */
   formatUserLogin(login: string): string;
-
-  /** Format a notification actor for display (e.g. bots, managed users) according to forge identity conventions. */
-  formatNotificationUser(account: Account, user: GitifyNotificationUser): string;
-
-  /** Fetch the authenticated user (used during login & on refresh). */
-  fetchAuthenticatedUser(account: Account): Promise<RefreshAccountData>;
-
-  /**
-   * Optional lifecycle hook called when an account's token rotates. Forges
-   * with HTTP client caches (e.g. GitHub Octokit) drop their cache here.
-   */
-  onAccountTokenChange?(account: Account): void;
-
-  /**
-   * List notifications already transformed to the shared shape.
-   * Returns `RawGitifyNotification[]` — `display` is populated later by the
-   * orchestrator's `formatNotification` step.
-   */
-  listNotifications(account: Account): Promise<RawGitifyNotification[]>;
-
-  markThreadAsRead(account: Account, threadId: string): Promise<void>;
-  markThreadAsDone(account: Account, threadId: string): Promise<void>;
-  unsubscribeThread(account: Account, threadId: string): Promise<void>;
 
   /**
    * Enrich notifications with forge-specific subject details (state, user,
@@ -157,12 +136,6 @@ export interface ForgeAdapter {
   enrichNotifications?(notifications: RawGitifyNotification[]): Promise<RawGitifyNotification[]>;
 
   /**
-   * GET an arbitrary forge URL and return JSON. Used by notification
-   * handlers to follow subject/comment URLs.
-   */
-  followUrl<T>(account: Account, url: Link): Promise<T>;
-
-  /**
    * Return the display-surface values (icon, color, default url, default user
    * type) for a notification. Adapter-internal dispatch keeps shared
    * formatting code (`formatters.ts`, `url.ts`) forge-agnostic.
@@ -177,18 +150,6 @@ export interface ForgeAdapter {
   validateToken(token: Token): boolean;
   /** URL to manage/create a personal access token on the forge. */
   getPersonalAccessTokenSettingsUrl(hostname: Hostname): Link;
-  /**
-   * URL to the forge page where the user manages this account's auth method
-   * (e.g. tokens, OAuth apps, GitHub Apps). Forges may key this off the
-   * account's auth method.
-   */
-  getAccountSettingsUrl(account: Account): Link;
-  /** URL to the forge's "my issues" list for the account's host. */
-  getIssuesUrl(account: Account): Link;
-  /** URL to the forge's "my pull requests" list for the account's host. */
-  getPullRequestsUrl(account: Account): Link;
-  /** URL to the forge's notification centre for the account's host. */
-  getNotificationsUrl(account: Account): Link;
   /** Login entries rendered in the Login route. */
   loginMethods: ReadonlyArray<LoginMethodDescriptor>;
   /** External documentation link shown in the PAT login route. */
@@ -218,28 +179,108 @@ export interface ForgeAdapter {
    * omit this bundle entirely — callers gate the OAuth-app UI on its presence.
    */
   oauthWebApp?: OAuthWebAppSupport;
+}
+
+/**
+ * The account-bound view of a forge adapter, obtained via `forAccount(account)`.
+ *
+ * Every member acts on the account the view was created for, so none of them
+ * take an account parameter. A view holds the account it was bound to, and the
+ * store replaces account objects when their token rotates, so create a view at
+ * the call site rather than keeping one around.
+ */
+export interface ForgeAccountAdapter {
+  /** Capability matrix for the account's forge and host. */
+  readonly capabilities: {
+    /** Whether the forge supports a "mark as done" action distinct from "mark as read". */
+    markAsDone(): boolean;
+    /** Whether the forge supports ignoring a thread's subscription (unsubscribe). */
+    unsubscribeThread(): boolean;
+  };
+
+  /** Format a notification actor for display (e.g. bots, managed users) according to forge identity conventions. */
+  formatNotificationUser(user: GitifyNotificationUser): string;
+
+  /** Fetch the authenticated user (used during login & on refresh). */
+  fetchAuthenticatedUser(): Promise<RefreshAccountData>;
+
+  /**
+   * Optional lifecycle hook called when the account's token rotates. Forges
+   * with HTTP client caches (e.g. GitHub Octokit) drop their cache here.
+   */
+  onAccountTokenChange?(): void;
+
+  /**
+   * List notifications already transformed to the shared shape. Returns
+   * `RawGitifyNotification[]`; `display` is populated later by the
+   * orchestrator's `formatNotification` step.
+   */
+  listNotifications(): Promise<RawGitifyNotification[]>;
+
+  markThreadAsRead(threadId: string): Promise<void>;
+  markThreadAsDone(threadId: string): Promise<void>;
+  unsubscribeThread(threadId: string): Promise<void>;
+
+  /**
+   * GET an arbitrary forge URL and return JSON. Used by notification
+   * handlers to follow subject/comment URLs.
+   */
+  followUrl<T>(url: Link): Promise<T>;
+
+  /**
+   * URL to the forge page where the user manages this account's auth method
+   * (e.g. tokens, OAuth apps, GitHub Apps). Forges may key this off the
+   * account's auth method.
+   */
+  getAccountSettingsUrl(): Link;
+  /** URL to the forge's "my issues" list for the account's host. */
+  getIssuesUrl(): Link;
+  /** URL to the forge's "my pull requests" list for the account's host. */
+  getPullRequestsUrl(): Link;
+  /** URL to the forge's notification centre for the account's host. */
+  getNotificationsUrl(): Link;
 
   /**
    * OAuth scope checks. Forges with no scope concept (e.g. Gitea) omit this
-   * bundle entirely — callers should treat `oauthScopes === undefined` as
+   * bundle entirely; callers should treat `oauthScopes === undefined` as
    * "nothing to verify" and skip any scopes UI rather than render a
    * meaningless "all granted" state.
    */
-  oauthScopes?: OAuthScopesSupport;
+  readonly oauthScopes?: {
+    /** Whether the account holds the minimum scopes Gitify needs to function. */
+    hasRequired(): boolean;
+    /** Whether the account holds the full recommended scope set. */
+    hasRecommended(): boolean;
+    /** Whether the account holds the alternate (legacy) scope set. */
+    hasAlternate(): boolean;
+  };
 }
+
+/**
+ * Maps one member of {@link ForgeAccountAdapter} to its implementation shape:
+ * functions gain `account` as their first parameter, nested bundles are mapped
+ * recursively, and anything else is left as is.
+ */
+type WithAccountMember<M> = M extends (...args: infer A) => infer R
+  ? (account: Account, ...args: A) => R
+  : M extends object
+    ? WithAccount<M>
+    : M;
+
+export type WithAccount<T> = { [K in keyof T]: WithAccountMember<T[K]> };
+
+/**
+ * Implementation-side shape of {@link ForgeAccountAdapter}: the same members
+ * with the account passed explicitly. Adapters implement this under
+ * `accountOps`; `forAccount(account)` binds it into a `ForgeAccountAdapter`.
+ */
+export type ForgeAccountOperations = WithAccount<ForgeAccountAdapter>;
 
 /**
  * OAuth scope-checking capability bundle. Present only on forges with an
  * OAuth scope concept (GitHub today).
  */
-export interface OAuthScopesSupport {
-  /** Whether the account holds the minimum scopes Gitify needs to function. */
-  hasRequired(account: Account): boolean;
-  /** Whether the account holds the full recommended scope set. */
-  hasRecommended(account: Account): boolean;
-  /** Whether the account holds the alternate (legacy) scope set. */
-  hasAlternate(account: Account): boolean;
-}
+export type OAuthScopesSupport = NonNullable<ForgeAccountOperations['oauthScopes']>;
 
 /**
  * Custom-OAuth-app web flow capability bundle. Present only on forges that

--- a/src/renderer/utils/forges/types.ts
+++ b/src/renderer/utils/forges/types.ts
@@ -83,7 +83,7 @@ export interface LoginMethodDescriptor {
  * The contract every forge adapter must implement.
  *
  * Goal: shared code (notifications orchestrator, hooks, UI) routes through
- * `getAdapter(forge)` for forge-wide members and `forAccount(account)` for
+ * `getAdapter(forge)` for forge-wide members and `getAccountAdapter(account)` for
  * account-scoped operations, and never imports forge-specific modules
  * directly.
  *
@@ -103,7 +103,7 @@ export interface ForgeAdapter {
 
   /**
    * Operations that act on behalf of one account. Shared code never calls
-   * these directly: it obtains an account-bound view via `forAccount(account)`
+   * these directly: it obtains an account-bound view via `getAccountAdapter(account)`
    * from the registry, which supplies the account to every call.
    */
   readonly accountOps: ForgeAccountOperations;
@@ -182,7 +182,7 @@ export interface ForgeAdapter {
 }
 
 /**
- * The account-bound view of a forge adapter, obtained via `forAccount(account)`.
+ * The account-bound view of a forge adapter, obtained via `getAccountAdapter(account)`.
  *
  * Every member acts on the account the view was created for, so none of them
  * take an account parameter. A view holds the account it was bound to, and the
@@ -272,7 +272,7 @@ export type WithAccount<T> = { [K in keyof T]: WithAccountMember<T[K]> };
 /**
  * Implementation-side shape of {@link ForgeAccountAdapter}: the same members
  * with the account passed explicitly. Adapters implement this under
- * `accountOps`; `forAccount(account)` binds it into a `ForgeAccountAdapter`.
+ * `accountOps`; `getAccountAdapter(account)` binds it into a `ForgeAccountAdapter`.
  */
 export type ForgeAccountOperations = WithAccount<ForgeAccountAdapter>;
 

--- a/src/renderer/utils/forges/types.ts
+++ b/src/renderer/utils/forges/types.ts
@@ -257,24 +257,33 @@ export interface ForgeAccountAdapter {
 }
 
 /**
- * Maps one member of {@link ForgeAccountAdapter} to its implementation shape:
- * functions gain `account` as their first parameter, nested bundles are mapped
- * recursively, and anything else is left as is.
- */
-type WithAccountMember<M> = M extends (...args: infer A) => infer R
-  ? (account: Account, ...args: A) => R
-  : M extends object
-    ? WithAccount<M>
-    : M;
-
-export type WithAccount<T> = { [K in keyof T]: WithAccountMember<T[K]> };
-
-/**
  * Implementation-side shape of {@link ForgeAccountAdapter}: the same members
  * with the account passed explicitly. Adapters implement this under
  * `accountOps`; `getAccountAdapter(account)` binds it into a `ForgeAccountAdapter`.
  */
-export type ForgeAccountOperations = WithAccount<ForgeAccountAdapter>;
+export interface ForgeAccountOperations {
+  readonly capabilities: {
+    markAsDone(account: Account): boolean;
+    unsubscribeThread(account: Account): boolean;
+  };
+  formatNotificationUser(account: Account, user: GitifyNotificationUser): string;
+  fetchAuthenticatedUser(account: Account): Promise<RefreshAccountData>;
+  onAccountTokenChange?(account: Account): void;
+  listNotifications(account: Account): Promise<RawGitifyNotification[]>;
+  markThreadAsRead(account: Account, threadId: string): Promise<void>;
+  markThreadAsDone(account: Account, threadId: string): Promise<void>;
+  unsubscribeThread(account: Account, threadId: string): Promise<void>;
+  followUrl<T>(account: Account, url: Link): Promise<T>;
+  getAccountSettingsUrl(account: Account): Link;
+  getIssuesUrl(account: Account): Link;
+  getPullRequestsUrl(account: Account): Link;
+  getNotificationsUrl(account: Account): Link;
+  readonly oauthScopes?: {
+    hasRequired(account: Account): boolean;
+    hasRecommended(account: Account): boolean;
+    hasAlternate(account: Account): boolean;
+  };
+}
 
 /**
  * OAuth scope-checking capability bundle. Present only on forges with an

--- a/src/renderer/utils/notifications/notifications.ts
+++ b/src/renderer/utils/notifications/notifications.ts
@@ -10,7 +10,7 @@ import type {
 import { determineFailureType } from '../api/errors';
 import { getAccountUUID } from '../auth/utils';
 import { rendererLogError, toError } from '../core/logger';
-import { forAccount, getAdapter } from '../forges/registry';
+import { getAccountAdapter, getAdapter } from '../forges/registry';
 import { filterBaseNotifications } from './filters/filter';
 import { formatNotification } from './formatters';
 import { getFlattenedNotificationsByRepo } from './group';
@@ -42,7 +42,7 @@ function getNotifications(accounts: Account[]) {
   return accounts.map((account) => {
     return {
       account,
-      notifications: forAccount(account).listNotifications(),
+      notifications: getAccountAdapter(account).listNotifications(),
     };
   });
 }

--- a/src/renderer/utils/notifications/notifications.ts
+++ b/src/renderer/utils/notifications/notifications.ts
@@ -10,7 +10,7 @@ import type {
 import { determineFailureType } from '../api/errors';
 import { getAccountUUID } from '../auth/utils';
 import { rendererLogError, toError } from '../core/logger';
-import { getAdapter } from '../forges/registry';
+import { forAccount, getAdapter } from '../forges/registry';
 import { filterBaseNotifications } from './filters/filter';
 import { formatNotification } from './formatters';
 import { getFlattenedNotificationsByRepo } from './group';
@@ -42,7 +42,7 @@ function getNotifications(accounts: Account[]) {
   return accounts.map((account) => {
     return {
       account,
-      notifications: getAdapter(account).listNotifications(account),
+      notifications: forAccount(account).listNotifications(),
     };
   });
 }

--- a/src/renderer/utils/notifications/url.test.ts
+++ b/src/renderer/utils/notifications/url.test.ts
@@ -19,7 +19,7 @@ describe('renderer/utils/notifications/url.ts', () => {
     const mockNotificationReferrer =
       'notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDEzODY2MTA5NjoxMjM0NTY3ODk%3D';
 
-    const followUrlSpy = vi.spyOn(githubAdapter, 'followUrl');
+    const followUrlSpy = vi.spyOn(githubAdapter.accountOps, 'followUrl');
 
     it('Subject HTML URL: prefer if available from enrichment stage', async () => {
       const mockSubjectHtmlUrl = 'https://gitify.io/' as Link;

--- a/src/renderer/utils/notifications/url.ts
+++ b/src/renderer/utils/notifications/url.ts
@@ -1,7 +1,7 @@
 import type { GitifyNotification, Link } from '../../types';
 
 import { rendererLogError, toError } from '../core/logger';
-import { getAdapter } from '../forges/registry';
+import { forAccount, getAdapter } from '../forges/registry';
 
 export function generateNotificationReferrerId(notification: GitifyNotification): string {
   const raw = `018:NotificationThread${notification.id}:${notification.account.user?.id}`;
@@ -9,8 +9,7 @@ export function generateNotificationReferrerId(notification: GitifyNotification)
 }
 
 export async function generateNotificationWebUrl(notification: GitifyNotification): Promise<Link> {
-  const adapter = getAdapter(notification.account);
-  const url = new URL(adapter.getDisplayHelpers(notification).defaultUrl);
+  const url = new URL(getAdapter(notification.account).getDisplayHelpers(notification).defaultUrl);
 
   if (notification.subject.htmlUrl) {
     url.href = notification.subject.htmlUrl;
@@ -19,8 +18,7 @@ export async function generateNotificationWebUrl(notification: GitifyNotificatio
       const followTarget =
         notification.subject.latestCommentUrl ?? notification.subject.url ?? null;
       if (followTarget) {
-        const response = await adapter.followUrl<{ html_url: string }>(
-          notification.account,
+        const response = await forAccount(notification.account).followUrl<{ html_url: string }>(
           followTarget,
         );
         url.href = response.html_url;

--- a/src/renderer/utils/notifications/url.ts
+++ b/src/renderer/utils/notifications/url.ts
@@ -1,7 +1,7 @@
 import type { GitifyNotification, Link } from '../../types';
 
 import { rendererLogError, toError } from '../core/logger';
-import { forAccount, getAdapter } from '../forges/registry';
+import { getAccountAdapter, getAdapter } from '../forges/registry';
 
 export function generateNotificationReferrerId(notification: GitifyNotification): string {
   const raw = `018:NotificationThread${notification.id}:${notification.account.user?.id}`;
@@ -18,9 +18,9 @@ export async function generateNotificationWebUrl(notification: GitifyNotificatio
       const followTarget =
         notification.subject.latestCommentUrl ?? notification.subject.url ?? null;
       if (followTarget) {
-        const response = await forAccount(notification.account).followUrl<{ html_url: string }>(
-          followTarget,
-        );
+        const response = await getAccountAdapter(notification.account).followUrl<{
+          html_url: string;
+        }>(followTarget);
         url.href = response.html_url;
       }
     } catch (err) {

--- a/src/renderer/utils/system/links.ts
+++ b/src/renderer/utils/system/links.ts
@@ -11,7 +11,7 @@ import type {
   Link,
 } from '../../types';
 
-import { forAccount } from '../forges/registry';
+import { getAccountAdapter } from '../forges/registry';
 import { generateNotificationWebUrl } from '../notifications/url';
 import { openExternalLink } from './comms';
 
@@ -22,15 +22,15 @@ export function openGitifyReleaseNotes(version: string) {
 }
 
 export function openHostNotifications(account: Account) {
-  openExternalLink(forAccount(account).getNotificationsUrl());
+  openExternalLink(getAccountAdapter(account).getNotificationsUrl());
 }
 
 export function openHostIssues(account: Account) {
-  openExternalLink(forAccount(account).getIssuesUrl());
+  openExternalLink(getAccountAdapter(account).getIssuesUrl());
 }
 
 export function openHostPulls(account: Account) {
-  openExternalLink(forAccount(account).getPullRequestsUrl());
+  openExternalLink(getAccountAdapter(account).getPullRequestsUrl());
 }
 
 export function openAccountProfile(account: Account) {
@@ -48,7 +48,7 @@ export function openHost(hostname: Hostname) {
 }
 
 export function openAccountSettings(account: Account) {
-  const url = forAccount(account).getAccountSettingsUrl();
+  const url = getAccountAdapter(account).getAccountSettingsUrl();
   openExternalLink(url);
 }
 

--- a/src/renderer/utils/system/links.ts
+++ b/src/renderer/utils/system/links.ts
@@ -11,7 +11,7 @@ import type {
   Link,
 } from '../../types';
 
-import { getAdapter } from '../forges/registry';
+import { forAccount } from '../forges/registry';
 import { generateNotificationWebUrl } from '../notifications/url';
 import { openExternalLink } from './comms';
 
@@ -22,15 +22,15 @@ export function openGitifyReleaseNotes(version: string) {
 }
 
 export function openHostNotifications(account: Account) {
-  openExternalLink(getAdapter(account).getNotificationsUrl(account));
+  openExternalLink(forAccount(account).getNotificationsUrl());
 }
 
 export function openHostIssues(account: Account) {
-  openExternalLink(getAdapter(account).getIssuesUrl(account));
+  openExternalLink(forAccount(account).getIssuesUrl());
 }
 
 export function openHostPulls(account: Account) {
-  openExternalLink(getAdapter(account).getPullRequestsUrl(account));
+  openExternalLink(forAccount(account).getPullRequestsUrl());
 }
 
 export function openAccountProfile(account: Account) {
@@ -48,7 +48,7 @@ export function openHost(hostname: Hostname) {
 }
 
 export function openAccountSettings(account: Account) {
-  const url = getAdapter(account).getAccountSettingsUrl(account);
+  const url = forAccount(account).getAccountSettingsUrl();
   openExternalLink(url);
 }
 


### PR DESCRIPTION
## Summary

- Split the forge adapter contract. `ForgeAdapter` keeps the forge-wide members (login flows, token validation, display helpers), and a new `ForgeAccountAdapter` carries the account-scoped operations with no account parameter.
- Adapters implement those operations under `accountOps`, still taking the account explicitly; the shape is derived from `ForgeAccountAdapter` by a mapped `WithAccount` type so the two cannot drift. `getAccountAdapter(account)` in the registry binds them, so call sites read `getAccountAdapter(account).listNotifications()` instead of `getAdapter(account).listNotifications(account)`.
- Migrates all 18 call sites, re-points test spies at `adapter.accountOps.*`, and adds registry tests for the binding (argument forwarding, nested capability bundles, optional bundles, call-time member lookup).

Follows up on the double-passing pattern raised in https://github.com/gitify-app/gitify/pull/3255#issuecomment-5529692319.

## Notes

- No behaviour change: URLs, capability checks and notification flows are untouched. The full unit suite, typecheck, lint and format pass.
- A bound view closes over the account object it was created from, and the store replaces accounts on token rotation, so views should be created at the call site rather than stored. This is documented on `ForgeAccountAdapter`.
- `followUrl<T>` stays generic on the bound side; on the implementation side the type parameter erases to `unknown`, matching the trust boundary that existed before.
