### PR TITLE
chore(deps-core): update electron to v44.1.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   react-is: 19.2.8
   cross-spawn: 7.0.6
   got: 11.8.6
-  electron: 43.5.1
+  electron: 44.1.0
 
 importers:
 
@@ -22,7 +22,7 @@ importers:
         version: 5.4.4
       electron-menubar:
         specifier: 10.2.1
-        version: 10.2.1(electron@43.5.1(supports-color@10.2.2))
+        version: 10.2.1(electron@44.1.0(supports-color@10.2.2))
       electron-updater:
         specifier: 6.8.9
         version: 6.8.9(supports-color@10.2.2)
@@ -142,8 +142,8 @@ importers:
         specifier: 17.4.2
         version: 17.4.2
       electron:
-        specifier: 43.5.1
-        version: 43.5.1(supports-color@10.2.2)
+        specifier: 44.1.0
+        version: 44.1.0(supports-color@10.2.2)
       electron-builder:
         specifier: 26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
@@ -2563,7 +2563,7 @@ packages:
   electron-menubar@10.2.1:
     resolution: {integrity: sha512-JIpqGjVYUSloNJn/8hqotzFIRNmJ0jpGQJjXGs4GB/viy8cXIBlWj2G30w+SqJR7TKa+EBhXrMLSA73HdP/VgA==}
     peerDependencies:
-      electron: 43.5.1
+      electron: 44.1.0
 
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
@@ -2578,8 +2578,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.5.1:
-    resolution: {integrity: sha512-lRHSwzZimdWWeqcTHFRCpicWwxBE6kotKIyGTusums/jvmVVC27rLPFikUz8LsLwV7gVWlYaiEYQAWzitbN6nA==}
+  electron@44.1.0:
+    resolution: {integrity: sha512-kmLg8axOg22DC3fXx5NCwBYW8fx0rK2zzJ3Tf67GjNCkxfoxEcd+yo0QfDjlBtHJs3xeA8fTg64b6iVzFTVErg==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -6858,9 +6858,9 @@ snapshots:
 
   electron-log@5.4.4: {}
 
-  electron-menubar@10.2.1(electron@43.5.1(supports-color@10.2.2)):
+  electron-menubar@10.2.1(electron@44.1.0(supports-color@10.2.2)):
     dependencies:
-      electron: 43.5.1(supports-color@10.2.2)
+      electron: 44.1.0(supports-color@10.2.2)
 
   electron-publish@26.15.3(supports-color@10.2.2):
     dependencies:
@@ -6903,7 +6903,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.5.1(supports-color@10.2.2):
+  electron@44.1.0(supports-color@10.2.2):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@10.2.2)
@@ -8087,7 +8087,7 @@ snapshots:
   react-devtools@7.0.1(supports-color@10.2.2):
     dependencies:
       cross-spawn: 7.0.6
-      electron: 43.5.1(supports-color@10.2.2)
+      electron: 44.1.0(supports-color@10.2.2)
       internal-ip: 6.2.0
       minimist: 1.2.8
       react-devtools-core: 7.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ allowBuilds:
   esbuild: true
   unrs-resolver: true
 catalog:
-  electron: '43.5.1'
+  electron: '44.1.0'
 minimumReleaseAgeExclude:
   - electron-menubar
 overrides:


### PR DESCRIPTION
## Summary

Bumps `electron` **43.5.1 → 44.1.0** via the pnpm catalog (the single source of truth for the pin). Lockfile diff is electron-only.

## Why now

Electron 43.3.0–43.4.1 and 44.0.0 broke Linux SNI tray icons ([electron#52674](https://github.com/electron/electron/issues/52674)); 7.5.0 pinned back to 43.2.0 and #3265 moved to 43.5.1 once the 43-line fix (#53215) was verified. The 44 line carries the same fix via [electron#53214](https://github.com/electron/electron/pull/53214), shipped in **44.1.0**. Note **44.0.0 must never land**: its only tray change is the bad-fix backport (#52951).

## Verification

The tray fix is confirmed by electron-menubar's 14-platform visual matrix, which is the only check that can tell a real fix from a plausible one (43.4.1's release note read identically and the matrix caught it):

| Electron | Budgie | Sway/Waybar | LXQt | run |
| --- | --- | --- | --- | --- |
| 43.2.0 (baseline) | 281 | 484 | 484 | main |
| 43.4.1 (bad fix) | **0** | **0** | **0** | menubar #154, 20–29 exhausted retries |
| **44.1.0** | 281 | 484 | 484 | menubar #167 (Renovate), 26 pass, merged |
| 44.1.1 | 281 | 484 | 484 | menubar #170 |

Every signature job passes on `attempt=1` with `exactTray` identical to the 43.2.0 baseline. GNOME (experimental) also matches its baseline profile on 44.1.0 after a re-run; its one earlier failure was the documented Mutter session nondeterminism, not Electron.

electron-menubar itself is now on 44.1.0 on `main` (gitify-app/electron-menubar#167).

Locally on this branch: `check` (455 formatted / 405 linted), `tsc --noEmit`, `build` and `pnpm test` (**1509 passed, 173 files**) are all clean with Electron resolving to 44.1.0.

## What CI should confirm

This is a major bump (new Chromium, new embedded Node), so the checks that matter beyond the unit suite are the three `electron-builder` package jobs (Linux, Windows, macOS) and the native-module rebuilds they trigger. Everything else was already exercised locally.

## Note

44.1.1 is out and adds a fix for an intermittent Linux startup crash (Pango/fontconfig race, [#53340](https://github.com/electron/electron/pull/53340)); it is equally matrix-verified. Renovate will propose it as a routine follow-up now that the hold is lifted.

Refs #3206, #3265
