### PR TITLE
fix(ci): patch app-builder-lib keychain password for macOS signing

### DIFF
--- a/patches/app-builder-lib@26.15.3.patch
+++ b/patches/app-builder-lib@26.15.3.patch
@@ -1,0 +1,24 @@
+diff --git a/out/codeSign/macCodeSign.js b/out/codeSign/macCodeSign.js
+index 9a69042fd48f4759a1c697bf23fa5b44f2da2366..637cc19f525c6ee3479b377cac4c6c78345aa8ba 100644
+--- a/out/codeSign/macCodeSign.js
++++ b/out/codeSign/macCodeSign.js
+@@ -156,16 +156,16 @@ async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink, cscIK
+     if (cscIKeyPassword != null) {
+         cscPasswords.push(cscIKeyPassword);
+     }
+-    return await importCerts(keychainFile, certPaths, cscPasswords);
++    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
+ }
+-async function importCerts(keychainFile, paths, keyPasswords) {
++async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
+     var _a;
+     for (let i = 0; i < paths.length; i++) {
+         const password = (_a = keyPasswords[i]) !== null && _a !== void 0 ? _a : "";
+         await (0, builder_util_1.exec)("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password]);
+         // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
+         // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
+-        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]);
++        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
+     }
+     return {
+         keychainFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   got: 11.8.6
   electron: 44.1.1
 
+patchedDependencies:
+  app-builder-lib@26.15.3: 4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1
+
 importers:
 
   .:
@@ -6377,7 +6380,7 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2):
+  app-builder-lib@26.15.3(patch_hash=4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -6803,7 +6806,7 @@ snapshots:
 
   dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
+      app-builder-lib: 26.15.3(patch_hash=4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
       builder-util: 26.15.3(supports-color@10.2.2)
       fs-extra: 10.1.0
       js-yaml: 4.3.2
@@ -6843,7 +6846,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3)(supports-color@10.2.2):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
+      app-builder-lib: 26.15.3(patch_hash=4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
       builder-util: 26.15.3(supports-color@10.2.2)
       electron-winstaller: 5.4.0(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -6852,7 +6855,7 @@ snapshots:
 
   electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
+      app-builder-lib: 26.15.3(patch_hash=4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
       builder-util: 26.15.3(supports-color@10.2.2)
       builder-util-runtime: 9.7.0(supports-color@10.2.2)
       chalk: 4.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,4 +19,8 @@ overrides:
   cross-spawn: '7.0.6'
   got: '11.8.6'
   electron: 'catalog:'
+# Temporary: electron-builder passes the .p12 import password to `security set-key-partition-list -k`,
+# which macOS 26.6+ rejects. Drop once electron-userland/electron-builder#10101 ships in a 26.x release.
+patchedDependencies:
+  app-builder-lib@26.15.3: patches/app-builder-lib@26.15.3.patch
 savePrefix: ''


### PR DESCRIPTION
## Problem

The v7.8.0 macOS publish job failed in electron-builder's temporary-keychain setup, before signing started:

```
security set-key-partition-list -S apple-tool:,apple: -s -k *** <tmp>.keychain
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

Nothing changed on our side (no secrets, no workflow, no electron-builder version). The only difference from the v7.7.1 publish two days earlier is the `macos-latest` runner image:

| Run | macOS | Runner image | Result |
|---|---|---|---|
| v7.7.1 (Sep 4) | 26.5.2 | macos-26-arm64 20260728.0273 | signed and published |
| v7.8.0 (Sep 6) | 26.6.2 | macos-26-arm64 20260831.0337 | keychain error |

## Root cause

electron-builder 26.15.3 passes the `.p12` import password (`CSC_KEY_PASSWORD`) to `security set-key-partition-list -k`, but that flag expects the temporary keychain's own randomly generated unlock password. Older macOS builds tolerated the mismatch because the keychain had just been unlocked; macOS 26.6 validates it and fails.

Upstream: electron-userland/electron-builder#10066, fixed by electron-userland/electron-builder#10101 (merged 2026-08-27). The fix is not in any stable release yet, including 26.16.0 (see electron-userland/electron-builder#10167).

## Change

- Add a pnpm patch for `app-builder-lib@26.15.3` that mirrors PR #10101: pass `keychainPassword` through to `importCerts` and use it for `set-key-partition-list -k`.
- Register it in `pnpm-workspace.yaml` (with a comment on when to drop it) and record the patch hash in `pnpm-lock.yaml`.

Windows and Linux packaging do not enter this code path.

## Verification

- Clean `pnpm install --frozen-lockfile` applies the patch; the installed `macCodeSign.js` in the pnpm store contains the fix.
- `vp fmt --check` and `vp lint` pass.

## After merge

Run the **Publish** workflow via `workflow_dispatch` on `main` with `tag_name: v7.8.0`. The v7.8.0 draft already exists with no assets; this will attach the signed artifacts, publish the release, and trigger the website deploy.

Follow-up: once electron-builder ships a 26.x release containing #10101, bump it and remove `patches/app-builder-lib@26.15.3.patch`.