### PR TITLE
feat(metrics): use new Issue Relates To Icon for linked issues pill

### DIFF
--- a/src/renderer/components/metrics/LinkedIssuesPill.tsx
+++ b/src/renderer/components/metrics/LinkedIssuesPill.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import { IssueOpenedIcon } from '@primer/octicons-react';
+import { IssueRelatesToIcon } from '@primer/octicons-react';
 
 import { IconColor } from '../../types';
 
@@ -26,7 +26,7 @@ export const LinkedIssuesPill: FC<LinkedIssuesPillProps> = ({ linkedIssues }) =>
     <MetricPill
       color={IconColor.GRAY}
       contents={description}
-      icon={IssueOpenedIcon}
+      icon={IssueRelatesToIcon}
       metric={linkedIssues.length}
     />
   );

--- a/src/renderer/components/metrics/__snapshots__/LinkedIssuesPill.test.tsx.snap
+++ b/src/renderer/components/metrics/__snapshots__/LinkedIssuesPill.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`renderer/components/metrics/LinkedIssuesPill.tsx > renders when linked 
       >
         <svg
           aria-hidden="true"
-          class="octicon octicon-issue-opened text-gitify-icon-muted"
+          class="octicon octicon-issue-relates-to text-gitify-icon-muted"
           data-component="Octicon"
           display="inline-block"
           fill="currentColor"
@@ -37,10 +37,10 @@ exports[`renderer/components/metrics/LinkedIssuesPill.tsx > renders when linked 
           width="12"
         >
           <path
-            d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
+            d="M1.5 8a6.5 6.5 0 0 1 13 0A.75.75 0 1 0 16 8a8 8 0 1 0-8 8 .75.75 0 1 0 0-1.5A6.5 6.5 0 0 1 1.5 8"
           />
           <path
-            d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
+            d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3m7.927 2.927-2.896 2.896a.25.25 0 0 1-.428-.177V13h-3.25a.75.75 0 1 1 0-1.5h3.25V9.354a.25.25 0 0 1 .3-.246.25.25 0 0 1 .127.069l2.897 2.896a.25.25 0 0 1 0 .354"
           />
         </svg>
         <span
@@ -91,7 +91,7 @@ exports[`renderer/components/metrics/LinkedIssuesPill.tsx > renders when linked 
       >
         <svg
           aria-hidden="true"
-          class="octicon octicon-issue-opened text-gitify-icon-muted"
+          class="octicon octicon-issue-relates-to text-gitify-icon-muted"
           data-component="Octicon"
           display="inline-block"
           fill="currentColor"
@@ -103,10 +103,10 @@ exports[`renderer/components/metrics/LinkedIssuesPill.tsx > renders when linked 
           width="12"
         >
           <path
-            d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"
+            d="M1.5 8a6.5 6.5 0 0 1 13 0A.75.75 0 1 0 16 8a8 8 0 1 0-8 8 .75.75 0 1 0 0-1.5A6.5 6.5 0 0 1 1.5 8"
           />
           <path
-            d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"
+            d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3m7.927 2.927-2.896 2.896a.25.25 0 0 1-.428-.177V13h-3.25a.75.75 0 1 1 0-1.5h3.25V9.354a.25.25 0 0 1 .3-.246.25.25 0 0 1 .127.069l2.897 2.896a.25.25 0 0 1 0 .354"
           />
         </svg>
         <span


### PR DESCRIPTION
Use `Issue Relates To` octicon instead of `Issue Opened` octicon
- https://primer.style/octicons/icon/issue-relates-to-16/ 
- https://primer.style/octicons/icon/issue-opened-16/

Available since https://github.com/primer/octicons/pull/1329